### PR TITLE
Fix book enrichment, add integration tests, and admin improvements

### DIFF
--- a/bibliotype/settings.py
+++ b/bibliotype/settings.py
@@ -244,6 +244,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'core.tasks.anonymize_expired_sessions_task',
         'schedule': crontab(hour=2, minute=0),  # Daily at 2 AM
     },
+    'research-publisher-mainstream': {
+        'task': 'core.tasks.research_publisher_mainstream_task',
+        'schedule': crontab(hour=3, minute=0, day_of_week='sunday'),  # Weekly on Sundays at 3 AM
+    },
 }
 
 # Custom 404 handler

--- a/core/admin.py
+++ b/core/admin.py
@@ -3,6 +3,8 @@ import logging
 
 from django.contrib import admin
 from django.contrib.admin.views.decorators import staff_member_required
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.models import User
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import path
@@ -22,6 +24,18 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────
+# User Admin (add ID column)
+# ──────────────────────────────────────────────
+
+admin.site.unregister(User)
+
+
+@admin.register(User)
+class UserAdmin(BaseUserAdmin):
+    list_display = ("id", "username", "email", "is_staff")
+
 
 # ──────────────────────────────────────────────
 # Model Admins
@@ -204,6 +218,7 @@ def command_runner_view(request):
         **admin.site.each_context(request),
         "title": "Command Runner",
         "commands": ADMIN_COMMANDS,
+        "commands_json": ADMIN_COMMANDS,
     }
     return render(request, "admin/command_runner.html", context)
 

--- a/core/admin.py
+++ b/core/admin.py
@@ -285,3 +285,29 @@ def _patched_get_urls(self):
 
 
 admin.AdminSite.get_urls = _patched_get_urls
+
+# Patch admin sidebar to include command runner link
+_original_get_app_list = admin.AdminSite.get_app_list
+
+
+def _patched_get_app_list(self, request, app_label=None):
+    app_list = _original_get_app_list(self, request, app_label=app_label)
+    if app_label is None:
+        app_list.append({
+            "name": "Tools",
+            "app_label": "tools",
+            "app_url": "#",
+            "has_module_perms": True,
+            "models": [
+                {
+                    "name": "Command Runner",
+                    "object_name": "CommandRunner",
+                    "admin_url": "/admin/command-runner/",
+                    "view_only": True,
+                },
+            ],
+        })
+    return app_list
+
+
+admin.AdminSite.get_app_list = _patched_get_app_list

--- a/core/admin.py
+++ b/core/admin.py
@@ -1,57 +1,81 @@
+import json
+import logging
+
 from django.contrib import admin
-from django import forms
-from django.forms import ModelMultipleChoiceField
+from django.contrib.admin.views.decorators import staff_member_required
+from django.http import JsonResponse
+from django.shortcuts import render
+from django.urls import path
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_protect
 
 from .models import (
-    AggregateAnalytics, AnonymizedReadingProfile, AnonymousUserSession, Author, Book, Genre, Publisher, UserBook, UserProfile
+    AggregateAnalytics,
+    AnonymizedReadingProfile,
+    AnonymousUserSession,
+    Author,
+    Book,
+    Genre,
+    Publisher,
+    UserBook,
+    UserProfile,
 )
 
+logger = logging.getLogger(__name__)
 
-class BookAdminForm(forms.ModelForm):
-    """Custom form for managing book genres"""
-    
-    class Meta:
-        model = Book
-        fields = '__all__'
-        
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Make the genres field readonly (display-only) initially
-        # Users will see their current genres but can't edit them in the standard way
-        # They can still use the admin interface's built-in add/delete buttons
-        pass
+# ──────────────────────────────────────────────
+# Model Admins
+# ──────────────────────────────────────────────
+
+
+@admin.register(Genre)
+class GenreAdmin(admin.ModelAdmin):
+    list_display = ("name", "book_count")
+    search_fields = ("name",)
+    ordering = ("name",)
+
+    @admin.display(description="Books")
+    def book_count(self, obj):
+        return obj.books.count()
 
 
 @admin.register(Author)
 class AuthorAdmin(admin.ModelAdmin):
-    list_display = ("name", "normalized_name", "is_mainstream", "popularity_score")
+    list_display = ("name", "normalized_name", "is_mainstream", "popularity_score", "mainstream_last_checked")
     list_editable = ("is_mainstream",)
+    list_filter = ("is_mainstream",)
     search_fields = ("name", "normalized_name")
+    readonly_fields = ("mainstream_last_checked",)
     ordering = ("-popularity_score", "name")
 
 
 @admin.register(Publisher)
 class PublisherAdmin(admin.ModelAdmin):
-    list_display = ("name", "is_mainstream", "parent")
+    list_display = ("name", "is_mainstream", "parent", "book_count", "mainstream_last_checked")
     list_editable = ("is_mainstream",)
     search_fields = ("name",)
     list_filter = ("is_mainstream", "parent")
+    readonly_fields = ("mainstream_last_checked",)
     ordering = ("name",)
+
+    @admin.display(description="Books")
+    def book_count(self, obj):
+        return obj.books.count()
 
 
 @admin.register(Book)
 class BookAdmin(admin.ModelAdmin):
-    form = BookAdminForm
-    filter_horizontal = ("genres",)  # This provides a better UI for ManyToMany fields
-    
+    filter_horizontal = ("genres",)
+
     list_display = (
         "title",
         "author",
         "publisher",
         "publish_year",
+        "page_count",
+        "average_rating",
         "global_read_count",
         "isbn13",
-        "normalized_title",
     )
     list_filter = ("publish_year", "genres")
     search_fields = ("title", "author__name", "isbn13")
@@ -67,36 +91,32 @@ class BookAdmin(admin.ModelAdmin):
     )
 
 
-@admin.register(Genre)
-class GenreAdmin(admin.ModelAdmin):
-    search_fields = ("name",)
-
-
 @admin.register(UserProfile)
 class UserProfileAdmin(admin.ModelAdmin):
-    list_display = ("user", "reader_type", "total_books_read", "last_updated")
+    list_display = ("user", "reader_type", "total_books_read", "is_public", "visible_in_recommendations", "last_updated")
+    list_filter = ("reader_type", "is_public", "visible_in_recommendations")
     search_fields = ("user__username",)
 
 
 @admin.register(UserBook)
 class UserBookAdmin(admin.ModelAdmin):
-    list_display = ('user', 'book', 'user_rating', 'is_top_book', 'top_book_position')
-    list_filter = ('is_top_book', 'user_rating')
-    search_fields = ('user__username', 'book__title', 'book__author__name')
+    list_display = ("user", "book", "user_rating", "is_top_book", "top_book_position")
+    list_filter = ("is_top_book", "user_rating")
+    search_fields = ("user__username", "book__title", "book__author__name")
 
 
 @admin.register(AnonymousUserSession)
 class AnonymousUserSessionAdmin(admin.ModelAdmin):
-    list_display = ('session_key', 'created_at', 'expires_at', 'anonymized')
-    list_filter = ('anonymized', 'expires_at')
-    readonly_fields = ('created_at',)
+    list_display = ("session_key", "created_at", "expires_at", "anonymized")
+    list_filter = ("anonymized", "expires_at")
+    readonly_fields = ("created_at",)
 
 
 @admin.register(AnonymizedReadingProfile)
 class AnonymizedReadingProfileAdmin(admin.ModelAdmin):
-    list_display = ('reader_type', 'total_books_read', 'genre_diversity_count', 'source', 'created_at')
-    list_filter = ('reader_type', 'source', 'created_at')
-    readonly_fields = ('created_at',)
+    list_display = ("reader_type", "total_books_read", "genre_diversity_count", "source", "created_at")
+    list_filter = ("reader_type", "source", "created_at")
+    readonly_fields = ("created_at",)
 
 
 @admin.register(AggregateAnalytics)
@@ -108,3 +128,160 @@ class AggregateAnalyticsAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+
+# ──────────────────────────────────────────────
+# Admin Command Runner
+# ──────────────────────────────────────────────
+
+ADMIN_COMMANDS = [
+    {
+        "name": "backfill_enrichment",
+        "description": "Dispatch background Celery tasks to enrich books missing publish_year, genres, or Google Books data.",
+        "arguments": [
+            {"name": "--dry-run", "type": "flag", "label": "Dry run", "help": "Show count without dispatching tasks"},
+            {"name": "--limit", "type": "int", "label": "Limit", "help": "Max books to queue"},
+        ],
+    },
+    {
+        "name": "enrich_books",
+        "description": "Enrich books synchronously via Open Library and Google Books APIs.",
+        "arguments": [
+            {"name": "--limit", "type": "int", "label": "API limit", "help": "Google Books API request limit"},
+            {"name": "--process-all", "type": "flag", "label": "Process all", "help": "Re-check all books"},
+        ],
+    },
+    {
+        "name": "research_publishers",
+        "description": "AI-powered publisher research to determine mainstream status and parent companies.",
+        "arguments": [
+            {"name": "--recheck-all", "type": "flag", "label": "Recheck all", "help": "Re-research all publishers"},
+            {"name": "--limit", "type": "int", "label": "Limit", "help": "Max publishers to check"},
+        ],
+    },
+    {
+        "name": "update_author_status",
+        "description": "Check author mainstream status via Open Library and Wikipedia APIs.",
+        "arguments": [
+            {"name": "--recheck-all", "type": "flag", "label": "Recheck all", "help": "Re-check all authors"},
+            {"name": "--age-days", "type": "int", "label": "Age (days)", "help": "Re-check authors older than N days"},
+        ],
+    },
+    {
+        "name": "analyze_genres",
+        "description": "Audit genre mappings: shows unmapped genres and their frequencies. Read-only.",
+        "arguments": [],
+    },
+    {
+        "name": "rebuild_analytics",
+        "description": "Rebuild the aggregate analytics singleton with current community data.",
+        "arguments": [],
+    },
+    {
+        "name": "review_publishers",
+        "description": "List non-mainstream publishers for manual review. Read-only.",
+        "arguments": [],
+    },
+    {
+        "name": "regenerate_dna",
+        "description": "Regenerate genre/reader-type DNA fields from current enriched Book data. Run after enrichment backfills.",
+        "arguments": [
+            {"name": "--dry-run", "type": "flag", "label": "Dry run", "help": "Show changes without saving"},
+            {"name": "--limit", "type": "int", "label": "Limit", "help": "Max profiles to process"},
+            {"name": "--username", "type": "str", "label": "Username", "help": "Process a single user"},
+        ],
+    },
+]
+
+# Whitelist of allowed command names for security
+ALLOWED_COMMANDS = {cmd["name"] for cmd in ADMIN_COMMANDS}
+
+
+@staff_member_required
+def command_runner_view(request):
+    """Render the command runner page."""
+    context = {
+        **admin.site.each_context(request),
+        "title": "Command Runner",
+        "commands": ADMIN_COMMANDS,
+    }
+    return render(request, "admin/command_runner.html", context)
+
+
+@staff_member_required
+def command_run_api(request):
+    """API endpoint to trigger a management command via Celery."""
+    if request.method != "POST":
+        return JsonResponse({"error": "POST required"}, status=405)
+
+    try:
+        body = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    command_name = body.get("command")
+    if not command_name or command_name not in ALLOWED_COMMANDS:
+        return JsonResponse({"error": "Invalid or disallowed command"}, status=400)
+
+    # Parse arguments from the request
+    raw_args = body.get("arguments", {})
+    cmd_config = next((c for c in ADMIN_COMMANDS if c["name"] == command_name), None)
+    if not cmd_config:
+        return JsonResponse({"error": "Command config not found"}, status=400)
+
+    kwargs = {}
+    for arg_def in cmd_config["arguments"]:
+        arg_name = arg_def["name"].lstrip("-").replace("-", "_")
+        if arg_def["type"] == "flag":
+            kwargs[arg_name] = bool(raw_args.get(arg_def["name"]))
+        elif arg_def["type"] == "int":
+            val = raw_args.get(arg_def["name"])
+            if val is not None and val != "":
+                try:
+                    kwargs[arg_name] = int(val)
+                except (ValueError, TypeError):
+                    return JsonResponse({"error": f"Invalid integer for {arg_def['name']}"}, status=400)
+        elif arg_def["type"] == "str":
+            val = raw_args.get(arg_def["name"])
+            if val is not None and val != "":
+                kwargs[arg_name] = str(val)
+
+    from .tasks import run_management_command_task
+
+    task = run_management_command_task.delay(command_name, kwargs=kwargs)
+    logger.info(f"Admin command runner: dispatched '{command_name}' as task {task.id} by {request.user.username}")
+
+    return JsonResponse({"task_id": task.id})
+
+
+@staff_member_required
+def command_result_api(request, task_id):
+    """API endpoint to poll for command result."""
+    from celery.result import AsyncResult
+
+    result = AsyncResult(task_id)
+
+    if result.ready():
+        if result.successful():
+            data = result.get()
+            return JsonResponse({"status": "complete", "result": data})
+        else:
+            return JsonResponse({"status": "error", "error": str(result.result)})
+    else:
+        return JsonResponse({"status": "pending"})
+
+
+# Patch admin site URLs to include command runner
+_original_get_urls = admin.AdminSite.get_urls
+
+
+def _patched_get_urls(self):
+    custom_urls = [
+        path("command-runner/", self.admin_view(command_runner_view), name="command_runner"),
+        path("api/command-run/", self.admin_view(command_run_api), name="command_run_api"),
+        path("api/command-result/<str:task_id>/", self.admin_view(command_result_api), name="command_result_api"),
+    ]
+    return custom_urls + _original_get_urls(self)
+
+
+admin.AdminSite.get_urls = _patched_get_urls

--- a/core/management/commands/backfill_enrichment.py
+++ b/core/management/commands/backfill_enrichment.py
@@ -1,0 +1,57 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from core.models import Book
+from core.tasks import enrich_book_task
+
+
+class Command(BaseCommand):
+    help = "Dispatch background enrichment tasks for books missing publish_year, genres, or API check data."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show how many books would be queued without dispatching tasks.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Limit the number of books to dispatch tasks for.",
+        )
+
+    def handle(self, *args, **options):
+        queryset = Book.objects.filter(
+            Q(publish_year__isnull=True) | Q(genres__isnull=True) | Q(google_books_last_checked__isnull=True)
+        ).distinct()
+
+        total = queryset.count()
+
+        if total == 0:
+            self.stdout.write(self.style.SUCCESS("All books are already enriched. Nothing to do."))
+            return
+
+        # Show breakdown
+        missing_year = Book.objects.filter(publish_year__isnull=True).count()
+        missing_genres = Book.objects.filter(genres__isnull=True).count()
+        missing_gb = Book.objects.filter(google_books_last_checked__isnull=True).count()
+
+        self.stdout.write(f"Books missing publish_year: {missing_year}")
+        self.stdout.write(f"Books missing genres: {missing_genres}")
+        self.stdout.write(f"Books missing Google Books check: {missing_gb}")
+        self.stdout.write(f"Total unique books needing enrichment: {total}")
+
+        if options["limit"]:
+            queryset = queryset[: options["limit"]]
+            self.stdout.write(self.style.NOTICE(f"Limiting to {options['limit']} books."))
+
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING("Dry run — no tasks dispatched."))
+            return
+
+        dispatched = 0
+        for book in queryset.iterator():
+            enrich_book_task.delay(book.pk)
+            dispatched += 1
+
+        self.stdout.write(self.style.SUCCESS(f"Dispatched {dispatched} enrichment tasks to Celery."))

--- a/core/management/commands/enrich_books.py
+++ b/core/management/commands/enrich_books.py
@@ -49,10 +49,11 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("--process-all flag set. Re-checking all books."))
             queryset = Book.objects.all()
         else:
-            self.stdout.write(self.style.NOTICE("Processing books that have not been checked or are missing genres."))
-            # A more robust query: get books that either haven't been checked OR still have no genres.
+            self.stdout.write(
+                self.style.NOTICE("Processing books that have not been checked or are missing genres/publish year.")
+            )
             queryset = Book.objects.filter(
-                Q(google_books_last_checked__isnull=True) | Q(genres__isnull=True)
+                Q(google_books_last_checked__isnull=True) | Q(genres__isnull=True) | Q(publish_year__isnull=True)
             ).distinct()
 
         total_books_to_process = queryset.count()

--- a/core/management/commands/regenerate_dna.py
+++ b/core/management/commands/regenerate_dna.py
@@ -1,0 +1,147 @@
+import random
+import logging
+from collections import Counter
+
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+
+from core.models import UserProfile, UserBook
+from core.dna_constants import CANONICAL_GENRE_MAP, READER_TYPE_DESCRIPTIONS
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Regenerate genre-dependent DNA fields (top_genres, reader_type, mainstream_score) "
+        "for users from their current Book data. Use after enrichment backfills."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would change without saving.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Limit the number of profiles to process.",
+        )
+        parser.add_argument(
+            "--username",
+            type=str,
+            help="Regenerate for a single user by username.",
+        )
+
+    def handle(self, *args, **options):
+        profiles = UserProfile.objects.filter(dna_data__isnull=False).select_related("user")
+
+        if options["username"]:
+            profiles = profiles.filter(user__username=options["username"])
+
+        if options["limit"]:
+            profiles = profiles[: options["limit"]]
+
+        profiles = list(profiles)
+
+        if not profiles:
+            self.stdout.write(self.style.SUCCESS("No profiles with DNA data found."))
+            return
+
+        self.stdout.write(f"Found {len(profiles)} profiles to regenerate.")
+        updated = 0
+
+        for profile in profiles:
+            user = profile.user
+            user_books = (
+                UserBook.objects.filter(user=user)
+                .select_related("book", "book__author", "book__publisher")
+                .prefetch_related("book__genres")
+            )
+
+            if not user_books.exists():
+                self.stdout.write(f"  {user.username}: no UserBook records, skipping.")
+                continue
+
+            # Collect current genres from enriched books
+            all_genres = []
+            for ub in user_books:
+                for genre in ub.book.genres.all():
+                    all_genres.append(genre.name)
+
+            # Canonicalize genres
+            mapped_genres = [CANONICAL_GENRE_MAP.get(g, g) for g in all_genres]
+            new_top_genres = Counter(mapped_genres).most_common(10)
+            # Convert to list of lists for JSON serialization
+            new_top_genres_serializable = [[g, c] for g, c in new_top_genres]
+
+            # Recalculate reader type scores (simplified — uses genre counts only)
+            # Full assign_reader_type requires a DataFrame, but genre scores are the main thing affected
+            genre_counts = Counter(mapped_genres)
+            old_scores = profile.dna_data.get("reader_type_scores", {})
+            # Rebuild genre-based scores on top of existing scores
+            scores = Counter(old_scores)
+            # Zero out genre-based scores before recalculating
+            genre_types = [
+                "Fantasy Fanatic", "Non-Fiction Ninja", "Philosophical Philomath",
+                "Nature Nut Case", "Social Savant", "Self Help Scholar",
+            ]
+            for gt in genre_types:
+                scores[gt] = 0
+
+            scores["Fantasy Fanatic"] += genre_counts.get("fantasy", 0) + genre_counts.get("science fiction", 0)
+            scores["Non-Fiction Ninja"] += genre_counts.get("non-fiction", 0)
+            scores["Philosophical Philomath"] += genre_counts.get("philosophy", 0)
+            scores["Nature Nut Case"] += genre_counts.get("nature", 0)
+            scores["Social Savant"] += genre_counts.get("social science", 0)
+            scores["Self Help Scholar"] += genre_counts.get("self-help", 0)
+
+            new_reader_type = scores.most_common(1)[0][0] if scores else profile.dna_data.get("reader_type", "")
+            new_top_types = [{"type": t, "score": s} for t, s in scores.most_common(3) if s > 0]
+
+            # Recalculate mainstream score
+            total = user_books.count()
+            mainstream_count = sum(
+                1 for ub in user_books
+                if ub.book.author.is_mainstream or (ub.book.publisher and ub.book.publisher.is_mainstream)
+            )
+            new_mainstream_score = round((mainstream_count / total) * 100) if total > 0 else 0
+
+            old_type = profile.dna_data.get("reader_type", "")
+            old_genres = profile.dna_data.get("top_genres", [])
+            old_mainstream = profile.dna_data.get("mainstream_score_percent", 0)
+
+            changes = []
+            if old_type != new_reader_type:
+                changes.append(f"reader_type: '{old_type}' -> '{new_reader_type}'")
+            if old_genres != new_top_genres_serializable:
+                changes.append(f"top_genres: {len(old_genres)} -> {len(new_top_genres_serializable)} entries")
+            if old_mainstream != new_mainstream_score:
+                changes.append(f"mainstream: {old_mainstream}% -> {new_mainstream_score}%")
+
+            if not changes:
+                self.stdout.write(f"  {user.username}: no changes needed.")
+                continue
+
+            self.stdout.write(f"  {user.username}: {', '.join(changes)}")
+
+            if not options["dry_run"]:
+                dna = profile.dna_data.copy()
+                dna["top_genres"] = new_top_genres_serializable
+                dna["reader_type"] = new_reader_type
+                dna["reader_type_scores"] = dict(scores)
+                dna["top_reader_types"] = new_top_types
+                dna["reader_type_explanation"] = random.choice(
+                    READER_TYPE_DESCRIPTIONS.get(new_reader_type, [dna.get("reader_type_explanation", "")])
+                )
+                dna["mainstream_score_percent"] = new_mainstream_score
+                profile.dna_data = dna
+                profile.reader_type = new_reader_type
+                profile.save(update_fields=["dna_data", "reader_type"])
+                updated += 1
+
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING("Dry run complete. No changes saved."))
+        else:
+            self.stdout.write(self.style.SUCCESS(f"Updated {updated} profiles."))

--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -263,14 +263,27 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                     check_author_mainstream_status_task.delay(author.id)
 
                 normalized_book_title = Book._normalize_title(title_from_csv)
+
+                publish_year_value = None
+                raw_year = original_row.get("Original Publication Year")
+                if pd.notna(raw_year):
+                    try:
+                        publish_year_value = int(float(raw_year))
+                    except (ValueError, TypeError):
+                        publish_year_value = None
+
+                book_defaults = {
+                    "title": title_from_csv,
+                    "page_count": int(p) if pd.notna(p := original_row.get("Number of Pages")) else None,
+                    "average_rating": float(r) if pd.notna(r := original_row.get("Average Rating")) else None,
+                }
+                if publish_year_value:
+                    book_defaults["publish_year"] = publish_year_value
+
                 book, created = Book.objects.update_or_create(
                     normalized_title=normalized_book_title,
                     author=author,
-                    defaults={
-                        "title": title_from_csv,
-                        "page_count": int(p) if pd.notna(p := original_row.get("Number of Pages")) else None,
-                        "average_rating": float(r) if pd.notna(r := original_row.get("Average Rating")) else None,
-                    },
+                    defaults=book_defaults,
                 )
 
                 # Check if the book already has genres by querying the database directly
@@ -283,19 +296,14 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                     # Query from the Genre side of the relationship to ensure fresh data
                     has_genres = Genre.objects.filter(books__id=book.pk).exists()
                 
-                # Skip enrichment during upload to avoid database locks
-                # Enrichment should be done in a separate background task
-                # if created or not has_genres:
-                #     logger.debug(f"Enriching '{book.title}' (created={created}, has_genres={has_genres})...")
-                #     enrich_book_from_apis(book, session)
-                # else:
-                #     logger.debug(f"Book '{book.title}' already exists with genres. Skipping enrichment.")
-                
-                # Just log the enrichment status
+                # Dispatch enrichment as a background task to avoid blocking upload
                 if created or not has_genres:
-                    logger.debug(f"Book '{book.title}' will be enriched later (created={created}, has_genres={has_genres})")
+                    from ..tasks import enrich_book_task
+
+                    logger.debug(f"Dispatching enrichment for '{book.title}' (created={created}, has_genres={has_genres})")
+                    enrich_book_task.delay(book.pk)
                 else:
-                    logger.debug(f"Book '{book.title}' already exists with genres.")
+                    logger.debug(f"Book '{book.title}' already enriched. Skipping.")
 
                 Book.objects.filter(pk=book.pk).update(global_read_count=F("global_read_count") + 1)
 

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -162,8 +162,8 @@ def claim_anonymous_dna_task(self, user_id: int, task_id: str):
 
 def _create_userbooks_from_anonymous_session(user, session_key):
     """Create UserBook records from AnonymousUserSession when claiming anonymous DNA"""
-    from ..models import AnonymousUserSession, UserBook, Book
-    from ..services.top_books_service import calculate_and_store_top_books
+    from .models import AnonymousUserSession, UserBook, Book
+    from .services.top_books_service import calculate_and_store_top_books
 
     try:
         anon_session = AnonymousUserSession.objects.get(session_key=session_key)

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -17,8 +17,10 @@ from .services.dna_analyser import calculate_full_dna, _save_dna_to_profile
 import requests
 from django.utils import timezone
 
+from django.db import models as models
+
 from .services.author_service import check_author_mainstream_status
-from .models import Author
+from .models import Author, Book
 from .analytics.events import (
     track_dna_generation_started,
     track_dna_generation_completed,
@@ -69,6 +71,30 @@ def check_author_mainstream_status_task(author_id: int):
             f"Critical error in check_author_mainstream_status_task for author_id {author_id}: {e}", exc_info=True
         )
         raise
+
+
+@shared_task(bind=True, max_retries=3)
+def enrich_book_task(self, book_id: int):
+    """Enrich a single book with data from Open Library and Google Books APIs."""
+    try:
+        book = Book.objects.get(pk=book_id)
+    except Book.DoesNotExist:
+        logger.error(f"Enrich task: Book with ID {book_id} not found")
+        return
+
+    logger.info(f"Enriching book '{book.title}' (id={book_id}) via background task")
+
+    try:
+        from .book_enrichment_service import enrich_book_from_apis
+
+        with requests.Session() as session:
+            session.headers.update({"User-Agent": "BibliotypeApp/1.0"})
+            enrich_book_from_apis(book, session, slow_down=True)
+
+        logger.info(f"Successfully enriched '{book.title}'")
+    except Exception as e:
+        logger.error(f"Error enriching book '{book.title}' (id={book_id}): {e}", exc_info=True)
+        raise self.retry(countdown=60 * (2**self.request.retries), exc=e)
 
 
 @shared_task(bind=True, max_retries=5)
@@ -345,6 +371,98 @@ def generate_reading_dna_task(self, csv_file_content: str, user_id: int | None, 
         )
         logger.error(f"Task failed due to an error in the analysis engine: {e}", exc_info=True)
         raise
+
+
+@shared_task
+def research_publisher_mainstream_task():
+    """Periodic task to check unchecked publishers for mainstream status via AI research."""
+    from .models import Publisher, Author
+    from .services.publisher_service import research_publisher_identity
+
+    BATCH_LIMIT = 20
+    AGE_THRESHOLD_DAYS = 90
+
+    cutoff = timezone.now() - timezone.timedelta(days=AGE_THRESHOLD_DAYS)
+    publishers_to_check = list(
+        Publisher.objects.filter(
+            models.Q(mainstream_last_checked__isnull=True) | models.Q(mainstream_last_checked__lt=cutoff),
+            parent__isnull=True,
+        )[:BATCH_LIMIT]
+    )
+
+    if not publishers_to_check:
+        logger.info("Publisher mainstream check: no publishers need checking.")
+        return 0
+
+    logger.info(f"Publisher mainstream check: processing {len(publishers_to_check)} publishers")
+    updated_count = 0
+
+    with requests.Session() as session:
+        session.headers.update({"User-Agent": "BibliotypeApp/1.0"})
+
+        for publisher in publishers_to_check:
+            try:
+                findings = research_publisher_identity(publisher.name, session)
+
+                if findings["error"]:
+                    logger.warning(f"Publisher research error for '{publisher.name}': {findings['error']}")
+                    publisher.mainstream_last_checked = timezone.now()
+                else:
+                    is_mainstream_result = findings.get("is_mainstream")
+                    publisher.is_mainstream = is_mainstream_result if isinstance(is_mainstream_result, bool) else False
+                    publisher.mainstream_last_checked = timezone.now()
+
+                    if parent_name := findings.get("parent_company_name"):
+                        parent_obj, _ = Publisher.objects.get_or_create(
+                            normalized_name=Author._normalize(parent_name),
+                            defaults={"name": parent_name, "is_mainstream": True},
+                        )
+                        publisher.parent = parent_obj
+
+                    updated_count += 1
+
+                publisher.save()
+                import time as _time
+
+                _time.sleep(2)
+            except Exception as e:
+                logger.error(f"Error researching publisher '{publisher.name}': {e}", exc_info=True)
+                continue
+
+    logger.info(f"Publisher mainstream check complete: updated {updated_count} publishers")
+    return updated_count
+
+
+@shared_task
+def run_management_command_task(command_name: str, args: list = None, kwargs: dict = None):
+    """Run a Django management command and store the output in cache."""
+    import io
+    from django.core.management import call_command
+    from .services.recommendation_service import safe_cache_set
+
+    args = args or []
+    kwargs = kwargs or {}
+
+    stdout_buffer = io.StringIO()
+    stderr_buffer = io.StringIO()
+
+    try:
+        call_command(command_name, *args, stdout=stdout_buffer, stderr=stderr_buffer, **kwargs)
+        result = {
+            "status": "success",
+            "stdout": stdout_buffer.getvalue(),
+            "stderr": stderr_buffer.getvalue(),
+        }
+    except Exception as e:
+        logger.error(f"Management command '{command_name}' failed: {e}", exc_info=True)
+        result = {
+            "status": "error",
+            "stdout": stdout_buffer.getvalue(),
+            "stderr": stderr_buffer.getvalue(),
+            "error": str(e),
+        }
+
+    return result
 
 
 @shared_task

--- a/core/templates/admin/command_runner.html
+++ b/core/templates/admin/command_runner.html
@@ -10,34 +10,38 @@
 <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet" />
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 <style>
+    /* Force light mode on the command runner page */
     :root {
-        --neo-black: #1a1a2e;
-        --neo-yellow: #ffe56c;
-        --neo-orange: #ffa75e;
-        --neo-pink: #ffb4dd;
-        --neo-cyan: #8bbfff;
-        --neo-green: #40e7aa;
-        --neo-purple: #c4b5fd;
-        --neo-bg: #FFF8F0;
+        color-scheme: light !important;
     }
+
+    #content {
+        background: #FFF8F0 !important;
+        padding: 24px !important;
+    }
+
+    /* Hide the default admin breadcrumb/header since we have our own */
+    .breadcrumbs { display: none; }
+    #content > h1:first-child { display: none; }
 
     .command-runner-container {
         font-family: "VT323", monospace;
         max-width: 960px;
         margin: 0 auto;
+        color: #1a1a2e;
     }
 
     .neo-card {
-        background: white;
-        border: 2px solid var(--neo-black);
-        box-shadow: 4px 4px 0 var(--neo-black);
+        background: #ffffff;
+        border: 2px solid #1a1a2e;
+        box-shadow: 4px 4px 0 #1a1a2e;
         padding: 20px;
         margin-bottom: 20px;
         transition: all 150ms ease-in-out;
     }
 
     .neo-card:hover {
-        box-shadow: 6px 6px 0 var(--neo-black);
+        box-shadow: 6px 6px 0 #1a1a2e;
     }
 
     .neo-card h3 {
@@ -45,25 +49,30 @@
         font-size: 1.5rem;
         margin: 0 0 4px 0;
         display: inline-block;
-        padding: 2px 8px;
-        border: 2px solid var(--neo-black);
+        padding: 2px 10px;
+        border: 2px solid #1a1a2e;
+        color: #1a1a2e;
     }
 
     .neo-card p.desc {
-        font-size: 1.1rem;
-        color: #555;
+        font-family: "VT323", monospace;
+        font-size: 1.15rem;
+        color: #444;
         margin: 8px 0 16px 0;
     }
 
     .neo-btn {
         font-family: "VT323", monospace;
-        font-size: 1.1rem;
-        padding: 8px 20px;
-        border: 2px solid var(--neo-black);
-        box-shadow: 3px 3px 0 var(--neo-black);
+        font-size: 1.15rem;
+        padding: 8px 22px;
+        border: 2px solid #1a1a2e;
+        box-shadow: 3px 3px 0 #1a1a2e;
         cursor: pointer;
         transition: all 150ms ease-in-out;
         display: inline-block;
+        color: #1a1a2e;
+        background: #40e7aa;
+        text-decoration: none;
     }
 
     .neo-btn:hover {
@@ -78,29 +87,31 @@
         transform: none;
     }
 
-    .neo-btn-run {
-        background: var(--neo-green);
-        color: var(--neo-black);
-    }
-
     .neo-input {
         font-family: "VT323", monospace;
-        font-size: 1rem;
+        font-size: 1.05rem;
         padding: 6px 10px;
-        border: 2px solid var(--neo-black);
-        background: white;
-        width: 100px;
+        border: 2px solid #1a1a2e;
+        background: #ffffff !important;
+        color: #1a1a2e !important;
+        width: 110px;
+        -webkit-appearance: auto;
+        appearance: auto;
     }
 
     .neo-input:focus {
         outline: none;
-        box-shadow: 2px 2px 0 var(--neo-black);
+        box-shadow: 2px 2px 0 #1a1a2e;
+    }
+
+    .neo-input::placeholder {
+        color: #999;
     }
 
     .neo-checkbox {
         width: 18px;
         height: 18px;
-        accent-color: var(--neo-black);
+        accent-color: #1a1a2e;
         cursor: pointer;
     }
 
@@ -119,18 +130,19 @@
     }
 
     .arg-group label {
+        font-family: "VT323", monospace;
         font-size: 1.1rem;
-        color: var(--neo-black);
+        color: #1a1a2e;
         cursor: pointer;
     }
 
     .output-box {
-        background: var(--neo-black);
-        color: var(--neo-green);
+        background: #1a1a2e;
+        color: #40e7aa;
         font-family: "VT323", monospace;
-        font-size: 1rem;
+        font-size: 1.05rem;
         padding: 16px;
-        border: 2px solid var(--neo-black);
+        border: 2px solid #1a1a2e;
         margin-top: 16px;
         white-space: pre-wrap;
         word-break: break-word;
@@ -147,25 +159,26 @@
         font-family: "VT323", monospace;
         font-size: 0.95rem;
         padding: 2px 10px;
-        border: 2px solid var(--neo-black);
+        border: 2px solid #1a1a2e;
         display: inline-block;
         margin-left: 10px;
+        color: #1a1a2e;
     }
 
-    .status-pending { background: var(--neo-yellow); }
-    .status-running { background: var(--neo-orange); }
-    .status-success { background: var(--neo-green); }
-    .status-error { background: var(--neo-pink); }
+    .status-running { background: #ffa75e; }
+    .status-success { background: #40e7aa; }
+    .status-error { background: #ff647c; color: #fff; }
 
     .page-header {
         font-family: "VT323", monospace;
         font-size: 2rem;
         margin-bottom: 8px;
         padding: 6px 14px;
-        background: var(--neo-yellow);
-        border: 2px solid var(--neo-black);
-        box-shadow: 4px 4px 0 var(--neo-black);
+        background: #ffe56c;
+        border: 2px solid #1a1a2e;
+        box-shadow: 4px 4px 0 #1a1a2e;
         display: inline-block;
+        color: #1a1a2e;
     }
 
     .page-subtitle {
@@ -180,19 +193,37 @@
         50% { opacity: 0.3; }
     }
     .blinking { animation: blink 1s infinite; }
+
+    .card-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .card-header-left {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 4px;
+    }
 </style>
 {% endblock %}
 
 {% block content %}
+{{ commands_json|json_script:"commands-data" }}
+{% csrf_token %}
+
 <div class="command-runner-container" x-data="commandRunner()">
     <h1 class="page-header">Command Runner</h1>
     <p class="page-subtitle">Run management commands on the server. Output will appear below each command.</p>
 
     {% for cmd in commands %}
-    <div class="neo-card" x-data="{ expanded: false }">
-        <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px;">
-            <div>
-                <h3 style="background: {% cycle 'var(--neo-cyan)' 'var(--neo-pink)' 'var(--neo-orange)' 'var(--neo-yellow)' 'var(--neo-green)' 'var(--neo-purple)' 'var(--neo-cyan)' %};">
+    <div class="neo-card">
+        <div class="card-header">
+            <div class="card-header-left">
+                <h3 style="background: {% cycle '#8bbfff' '#ffb4dd' '#ffa75e' '#ffe56c' '#40e7aa' '#c4b5fd' '#8bbfff' '#ffb4dd' %};">
                     {{ cmd.name }}
                 </h3>
                 <template x-if="tasks['{{ cmd.name }}']?.status === 'pending'">
@@ -206,7 +237,7 @@
                 </template>
             </div>
             <button
-                class="neo-btn neo-btn-run"
+                class="neo-btn"
                 @click="runCommand('{{ cmd.name }}')"
                 :disabled="tasks['{{ cmd.name }}']?.status === 'pending'"
             >
@@ -268,8 +299,7 @@
 
 <script>
 function commandRunner() {
-    // Build initial args state from the command config
-    const commands = {{ commands|safe }};
+    const commands = JSON.parse(document.getElementById("commands-data").textContent);
     const initialArgs = {};
     commands.forEach(cmd => {
         initialArgs[cmd.name] = {};
@@ -285,9 +315,7 @@ function commandRunner() {
         async runCommand(name) {
             this.tasks[name] = { status: "pending", output: undefined };
 
-            const csrfToken = document.querySelector("[name=csrfmiddlewaretoken]")?.value
-                || document.cookie.split("; ").find(c => c.startsWith("csrftoken="))?.split("=")[1]
-                || "";
+            const csrfToken = document.querySelector("[name=csrfmiddlewaretoken]")?.value || "";
 
             try {
                 const resp = await fetch("{% url 'admin:command_run_api' %}", {

--- a/core/templates/admin/command_runner.html
+++ b/core/templates/admin/command_runner.html
@@ -1,0 +1,357 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}Command Runner | {{ site_title|default:"Django site admin" }}{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet" />
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+<style>
+    :root {
+        --neo-black: #1a1a2e;
+        --neo-yellow: #ffe56c;
+        --neo-orange: #ffa75e;
+        --neo-pink: #ffb4dd;
+        --neo-cyan: #8bbfff;
+        --neo-green: #40e7aa;
+        --neo-purple: #c4b5fd;
+        --neo-bg: #FFF8F0;
+    }
+
+    .command-runner-container {
+        font-family: "VT323", monospace;
+        max-width: 960px;
+        margin: 0 auto;
+    }
+
+    .neo-card {
+        background: white;
+        border: 2px solid var(--neo-black);
+        box-shadow: 4px 4px 0 var(--neo-black);
+        padding: 20px;
+        margin-bottom: 20px;
+        transition: all 150ms ease-in-out;
+    }
+
+    .neo-card:hover {
+        box-shadow: 6px 6px 0 var(--neo-black);
+    }
+
+    .neo-card h3 {
+        font-family: "VT323", monospace;
+        font-size: 1.5rem;
+        margin: 0 0 4px 0;
+        display: inline-block;
+        padding: 2px 8px;
+        border: 2px solid var(--neo-black);
+    }
+
+    .neo-card p.desc {
+        font-size: 1.1rem;
+        color: #555;
+        margin: 8px 0 16px 0;
+    }
+
+    .neo-btn {
+        font-family: "VT323", monospace;
+        font-size: 1.1rem;
+        padding: 8px 20px;
+        border: 2px solid var(--neo-black);
+        box-shadow: 3px 3px 0 var(--neo-black);
+        cursor: pointer;
+        transition: all 150ms ease-in-out;
+        display: inline-block;
+    }
+
+    .neo-btn:hover {
+        box-shadow: none;
+        transform: translate(3px, 3px);
+    }
+
+    .neo-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        box-shadow: none;
+        transform: none;
+    }
+
+    .neo-btn-run {
+        background: var(--neo-green);
+        color: var(--neo-black);
+    }
+
+    .neo-input {
+        font-family: "VT323", monospace;
+        font-size: 1rem;
+        padding: 6px 10px;
+        border: 2px solid var(--neo-black);
+        background: white;
+        width: 100px;
+    }
+
+    .neo-input:focus {
+        outline: none;
+        box-shadow: 2px 2px 0 var(--neo-black);
+    }
+
+    .neo-checkbox {
+        width: 18px;
+        height: 18px;
+        accent-color: var(--neo-black);
+        cursor: pointer;
+    }
+
+    .args-row {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        margin-bottom: 12px;
+        flex-wrap: wrap;
+    }
+
+    .arg-group {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .arg-group label {
+        font-size: 1.1rem;
+        color: var(--neo-black);
+        cursor: pointer;
+    }
+
+    .output-box {
+        background: var(--neo-black);
+        color: var(--neo-green);
+        font-family: "VT323", monospace;
+        font-size: 1rem;
+        padding: 16px;
+        border: 2px solid var(--neo-black);
+        margin-top: 16px;
+        white-space: pre-wrap;
+        word-break: break-word;
+        max-height: 400px;
+        overflow-y: auto;
+        line-height: 1.4;
+    }
+
+    .output-box.error {
+        color: #ff647c;
+    }
+
+    .status-badge {
+        font-family: "VT323", monospace;
+        font-size: 0.95rem;
+        padding: 2px 10px;
+        border: 2px solid var(--neo-black);
+        display: inline-block;
+        margin-left: 10px;
+    }
+
+    .status-pending { background: var(--neo-yellow); }
+    .status-running { background: var(--neo-orange); }
+    .status-success { background: var(--neo-green); }
+    .status-error { background: var(--neo-pink); }
+
+    .page-header {
+        font-family: "VT323", monospace;
+        font-size: 2rem;
+        margin-bottom: 8px;
+        padding: 6px 14px;
+        background: var(--neo-yellow);
+        border: 2px solid var(--neo-black);
+        box-shadow: 4px 4px 0 var(--neo-black);
+        display: inline-block;
+    }
+
+    .page-subtitle {
+        font-family: "VT323", monospace;
+        font-size: 1.2rem;
+        color: #666;
+        margin-bottom: 24px;
+    }
+
+    @keyframes blink {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.3; }
+    }
+    .blinking { animation: blink 1s infinite; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="command-runner-container" x-data="commandRunner()">
+    <h1 class="page-header">Command Runner</h1>
+    <p class="page-subtitle">Run management commands on the server. Output will appear below each command.</p>
+
+    {% for cmd in commands %}
+    <div class="neo-card" x-data="{ expanded: false }">
+        <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px;">
+            <div>
+                <h3 style="background: {% cycle 'var(--neo-cyan)' 'var(--neo-pink)' 'var(--neo-orange)' 'var(--neo-yellow)' 'var(--neo-green)' 'var(--neo-purple)' 'var(--neo-cyan)' %};">
+                    {{ cmd.name }}
+                </h3>
+                <template x-if="tasks['{{ cmd.name }}']?.status === 'pending'">
+                    <span class="status-badge status-running blinking">Running...</span>
+                </template>
+                <template x-if="tasks['{{ cmd.name }}']?.status === 'complete'">
+                    <span class="status-badge status-success">Done</span>
+                </template>
+                <template x-if="tasks['{{ cmd.name }}']?.status === 'error'">
+                    <span class="status-badge status-error">Error</span>
+                </template>
+            </div>
+            <button
+                class="neo-btn neo-btn-run"
+                @click="runCommand('{{ cmd.name }}')"
+                :disabled="tasks['{{ cmd.name }}']?.status === 'pending'"
+            >
+                <span x-show="tasks['{{ cmd.name }}']?.status !== 'pending'">Run</span>
+                <span x-show="tasks['{{ cmd.name }}']?.status === 'pending'" class="blinking">Running...</span>
+            </button>
+        </div>
+
+        <p class="desc">{{ cmd.description }}</p>
+
+        {% if cmd.arguments %}
+        <div class="args-row">
+            {% for arg in cmd.arguments %}
+            <div class="arg-group">
+                {% if arg.type == "flag" %}
+                    <input
+                        type="checkbox"
+                        class="neo-checkbox"
+                        id="arg-{{ cmd.name }}-{{ arg.name }}"
+                        x-model="args['{{ cmd.name }}']['{{ arg.name }}']"
+                    />
+                    <label for="arg-{{ cmd.name }}-{{ arg.name }}" title="{{ arg.help }}">{{ arg.label }}</label>
+                {% elif arg.type == "int" %}
+                    <label for="arg-{{ cmd.name }}-{{ arg.name }}" title="{{ arg.help }}">{{ arg.label }}:</label>
+                    <input
+                        type="number"
+                        class="neo-input"
+                        id="arg-{{ cmd.name }}-{{ arg.name }}"
+                        x-model="args['{{ cmd.name }}']['{{ arg.name }}']"
+                        placeholder="{{ arg.help }}"
+                        min="1"
+                    />
+                {% elif arg.type == "str" %}
+                    <label for="arg-{{ cmd.name }}-{{ arg.name }}" title="{{ arg.help }}">{{ arg.label }}:</label>
+                    <input
+                        type="text"
+                        class="neo-input"
+                        style="width: 160px;"
+                        id="arg-{{ cmd.name }}-{{ arg.name }}"
+                        x-model="args['{{ cmd.name }}']['{{ arg.name }}']"
+                        placeholder="{{ arg.help }}"
+                    />
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        <template x-if="tasks['{{ cmd.name }}']?.output !== undefined">
+            <div
+                class="output-box"
+                :class="{ 'error': tasks['{{ cmd.name }}']?.status === 'error' }"
+                x-text="tasks['{{ cmd.name }}']?.output || 'No output.'"
+            ></div>
+        </template>
+    </div>
+    {% endfor %}
+</div>
+
+<script>
+function commandRunner() {
+    // Build initial args state from the command config
+    const commands = {{ commands|safe }};
+    const initialArgs = {};
+    commands.forEach(cmd => {
+        initialArgs[cmd.name] = {};
+        (cmd.arguments || []).forEach(arg => {
+            initialArgs[cmd.name][arg.name] = arg.type === "flag" ? false : "";
+        });
+    });
+
+    return {
+        tasks: {},
+        args: initialArgs,
+
+        async runCommand(name) {
+            this.tasks[name] = { status: "pending", output: undefined };
+
+            const csrfToken = document.querySelector("[name=csrfmiddlewaretoken]")?.value
+                || document.cookie.split("; ").find(c => c.startsWith("csrftoken="))?.split("=")[1]
+                || "";
+
+            try {
+                const resp = await fetch("{% url 'admin:command_run_api' %}", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "X-CSRFToken": csrfToken,
+                    },
+                    body: JSON.stringify({
+                        command: name,
+                        arguments: this.args[name] || {},
+                    }),
+                });
+
+                const data = await resp.json();
+                if (!resp.ok) {
+                    this.tasks[name] = { status: "error", output: data.error || "Request failed." };
+                    return;
+                }
+
+                this.pollResult(name, data.task_id);
+            } catch (err) {
+                this.tasks[name] = { status: "error", output: "Network error: " + err.message };
+            }
+        },
+
+        async pollResult(name, taskId) {
+            const url = "{% url 'admin:command_result_api' task_id='__TASK_ID__' %}".replace("__TASK_ID__", taskId);
+            const maxAttempts = 120;
+            let attempts = 0;
+
+            const poll = async () => {
+                attempts++;
+                try {
+                    const resp = await fetch(url);
+                    const data = await resp.json();
+
+                    if (data.status === "pending") {
+                        if (attempts < maxAttempts) {
+                            setTimeout(poll, 2000);
+                        } else {
+                            this.tasks[name] = { status: "error", output: "Timed out waiting for result." };
+                        }
+                    } else if (data.status === "complete") {
+                        const result = data.result;
+                        let output = "";
+                        if (result.stdout) output += result.stdout;
+                        if (result.stderr) output += (output ? "\n--- STDERR ---\n" : "") + result.stderr;
+                        if (result.error) output += (output ? "\n--- ERROR ---\n" : "") + result.error;
+                        this.tasks[name] = {
+                            status: result.status === "error" ? "error" : "complete",
+                            output: output || "Command completed with no output.",
+                        };
+                    } else if (data.status === "error") {
+                        this.tasks[name] = { status: "error", output: data.error || "Task failed." };
+                    }
+                } catch (err) {
+                    this.tasks[name] = { status: "error", output: "Poll error: " + err.message };
+                }
+            };
+
+            poll();
+        },
+    };
+}
+</script>
+{% endblock %}

--- a/core/tests/test_integration.py
+++ b/core/tests/test_integration.py
@@ -1,0 +1,588 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import requests
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from core.models import (
+    AnonymousUserSession,
+    Author,
+    Book,
+    Genre,
+    Publisher,
+    UserBook,
+    UserProfile,
+)
+
+
+# ──────────────────────────────────────────────
+# Class 1: Book Enrichment Integration Tests
+# ──────────────────────────────────────────────
+
+
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=True,
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+)
+class BookEnrichmentIntegrationTests(TestCase):
+
+    def setUp(self):
+        self.author = Author.objects.create(name="Test Author")
+        self.book = Book.objects.create(
+            title="Test Book",
+            author=self.author,
+            isbn13=None,
+            page_count=None,
+            publish_year=None,
+            google_books_last_checked=None,
+        )
+
+    @patch("core.book_enrichment_service._fetch_ratings_and_categories_from_google_books")
+    @patch("core.book_enrichment_service._fetch_from_open_library")
+    def test_enrich_book_task_updates_book_with_api_data(self, mock_ol, mock_gb):
+        """Full enrichment pipeline: task → service → DB updates."""
+        from core.tasks import enrich_book_task
+
+        mock_ol.return_value = (
+            {
+                "genres": ["fantasy"],
+                "publish_year": 2020,
+                "page_count": 350,
+                "publisher": "Tor Books",
+                "isbn_13": None,
+            },
+            2,
+        )
+        mock_gb.return_value = ({"ratings_count": 500, "average_rating": 4.1}, 1)
+
+        enrich_book_task.delay(self.book.id)
+
+        self.book.refresh_from_db()
+        self.assertEqual(self.book.publish_year, 2020)
+        self.assertEqual(self.book.page_count, 350)
+        self.assertIsNotNone(self.book.google_books_last_checked)
+        self.assertEqual(self.book.google_books_ratings_count, 500)
+        self.assertAlmostEqual(self.book.google_books_average_rating, 4.1)
+
+        # Check publisher was created and linked
+        self.assertIsNotNone(self.book.publisher)
+        self.assertEqual(self.book.publisher.name, "Tor Books")
+
+        # Check genres
+        genre_names = set(self.book.genres.values_list("name", flat=True))
+        self.assertIn("fantasy", genre_names)
+
+    def test_enrich_book_task_book_not_found(self):
+        """Graceful exit when book_id doesn't exist."""
+        from core.tasks import enrich_book_task
+
+        # Should not raise
+        result = enrich_book_task.delay(99999)
+        self.assertIsNone(result.result)
+
+    @patch("core.book_enrichment_service.enrich_book_from_apis")
+    def test_enrich_book_task_retries_on_api_failure(self, mock_enrich):
+        """Task should retry on API failures."""
+        from core.tasks import enrich_book_task
+
+        mock_enrich.side_effect = requests.RequestException("API timeout")
+
+        # In eager mode with propagation, the retry raises immediately
+        with self.assertRaises(Exception):
+            enrich_book_task.delay(self.book.id)
+
+        # The enrichment function was called at least once
+        self.assertGreaterEqual(mock_enrich.call_count, 1)
+
+    @patch("core.book_enrichment_service._fetch_ratings_and_categories_from_google_books")
+    @patch("core.book_enrichment_service._fetch_from_open_library")
+    def test_enrich_book_genre_canonicalization(self, mock_ol, mock_gb):
+        """Canonical genres from OL become Genre objects on the Book."""
+        from core.book_enrichment_service import enrich_book_from_apis
+
+        mock_ol.return_value = (
+            {
+                "genres": ["fantasy", "science fiction"],
+                "publish_year": None,
+                "page_count": None,
+                "publisher": None,
+                "isbn_13": None,
+            },
+            2,
+        )
+        mock_gb.return_value = ({}, 1)
+
+        session = MagicMock()
+        enrich_book_from_apis(self.book, session)
+
+        self.book.refresh_from_db()
+        genre_names = set(self.book.genres.values_list("name", flat=True))
+        self.assertEqual(genre_names, {"fantasy", "science fiction"})
+
+        # Verify Genre objects exist in DB
+        self.assertTrue(Genre.objects.filter(name="fantasy").exists())
+        self.assertTrue(Genre.objects.filter(name="science fiction").exists())
+
+    @patch("core.book_enrichment_service._fetch_ratings_and_categories_from_google_books")
+    @patch("core.book_enrichment_service._fetch_from_open_library")
+    def test_google_books_genres_replace_open_library_genres(self, mock_ol, mock_gb):
+        """When Google Books returns categories, they replace OL genres."""
+        from core.book_enrichment_service import enrich_book_from_apis
+
+        mock_ol.return_value = (
+            {
+                "genres": ["fantasy"],
+                "publish_year": None,
+                "page_count": None,
+                "publisher": None,
+                "isbn_13": None,
+            },
+            2,
+        )
+        # Google Books returns Science Fiction category
+        mock_gb.return_value = (
+            {"categories": ["Science Fiction"], "ratings_count": 100, "average_rating": 4.0},
+            1,
+        )
+
+        session = MagicMock()
+        enrich_book_from_apis(self.book, session)
+
+        self.book.refresh_from_db()
+        genre_names = set(self.book.genres.values_list("name", flat=True))
+        self.assertIn("science fiction", genre_names)
+        self.assertNotIn("fantasy", genre_names)
+
+
+# ──────────────────────────────────────────────
+# Class 2: Publisher Research Integration Tests
+# ──────────────────────────────────────────────
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class PublisherResearchIntegrationTests(TestCase):
+
+    def setUp(self):
+        self.pub_never_checked = Publisher.objects.create(
+            name="Never Checked Press",
+            mainstream_last_checked=None,
+        )
+        self.pub_stale = Publisher.objects.create(
+            name="Stale Check Press",
+            mainstream_last_checked=timezone.now() - timezone.timedelta(days=100),
+        )
+        self.pub_recent = Publisher.objects.create(
+            name="Recent Check Press",
+            mainstream_last_checked=timezone.now() - timezone.timedelta(days=10),
+        )
+        # Publisher with parent should be excluded
+        parent = Publisher.objects.create(
+            name="Parent Corp", mainstream_last_checked=timezone.now()
+        )
+        self.pub_with_parent = Publisher.objects.create(
+            name="Child Imprint",
+            parent=parent,
+            mainstream_last_checked=None,
+        )
+
+    @patch("time.sleep")
+    @patch("core.services.publisher_service.research_publisher_identity")
+    def test_updates_unchecked_and_stale_publishers(self, mock_research, mock_sleep):
+        """Task picks unchecked + stale publishers, updates is_mainstream and parent."""
+        from core.tasks import research_publisher_mainstream_task
+
+        mock_research.return_value = {
+            "is_mainstream": True,
+            "parent_company_name": "PRH",
+            "error": None,
+        }
+
+        result = research_publisher_mainstream_task.delay()
+
+        # Should only process never_checked and stale (not recent or child)
+        self.assertEqual(mock_research.call_count, 2)
+
+        self.pub_never_checked.refresh_from_db()
+        self.assertTrue(self.pub_never_checked.is_mainstream)
+        self.assertIsNotNone(self.pub_never_checked.mainstream_last_checked)
+
+        self.pub_stale.refresh_from_db()
+        self.assertTrue(self.pub_stale.is_mainstream)
+        self.assertIsNotNone(self.pub_stale.mainstream_last_checked)
+
+        # Parent "PRH" should have been created
+        self.assertTrue(Publisher.objects.filter(name="PRH").exists())
+
+        # Return value should be 2 (both updated successfully)
+        self.assertEqual(result.result, 2)
+
+    @patch("time.sleep")
+    @patch("core.services.publisher_service.research_publisher_identity")
+    def test_handles_api_error_gracefully(self, mock_research, mock_sleep):
+        """Error on one publisher doesn't crash; still sets mainstream_last_checked."""
+        from core.tasks import research_publisher_mainstream_task
+
+        mock_research.side_effect = [
+            {"is_mainstream": None, "parent_company_name": None, "error": "API timeout"},
+            {"is_mainstream": True, "parent_company_name": None, "error": None},
+        ]
+
+        result = research_publisher_mainstream_task.delay()
+
+        # Both should have mainstream_last_checked set
+        self.pub_never_checked.refresh_from_db()
+        self.assertIsNotNone(self.pub_never_checked.mainstream_last_checked)
+
+        self.pub_stale.refresh_from_db()
+        self.assertIsNotNone(self.pub_stale.mainstream_last_checked)
+
+        # Only one was successfully updated
+        self.assertEqual(result.result, 1)
+
+    @patch("core.services.publisher_service.research_publisher_identity")
+    def test_no_publishers_to_check(self, mock_research):
+        """Returns 0 when all publishers recently checked."""
+        # Mark all parentless publishers as recently checked
+        Publisher.objects.filter(parent__isnull=True).update(
+            mainstream_last_checked=timezone.now()
+        )
+
+        from core.tasks import research_publisher_mainstream_task
+
+        result = research_publisher_mainstream_task.delay()
+        mock_research.assert_not_called()
+        self.assertEqual(result.result, 0)
+
+
+# ──────────────────────────────────────────────
+# Class 3: Admin Command Runner Integration Tests
+# ──────────────────────────────────────────────
+
+
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_STORE_EAGER_RESULT=True,
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+)
+class AdminCommandRunnerIntegrationTests(TestCase):
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username="admin", password="adminpass", email="admin@test.com"
+        )
+        self.regular_user = User.objects.create_user(
+            username="regular", password="regularpass"
+        )
+        self.client.login(username="admin", password="adminpass")
+
+    @patch("core.tasks.run_management_command_task")
+    def test_dispatches_whitelisted_command(self, mock_task):
+        """Valid command dispatches task and returns task_id."""
+        mock_result = MagicMock()
+        mock_result.id = "fake-task-id"
+        mock_task.delay.return_value = mock_result
+
+        response = self.client.post(
+            "/admin/api/command-run/",
+            data=json.dumps({"command": "backfill_enrichment", "arguments": {}}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["task_id"], "fake-task-id")
+        mock_task.delay.assert_called_once()
+
+    def test_rejects_non_whitelisted_command(self):
+        """Security: commands not in ALLOWED_COMMANDS rejected."""
+        response = self.client.post(
+            "/admin/api/command-run/",
+            data=json.dumps({"command": "flush", "arguments": {}}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    @patch("core.tasks.run_management_command_task")
+    def test_parses_flag_and_int_arguments(self, mock_task):
+        """--dry-run (flag) and --limit (int) parsed correctly."""
+        mock_result = MagicMock()
+        mock_result.id = "task-123"
+        mock_task.delay.return_value = mock_result
+
+        response = self.client.post(
+            "/admin/api/command-run/",
+            data=json.dumps({
+                "command": "backfill_enrichment",
+                "arguments": {"--dry-run": True, "--limit": "50"},
+            }),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_task.delay.assert_called_once_with(
+            "backfill_enrichment", kwargs={"dry_run": True, "limit": 50}
+        )
+
+    def test_rejects_invalid_integer_argument(self):
+        """Non-numeric value for int arg returns 400."""
+        response = self.client.post(
+            "/admin/api/command-run/",
+            data=json.dumps({
+                "command": "backfill_enrichment",
+                "arguments": {"--limit": "not-a-number"},
+            }),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid integer", response.json()["error"])
+
+    def test_requires_staff_user(self):
+        """Non-staff user gets redirected."""
+        self.client.logout()
+        self.client.login(username="regular", password="regularpass")
+
+        response = self.client.post(
+            "/admin/api/command-run/",
+            data=json.dumps({"command": "backfill_enrichment", "arguments": {}}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 302)
+
+    @patch("celery.result.AsyncResult")
+    def test_result_api_pending_then_complete(self, mock_async_result_cls):
+        """Polling lifecycle: pending → complete."""
+        mock_result = MagicMock()
+        mock_async_result_cls.return_value = mock_result
+
+        # First call: pending
+        mock_result.ready.return_value = False
+        response = self.client.get("/admin/api/command-result/test-task-id/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "pending")
+
+        # Second call: complete
+        mock_result.ready.return_value = True
+        mock_result.successful.return_value = True
+        mock_result.get.return_value = {"status": "success", "stdout": "Done!\n", "stderr": ""}
+        response = self.client.get("/admin/api/command-result/test-task-id/")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["status"], "complete")
+        self.assertEqual(data["result"]["stdout"], "Done!\n")
+
+    @patch("django.core.management.call_command")
+    def test_run_management_command_task_captures_output(self, mock_call_command):
+        """Task wraps call_command and captures stdout."""
+        from core.tasks import run_management_command_task
+
+        def write_output(command_name, *args, stdout=None, stderr=None, **kwargs):
+            if stdout:
+                stdout.write("Command output here\n")
+
+        mock_call_command.side_effect = write_output
+
+        result = run_management_command_task("test_command")
+        self.assertEqual(result["status"], "success")
+        self.assertIn("Command output here", result["stdout"])
+
+    @patch("django.core.management.call_command")
+    def test_run_management_command_task_captures_error(self, mock_call_command):
+        """Task catches CommandError and returns error result."""
+        from core.tasks import run_management_command_task
+
+        mock_call_command.side_effect = CommandError("Something went wrong")
+
+        result = run_management_command_task("failing_command")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Something went wrong", result["error"])
+
+
+# ──────────────────────────────────────────────
+# Class 4: Create UserBooks From Anonymous Session
+# ──────────────────────────────────────────────
+
+
+class CreateUserbooksFromAnonymousSessionTests(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="claimuser", password="password")
+        self.author = Author.objects.create(name="Session Author")
+        self.book1 = Book.objects.create(title="Book One", author=self.author)
+        self.book2 = Book.objects.create(title="Book Two", author=self.author)
+        self.book3 = Book.objects.create(title="Book Three", author=self.author)
+        self.session_key = "test-session-key-123"
+        self.anon_session = AnonymousUserSession.objects.create(
+            session_key=self.session_key,
+            dna_data={"reader_type": "Test Reader"},
+            books_data=[self.book1.id, self.book2.id, self.book3.id],
+            top_books_data=[self.book1.id, self.book2.id],
+            expires_at=timezone.now() + timezone.timedelta(days=7),
+        )
+
+    @patch("core.services.top_books_service.calculate_and_store_top_books")
+    def test_creates_userbooks_and_marks_top_books(self, mock_calc_top):
+        """Happy path: UserBooks created, top books marked with positions."""
+        from core.tasks import _create_userbooks_from_anonymous_session
+
+        _create_userbooks_from_anonymous_session(self.user, self.session_key)
+
+        # All 3 UserBooks should exist
+        self.assertEqual(UserBook.objects.filter(user=self.user).count(), 3)
+
+        # Top books should be marked
+        ub1 = UserBook.objects.get(user=self.user, book=self.book1)
+        self.assertTrue(ub1.is_top_book)
+        self.assertEqual(ub1.top_book_position, 1)
+
+        ub2 = UserBook.objects.get(user=self.user, book=self.book2)
+        self.assertTrue(ub2.is_top_book)
+        self.assertEqual(ub2.top_book_position, 2)
+
+        # Non-top book
+        ub3 = UserBook.objects.get(user=self.user, book=self.book3)
+        self.assertFalse(ub3.is_top_book)
+
+        mock_calc_top.assert_called_once_with(self.user, limit=5)
+
+    @patch("core.services.top_books_service.calculate_and_store_top_books")
+    def test_handles_missing_book_ids(self, mock_calc_top):
+        """Nonexistent book ID in books_data skipped gracefully."""
+        from core.tasks import _create_userbooks_from_anonymous_session
+
+        self.anon_session.books_data = [self.book1.id, 99999, self.book3.id]
+        self.anon_session.save()
+
+        _create_userbooks_from_anonymous_session(self.user, self.session_key)
+
+        # Only 2 valid books created
+        self.assertEqual(UserBook.objects.filter(user=self.user).count(), 2)
+
+    def test_handles_missing_session(self):
+        """Nonexistent session_key doesn't crash."""
+        from core.tasks import _create_userbooks_from_anonymous_session
+
+        _create_userbooks_from_anonymous_session(self.user, "nonexistent-session-key")
+
+        self.assertEqual(UserBook.objects.filter(user=self.user).count(), 0)
+
+    @patch("core.services.top_books_service.calculate_and_store_top_books")
+    def test_handles_empty_books_data(self, mock_calc_top):
+        """Empty books_data returns early."""
+        from core.tasks import _create_userbooks_from_anonymous_session
+
+        self.anon_session.books_data = []
+        self.anon_session.save()
+
+        _create_userbooks_from_anonymous_session(self.user, self.session_key)
+
+        self.assertEqual(UserBook.objects.filter(user=self.user).count(), 0)
+        mock_calc_top.assert_not_called()
+
+
+# ──────────────────────────────────────────────
+# Class 5: Management Command Integration Tests
+# ──────────────────────────────────────────────
+
+
+class ManagementCommandIntegrationTests(TestCase):
+
+    def setUp(self):
+        self.author = Author.objects.create(name="Command Author", is_mainstream=True)
+        self.genre_fantasy = Genre.objects.create(name="fantasy")
+        self.genre_scifi = Genre.objects.create(name="science fiction")
+
+        # Book with genres but missing Google Books check
+        self.book1 = Book.objects.create(
+            title="Fantasy Book",
+            author=self.author,
+            publish_year=2020,
+            page_count=300,
+            google_books_last_checked=None,
+        )
+        self.book1.genres.add(self.genre_fantasy)
+
+        # Book missing publish_year
+        self.book2 = Book.objects.create(
+            title="Unknown Year Book",
+            author=self.author,
+            publish_year=None,
+            google_books_last_checked=timezone.now(),
+        )
+
+        # Book fully enriched
+        self.book3 = Book.objects.create(
+            title="Enriched Book",
+            author=self.author,
+            publish_year=2021,
+            page_count=400,
+            google_books_last_checked=timezone.now(),
+        )
+        self.book3.genres.add(self.genre_scifi)
+
+        # User with DNA data and UserBook records
+        self.user = User.objects.create_user(username="dnauser", password="password")
+        self.user.userprofile.dna_data = {
+            "reader_type": "Novella Navigator",
+            "top_genres": [],
+            "reader_type_scores": {"Novella Navigator": 5},
+            "top_reader_types": [{"type": "Novella Navigator", "score": 5}],
+            "mainstream_score_percent": 0,
+            "reader_type_explanation": "Old explanation",
+        }
+        self.user.userprofile.reader_type = "Novella Navigator"
+        self.user.userprofile.save()
+
+        UserBook.objects.create(user=self.user, book=self.book1, user_rating=5)
+        UserBook.objects.create(user=self.user, book=self.book3, user_rating=4)
+
+    @patch("core.management.commands.backfill_enrichment.enrich_book_task")
+    def test_backfill_enrichment_dry_run(self, mock_task):
+        """Identifies books needing enrichment but dispatches nothing."""
+        from io import StringIO
+
+        out = StringIO()
+        call_command("backfill_enrichment", "--dry-run", stdout=out)
+        output = out.getvalue()
+
+        self.assertIn("missing", output.lower())
+        mock_task.delay.assert_not_called()
+
+    @patch("core.management.commands.backfill_enrichment.enrich_book_task")
+    def test_backfill_enrichment_with_limit(self, mock_task):
+        """Dispatches only up to --limit tasks."""
+        from io import StringIO
+
+        out = StringIO()
+        call_command("backfill_enrichment", "--limit", "1", stdout=out)
+
+        self.assertEqual(mock_task.delay.call_count, 1)
+
+    def test_regenerate_dna_updates_genres_and_reader_type(self):
+        """After enrichment, regenerate_dna updates dna_data fields."""
+        from io import StringIO
+
+        out = StringIO()
+        call_command("regenerate_dna", "--username", "dnauser", stdout=out)
+
+        self.user.userprofile.refresh_from_db()
+        dna = self.user.userprofile.dna_data
+
+        # top_genres should contain fantasy (from book1) and science fiction (from book3)
+        genre_names = [g[0] for g in dna["top_genres"]]
+        self.assertIn("fantasy", genre_names)
+        self.assertIn("science fiction", genre_names)
+
+        # Reader type should have been recalculated
+        self.assertIn("reader_type", dna)
+
+        # Mainstream score should be recalculated (author is mainstream)
+        self.assertEqual(dna["mainstream_score_percent"], 100)


### PR DESCRIPTION
## Summary

- **Fix critical `ModuleNotFoundError` in `enrich_book_task`** — the import at `core/tasks.py:88` was changed to `from .services.book_enrichment_service import enrich_book_from_apis` but the file lives at `core/book_enrichment_service.py`, not under `core/services/`. This caused every enrichment Celery task to fail and retry endlessly. Reverted to the correct `from .book_enrichment_service import ...`.
- **Fix relative imports in `_create_userbooks_from_anonymous_session`** — `from ..models` and `from ..services` were wrong (double dot) since the function is in `core/tasks.py`, not a subpackage. Fixed to `from .models` and `from .services`.
- **Add user ID column to Django admin** — custom `UserAdmin` shows `id`, `username`, `email`, `is_staff` in the user list.
- **Add 23 integration tests** in `core/tests/test_integration.py` covering previously untested code paths (see below).
- **Command runner template improvements** — force light mode, use `json_script` for safe data passing, explicit CSRF token, hardcoded color values instead of CSS variables.

## New Integration Tests (23 tests, 5 classes)

### `BookEnrichmentIntegrationTests` (5 tests)
| Test | What it verifies |
|---|---|
| `test_enrich_book_task_updates_book_with_api_data` | Full pipeline: Celery task → service → Book DB updates (publish_year, page_count, genres, publisher, Google Books fields) |
| `test_enrich_book_task_book_not_found` | Graceful exit when book_id doesn't exist (no exception) |
| `test_enrich_book_task_retries_on_api_failure` | Task raises on `requests.RequestException` and enrichment function is called |
| `test_enrich_book_genre_canonicalization` | OL canonical genres become Genre objects linked to the Book |
| `test_google_books_genres_replace_open_library_genres` | Google Books categories replace OL genres when available |

### `PublisherResearchIntegrationTests` (3 tests)
| Test | What it verifies |
|---|---|
| `test_updates_unchecked_and_stale_publishers` | Task processes unchecked + stale publishers (not recent or child), creates parent Publisher, sets is_mainstream |
| `test_handles_api_error_gracefully` | API error on one publisher doesn't crash task; mainstream_last_checked still set |
| `test_no_publishers_to_check` | Returns 0 and doesn't call API when all publishers recently checked |

### `AdminCommandRunnerIntegrationTests` (8 tests)
| Test | What it verifies |
|---|---|
| `test_dispatches_whitelisted_command` | Valid command dispatches Celery task and returns task_id |
| `test_rejects_non_whitelisted_command` | Security: non-whitelisted commands return 400 |
| `test_parses_flag_and_int_arguments` | `--dry-run` (flag) and `--limit` (int) parsed correctly into kwargs |
| `test_rejects_invalid_integer_argument` | Non-numeric int arg returns 400 with error message |
| `test_requires_staff_user` | Non-staff user gets 302 redirect |
| `test_result_api_pending_then_complete` | Polling lifecycle: pending → complete with stdout |
| `test_run_management_command_task_captures_output` | Task captures stdout from `call_command` |
| `test_run_management_command_task_captures_error` | Task catches `CommandError` and returns error result |

### `CreateUserbooksFromAnonymousSessionTests` (4 tests)
| Test | What it verifies |
|---|---|
| `test_creates_userbooks_and_marks_top_books` | Happy path: UserBooks created, top books marked with correct positions |
| `test_handles_missing_book_ids` | Nonexistent book ID in books_data skipped gracefully |
| `test_handles_missing_session` | Nonexistent session_key doesn't crash |
| `test_handles_empty_books_data` | Empty books_data returns early, no side effects |

### `ManagementCommandIntegrationTests` (3 tests)
| Test | What it verifies |
|---|---|
| `test_backfill_enrichment_dry_run` | `--dry-run` shows counts but dispatches nothing |
| `test_backfill_enrichment_with_limit` | `--limit N` dispatches exactly N tasks |
| `test_regenerate_dna_updates_genres_and_reader_type` | Command recalculates top_genres, reader_type, and mainstream_score from enriched Book data |

## Test plan
- [x] `poetry run python manage.py test core.tests.test_integration` — all 23 new tests pass
- [x] `poetry run python manage.py test` — no new failures introduced (2 pre-existing flaky failures unrelated to this PR)
- [ ] Verify enrichment tasks succeed on deployed worker after the import fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)