### PR TITLE
Add backfill_isbn management command

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -150,6 +150,14 @@ class AggregateAnalyticsAdmin(admin.ModelAdmin):
 
 ADMIN_COMMANDS = [
     {
+        "name": "backfill_isbn",
+        "description": "Backfill ISBN13 for books missing it by querying Open Library. Run before backfill_enrichment for better results.",
+        "arguments": [
+            {"name": "--dry-run", "type": "flag", "label": "Dry run", "help": "Show what would be updated without saving"},
+            {"name": "--limit", "type": "int", "label": "Limit", "help": "Max books to process"},
+        ],
+    },
+    {
         "name": "backfill_enrichment",
         "description": "Dispatch background Celery tasks to enrich books missing publish_year, genres, or Google Books data.",
         "arguments": [

--- a/core/management/commands/analyze_genres.py
+++ b/core/management/commands/analyze_genres.py
@@ -1,10 +1,12 @@
-from collections import Counter
+import logging
 
 from django.core.management.base import BaseCommand
 from django.db.models import Count
 
 from core.dna_constants import CANONICAL_GENRE_MAP
 from core.models import Genre
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -17,54 +19,51 @@ class Command(BaseCommand):
             help="Deletes all genres from the database that are not found in the CANONICAL_GENRE_MAP.",
         )
 
-    def handle(self, *args, **kwargs):
-        self.stdout.write("Analyzing genres in the database...")
+    def _log(self, msg):
+        self.stdout.write(msg)
+        logger.info(f"analyze_genres: {msg}")
 
-        # Get all genres and how many books are associated with them
+    def _warn(self, msg):
+        self.stdout.write(self.style.WARNING(msg))
+        logger.warning(f"analyze_genres: {msg}")
+
+    def handle(self, *args, **kwargs):
+        self._log("Analyzing genres in the database...")
+
         all_genres = Genre.objects.annotate(num_books=Count("books")).all()
 
         unmapped_genres = []
         mapped_count = 0
 
         for genre in all_genres:
-            # Check if the genre name exists as a key in our master map
             if genre.name.lower().strip() not in CANONICAL_GENRE_MAP:
                 unmapped_genres.append(genre)
             else:
                 mapped_count += 1
 
-        self.stdout.write("\n" + "=" * 50)
-        self.stdout.write(f"Found {all_genres.count()} total unique genre strings in the database.")
-        self.stdout.write(self.style.SUCCESS(f"  - {mapped_count} are correctly mapped."))
-        self.stdout.write(self.style.WARNING(f"  - {len(unmapped_genres)} are UNMAPPED junk/alias genres."))
-        self.stdout.write("=" * 50 + "\n")
+        self._log(f"Found {all_genres.count()} total unique genre strings in the database.")
+        self._log(f"  - {mapped_count} are correctly mapped.")
+        self._warn(f"  - {len(unmapped_genres)} are UNMAPPED junk/alias genres.")
 
         if not unmapped_genres:
-            self.stdout.write(self.style.SUCCESS("Congratulations! All genres in the database are properly mapped."))
+            self._log("All genres in the database are properly mapped.")
             return
 
-        # Sort by the number of books they're attached to, then by name
         unmapped_genres.sort(key=lambda g: (-g.num_books, g.name))
 
-        self.stdout.write("List of UNMAPPED Genres (and book count):")
+        self._log("List of UNMAPPED Genres (and book count):")
         for genre in unmapped_genres:
-            self.stdout.write(f"  - '{genre.name}' ({genre.num_books} books)")
+            self._log(f"  - '{genre.name}' ({genre.num_books} books)")
 
         if kwargs["delete"]:
-            self.stdout.write("\n" + self.style.WARNING("--- Deleting Unmapped Genres ---"))
+            self._warn("--- Deleting Unmapped Genres ---")
 
-            # Get the primary keys of the unmapped genres
             pks_to_delete = [genre.pk for genre in unmapped_genres]
-
-            # This is a safe and efficient bulk delete operation.
-            # Django handles removing the links from the book-to-genre relationship table automatically.
             deleted_count, _ = Genre.objects.filter(pk__in=pks_to_delete).delete()
 
-            self.stdout.write(self.style.SUCCESS(f"Successfully deleted {deleted_count} unmapped genre entries."))
+            self._log(f"Successfully deleted {deleted_count} unmapped genre entries.")
         else:
-            self.stdout.write(
-                self.style.NOTICE(
-                    "\nTo clean up the database, review the list above. Add any legitimate aliases to your "
-                    "GENRE_ALIASES in dna_constants.py, then run this command again with the --delete flag."
-                )
+            self._log(
+                "To clean up the database, review the list above. Add any legitimate aliases to your "
+                "GENRE_ALIASES in dna_constants.py, then run this command again with the --delete flag."
             )

--- a/core/management/commands/backfill_enrichment.py
+++ b/core/management/commands/backfill_enrichment.py
@@ -1,8 +1,12 @@
+import logging
+
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 
 from core.models import Book
 from core.tasks import enrich_book_task
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -20,6 +24,10 @@ class Command(BaseCommand):
             help="Limit the number of books to dispatch tasks for.",
         )
 
+    def _log(self, msg):
+        self.stdout.write(msg)
+        logger.info(f"backfill_enrichment: {msg}")
+
     def handle(self, *args, **options):
         queryset = Book.objects.filter(
             Q(publish_year__isnull=True) | Q(genres__isnull=True) | Q(google_books_last_checked__isnull=True)
@@ -28,7 +36,7 @@ class Command(BaseCommand):
         total = queryset.count()
 
         if total == 0:
-            self.stdout.write(self.style.SUCCESS("All books are already enriched. Nothing to do."))
+            self._log("All books are already enriched. Nothing to do.")
             return
 
         # Show breakdown
@@ -36,17 +44,17 @@ class Command(BaseCommand):
         missing_genres = Book.objects.filter(genres__isnull=True).count()
         missing_gb = Book.objects.filter(google_books_last_checked__isnull=True).count()
 
-        self.stdout.write(f"Books missing publish_year: {missing_year}")
-        self.stdout.write(f"Books missing genres: {missing_genres}")
-        self.stdout.write(f"Books missing Google Books check: {missing_gb}")
-        self.stdout.write(f"Total unique books needing enrichment: {total}")
+        self._log(f"Books missing publish_year: {missing_year}")
+        self._log(f"Books missing genres: {missing_genres}")
+        self._log(f"Books missing Google Books check: {missing_gb}")
+        self._log(f"Total unique books needing enrichment: {total}")
 
         if options["limit"]:
             queryset = queryset[: options["limit"]]
-            self.stdout.write(self.style.NOTICE(f"Limiting to {options['limit']} books."))
+            self._log(f"Limiting to {options['limit']} books.")
 
         if options["dry_run"]:
-            self.stdout.write(self.style.WARNING("Dry run — no tasks dispatched."))
+            self._log("Dry run — no tasks dispatched.")
             return
 
         dispatched = 0
@@ -54,4 +62,4 @@ class Command(BaseCommand):
             enrich_book_task.delay(book.pk)
             dispatched += 1
 
-        self.stdout.write(self.style.SUCCESS(f"Dispatched {dispatched} enrichment tasks to Celery."))
+        self._log(f"Dispatched {dispatched} enrichment tasks to Celery.")

--- a/core/management/commands/backfill_isbn.py
+++ b/core/management/commands/backfill_isbn.py
@@ -1,0 +1,129 @@
+import re
+import time
+
+import requests
+from django.core.management.base import BaseCommand
+from django.db import IntegrityError
+
+from core.models import Book
+
+
+class Command(BaseCommand):
+    help = "Backfill ISBN13 for books missing it by querying Open Library search API."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be updated without saving.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Limit the number of books to process.",
+        )
+
+    def _clean_title_for_api(self, title):
+        clean_title = re.sub(r"[\(\[].*?[\)\]]", "", title)
+        clean_title = clean_title.split(":")[0]
+        return clean_title.strip()
+
+    def _find_isbn13(self, isbn_list):
+        """Pick the first 13-digit ISBN from the list."""
+        for isbn in isbn_list:
+            cleaned = isbn.strip()
+            if len(cleaned) == 13 and cleaned.isdigit():
+                return cleaned
+        return None
+
+    def handle(self, *args, **options):
+        queryset = Book.objects.filter(isbn13__isnull=True).select_related("author")
+
+        total = queryset.count()
+        if total == 0:
+            self.stdout.write(self.style.SUCCESS("All books already have ISBN13. Nothing to do."))
+            return
+
+        self.stdout.write(f"Found {total} books missing ISBN13.")
+
+        if options["limit"]:
+            queryset = queryset[: options["limit"]]
+            self.stdout.write(self.style.NOTICE(f"Limiting to {options['limit']} books."))
+
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING("Dry run — no changes will be saved."))
+
+        updated = 0
+        skipped = 0
+        not_found = 0
+        conflicts = 0
+
+        with requests.Session() as session:
+            session.headers.update({"User-Agent": "BibliotypeApp/1.0"})
+
+            for book in queryset.iterator():
+                clean_title = self._clean_title_for_api(book.title)
+                search_url = "https://openlibrary.org/search.json"
+                params = {
+                    "title": clean_title,
+                    "author": book.author.name,
+                    "limit": 1,
+                    "fields": "isbn,title,author_name",
+                }
+
+                try:
+                    res = session.get(search_url, params=params, timeout=10)
+                    res.raise_for_status()
+                    data = res.json()
+                except requests.RequestException as e:
+                    self.stdout.write(self.style.WARNING(f"  API error for '{book.title}': {e}"))
+                    skipped += 1
+                    time.sleep(1.2)
+                    continue
+
+                docs = data.get("docs", [])
+                if not docs or "isbn" not in docs[0]:
+                    self.stdout.write(f"  No ISBN found: '{book.title}'")
+                    not_found += 1
+                    time.sleep(1.2)
+                    continue
+
+                isbn13 = self._find_isbn13(docs[0]["isbn"])
+                if not isbn13:
+                    self.stdout.write(f"  No ISBN-13 in results: '{book.title}'")
+                    not_found += 1
+                    time.sleep(1.2)
+                    continue
+
+                if options["dry_run"]:
+                    self.stdout.write(f"  Would set: '{book.title}' -> {isbn13}")
+                    updated += 1
+                else:
+                    # Check for existing book with this ISBN before saving
+                    if Book.objects.filter(isbn13=isbn13).exists():
+                        self.stdout.write(self.style.WARNING(f"  ISBN conflict: '{book.title}' -> {isbn13} (already taken)"))
+                        conflicts += 1
+                        time.sleep(1.2)
+                        continue
+
+                    book.isbn13 = isbn13
+                    try:
+                        book.save(update_fields=["isbn13"])
+                        self.stdout.write(self.style.SUCCESS(f"  Updated: '{book.title}' -> {isbn13}"))
+                        updated += 1
+                    except IntegrityError:
+                        self.stdout.write(self.style.WARNING(f"  ISBN conflict on save: '{book.title}' -> {isbn13}"))
+                        conflicts += 1
+
+                time.sleep(1.2)
+
+        self.stdout.write("")
+        self.stdout.write(f"Updated: {updated}")
+        self.stdout.write(f"Not found: {not_found}")
+        self.stdout.write(f"Conflicts: {conflicts}")
+        self.stdout.write(f"API errors: {skipped}")
+
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING("Dry run complete. No changes saved."))
+        else:
+            self.stdout.write(self.style.SUCCESS(f"Done. {updated} books updated with ISBN13."))

--- a/core/management/commands/backfill_isbn.py
+++ b/core/management/commands/backfill_isbn.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import time
 
@@ -10,9 +11,11 @@ from core.models import Book
 
 logger = logging.getLogger(__name__)
 
+GOOGLE_BOOKS_API_KEY = os.getenv("GOOGLE_BOOKS_API_KEY")
+
 
 class Command(BaseCommand):
-    help = "Backfill ISBN13 for books missing it by querying Open Library search API."
+    help = "Backfill ISBN13 for books missing it by querying Open Library and Google Books APIs."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -26,17 +29,130 @@ class Command(BaseCommand):
             help="Limit the number of books to process.",
         )
 
+    def _log(self, msg):
+        self.stdout.write(msg)
+        logger.info(f"backfill_isbn: {msg}")
+
+    def _warn(self, msg):
+        self.stdout.write(self.style.WARNING(msg))
+        logger.warning(f"backfill_isbn: {msg}")
+
     def _clean_title_for_api(self, title):
-        clean_title = re.sub(r"[\(\[].*?[\)\]]", "", title)
-        clean_title = clean_title.split(":")[0]
-        return clean_title.strip()
+        """Clean Goodreads-style titles for API search."""
+        clean = title
+        # Remove parenthetical/bracketed text (series info, notes)
+        clean = re.sub(r"[\(\[].*?[\)\]]", "", clean)
+        # Remove "Publisher: ..." suffix pattern from Goodreads
+        clean = re.sub(r"\s+Publisher:.*$", "", clean, flags=re.IGNORECASE)
+        # Only split on colon if it looks like a subtitle (not embedded in the title)
+        # Keep the first part if what follows the colon is long (likely a subtitle)
+        if ":" in clean:
+            parts = clean.split(":", 1)
+            # If the part before the colon is a reasonable title, use just that
+            if len(parts[0].strip()) >= 5:
+                clean = parts[0]
+        # Remove trailing junk
+        clean = re.sub(r"\s*[-–—]\s*$", "", clean)
+        return clean.strip()
+
+    def _isbn10_to_isbn13(self, isbn10):
+        """Convert an ISBN-10 to ISBN-13."""
+        if len(isbn10) != 10:
+            return None
+        # Remove the old check digit, prefix with 978
+        base = "978" + isbn10[:9]
+        # Calculate ISBN-13 check digit
+        total = sum(int(d) * (1 if i % 2 == 0 else 3) for i, d in enumerate(base))
+        check = (10 - (total % 10)) % 10
+        return base + str(check)
 
     def _find_isbn13(self, isbn_list):
-        """Pick the first 13-digit ISBN from the list."""
+        """Pick the first valid ISBN-13 from the list, converting ISBN-10s if needed."""
+        # First pass: look for ISBN-13 directly
         for isbn in isbn_list:
             cleaned = isbn.strip()
             if len(cleaned) == 13 and cleaned.isdigit():
                 return cleaned
+        # Second pass: convert ISBN-10 to ISBN-13
+        for isbn in isbn_list:
+            cleaned = isbn.strip()
+            if len(cleaned) == 10 and cleaned[:9].isdigit():
+                converted = self._isbn10_to_isbn13(cleaned)
+                if converted:
+                    return converted
+        return None
+
+    def _search_open_library(self, session, title, author_name):
+        """Search Open Library for ISBN. Returns ISBN-13 string or None."""
+        clean_title = self._clean_title_for_api(title)
+        search_url = "https://openlibrary.org/search.json"
+        params = {
+            "title": clean_title,
+            "author": author_name,
+            "limit": 3,
+            "fields": "isbn,title,author_name",
+        }
+
+        try:
+            res = session.get(search_url, params=params, timeout=10)
+            res.raise_for_status()
+            data = res.json()
+        except requests.RequestException as e:
+            self._warn(f"  OL API error for '{title}': {e}")
+            return None
+
+        docs = data.get("docs", [])
+        # Check all returned docs, not just the first
+        for doc in docs:
+            if "isbn" in doc:
+                isbn13 = self._find_isbn13(doc["isbn"])
+                if isbn13:
+                    return isbn13
+
+        return None
+
+    def _search_google_books(self, session, title, author_name):
+        """Search Google Books for ISBN. Returns ISBN-13 string or None."""
+        if not GOOGLE_BOOKS_API_KEY:
+            return None
+
+        clean_title = self._clean_title_for_api(title)
+        title_q = requests.utils.quote(clean_title)
+        author_q = requests.utils.quote(author_name)
+        query = f"intitle:{title_q}+inauthor:{author_q}"
+        url = f"https://www.googleapis.com/books/v1/volumes?q={query}&key={GOOGLE_BOOKS_API_KEY}"
+
+        try:
+            res = session.get(url, timeout=10)
+            res.raise_for_status()
+            data = res.json()
+        except requests.RequestException as e:
+            self._warn(f"  GB API error for '{title}': {e}")
+            return None
+
+        if data.get("totalItems", 0) == 0:
+            return None
+
+        # Check first few results for ISBN-13
+        for item in data.get("items", [])[:3]:
+            volume_info = item.get("volumeInfo", {})
+            identifiers = volume_info.get("industryIdentifiers", [])
+
+            # Prefer ISBN_13 directly
+            for ident in identifiers:
+                if ident.get("type") == "ISBN_13":
+                    isbn = ident.get("identifier", "").strip()
+                    if len(isbn) == 13 and isbn.isdigit():
+                        return isbn
+
+            # Fall back to converting ISBN_10
+            for ident in identifiers:
+                if ident.get("type") == "ISBN_10":
+                    isbn10 = ident.get("identifier", "").strip()
+                    converted = self._isbn10_to_isbn13(isbn10)
+                    if converted:
+                        return converted
+
         return None
 
     def handle(self, *args, **options):
@@ -44,24 +160,25 @@ class Command(BaseCommand):
 
         total = queryset.count()
         if total == 0:
-            self.stdout.write(self.style.SUCCESS("All books already have ISBN13. Nothing to do."))
+            self._log("All books already have ISBN13. Nothing to do.")
             return
 
-        self.stdout.write(f"Found {total} books missing ISBN13.")
-        logger.info(f"backfill_isbn: Found {total} books missing ISBN13.")
+        self._log(f"Found {total} books missing ISBN13.")
 
         if options["limit"]:
             queryset = queryset[: options["limit"]]
-            self.stdout.write(self.style.NOTICE(f"Limiting to {options['limit']} books."))
+            self._log(f"Limiting to {options['limit']} books.")
 
         if options["dry_run"]:
             for book in queryset.iterator():
-                self.stdout.write(f"  Missing ISBN: '{book.title}' by {book.author.name}")
-            self.stdout.write(self.style.WARNING(f"Dry run — {total} books need ISBN13. No API calls made."))
+                self._log(f"  Missing ISBN: '{book.title}' by {book.author.name}")
+            self._log(f"Dry run — {total} books need ISBN13. No API calls made.")
             return
 
+        if not GOOGLE_BOOKS_API_KEY:
+            self._warn("GOOGLE_BOOKS_API_KEY not set — Google Books fallback disabled.")
+
         updated = 0
-        skipped = 0
         not_found = 0
         conflicts = 0
 
@@ -69,50 +186,24 @@ class Command(BaseCommand):
             session.headers.update({"User-Agent": "BibliotypeApp/1.0"})
 
             for book in queryset.iterator():
-                clean_title = self._clean_title_for_api(book.title)
-                search_url = "https://openlibrary.org/search.json"
-                params = {
-                    "title": clean_title,
-                    "author": book.author.name,
-                    "limit": 1,
-                    "fields": "isbn,title,author_name",
-                }
+                # Try Open Library first
+                isbn13 = self._search_open_library(session, book.title, book.author.name)
+                source = "OL"
 
-                try:
-                    res = session.get(search_url, params=params, timeout=10)
-                    res.raise_for_status()
-                    data = res.json()
-                except requests.RequestException as e:
-                    msg = f"API error for '{book.title}': {e}"
-                    self.stdout.write(self.style.WARNING(f"  {msg}"))
-                    logger.warning(f"backfill_isbn: {msg}")
-                    skipped += 1
-                    time.sleep(1.2)
-                    continue
-
-                docs = data.get("docs", [])
-                if not docs or "isbn" not in docs[0]:
-                    msg = f"No ISBN found: '{book.title}'"
-                    self.stdout.write(f"  {msg}")
-                    logger.info(f"backfill_isbn: {msg}")
-                    not_found += 1
-                    time.sleep(1.2)
-                    continue
-
-                isbn13 = self._find_isbn13(docs[0]["isbn"])
+                # Fall back to Google Books
                 if not isbn13:
-                    msg = f"No ISBN-13 in results: '{book.title}'"
-                    self.stdout.write(f"  {msg}")
-                    logger.info(f"backfill_isbn: {msg}")
+                    isbn13 = self._search_google_books(session, book.title, book.author.name)
+                    source = "GB"
+
+                if not isbn13:
+                    self._log(f"  Not found: '{book.title}' by {book.author.name}")
                     not_found += 1
                     time.sleep(1.2)
                     continue
 
                 # Check for existing book with this ISBN before saving
                 if Book.objects.filter(isbn13=isbn13).exists():
-                    msg = f"ISBN conflict: '{book.title}' -> {isbn13} (already taken)"
-                    self.stdout.write(self.style.WARNING(f"  {msg}"))
-                    logger.warning(f"backfill_isbn: {msg}")
+                    self._warn(f"  ISBN conflict: '{book.title}' -> {isbn13} (already taken)")
                     conflicts += 1
                     time.sleep(1.2)
                     continue
@@ -120,23 +211,12 @@ class Command(BaseCommand):
                 book.isbn13 = isbn13
                 try:
                     book.save(update_fields=["isbn13"])
-                    msg = f"Updated: '{book.title}' -> {isbn13}"
-                    self.stdout.write(self.style.SUCCESS(f"  {msg}"))
-                    logger.info(f"backfill_isbn: {msg}")
+                    self._log(f"  Updated ({source}): '{book.title}' -> {isbn13}")
                     updated += 1
                 except IntegrityError:
-                    msg = f"ISBN conflict on save: '{book.title}' -> {isbn13}"
-                    self.stdout.write(self.style.WARNING(f"  {msg}"))
-                    logger.warning(f"backfill_isbn: {msg}")
+                    self._warn(f"  ISBN conflict on save: '{book.title}' -> {isbn13}")
                     conflicts += 1
 
                 time.sleep(1.2)
 
-        summary = f"Done. Updated: {updated}, Not found: {not_found}, Conflicts: {conflicts}, API errors: {skipped}"
-        self.stdout.write("")
-        self.stdout.write(f"Updated: {updated}")
-        self.stdout.write(f"Not found: {not_found}")
-        self.stdout.write(f"Conflicts: {conflicts}")
-        self.stdout.write(f"API errors: {skipped}")
-        self.stdout.write(self.style.SUCCESS(f"Done. {updated} books updated with ISBN13."))
-        logger.info(f"backfill_isbn: {summary}")
+        self._log(f"Done. Updated: {updated}, Not found: {not_found}, Conflicts: {conflicts}")

--- a/core/management/commands/backfill_isbn.py
+++ b/core/management/commands/backfill_isbn.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import time
 
@@ -6,6 +7,8 @@ from django.core.management.base import BaseCommand
 from django.db import IntegrityError
 
 from core.models import Book
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -45,6 +48,7 @@ class Command(BaseCommand):
             return
 
         self.stdout.write(f"Found {total} books missing ISBN13.")
+        logger.info(f"backfill_isbn: Found {total} books missing ISBN13.")
 
         if options["limit"]:
             queryset = queryset[: options["limit"]]
@@ -79,28 +83,36 @@ class Command(BaseCommand):
                     res.raise_for_status()
                     data = res.json()
                 except requests.RequestException as e:
-                    self.stdout.write(self.style.WARNING(f"  API error for '{book.title}': {e}"))
+                    msg = f"API error for '{book.title}': {e}"
+                    self.stdout.write(self.style.WARNING(f"  {msg}"))
+                    logger.warning(f"backfill_isbn: {msg}")
                     skipped += 1
                     time.sleep(1.2)
                     continue
 
                 docs = data.get("docs", [])
                 if not docs or "isbn" not in docs[0]:
-                    self.stdout.write(f"  No ISBN found: '{book.title}'")
+                    msg = f"No ISBN found: '{book.title}'"
+                    self.stdout.write(f"  {msg}")
+                    logger.info(f"backfill_isbn: {msg}")
                     not_found += 1
                     time.sleep(1.2)
                     continue
 
                 isbn13 = self._find_isbn13(docs[0]["isbn"])
                 if not isbn13:
-                    self.stdout.write(f"  No ISBN-13 in results: '{book.title}'")
+                    msg = f"No ISBN-13 in results: '{book.title}'"
+                    self.stdout.write(f"  {msg}")
+                    logger.info(f"backfill_isbn: {msg}")
                     not_found += 1
                     time.sleep(1.2)
                     continue
 
                 # Check for existing book with this ISBN before saving
                 if Book.objects.filter(isbn13=isbn13).exists():
-                    self.stdout.write(self.style.WARNING(f"  ISBN conflict: '{book.title}' -> {isbn13} (already taken)"))
+                    msg = f"ISBN conflict: '{book.title}' -> {isbn13} (already taken)"
+                    self.stdout.write(self.style.WARNING(f"  {msg}"))
+                    logger.warning(f"backfill_isbn: {msg}")
                     conflicts += 1
                     time.sleep(1.2)
                     continue
@@ -108,17 +120,23 @@ class Command(BaseCommand):
                 book.isbn13 = isbn13
                 try:
                     book.save(update_fields=["isbn13"])
-                    self.stdout.write(self.style.SUCCESS(f"  Updated: '{book.title}' -> {isbn13}"))
+                    msg = f"Updated: '{book.title}' -> {isbn13}"
+                    self.stdout.write(self.style.SUCCESS(f"  {msg}"))
+                    logger.info(f"backfill_isbn: {msg}")
                     updated += 1
                 except IntegrityError:
-                    self.stdout.write(self.style.WARNING(f"  ISBN conflict on save: '{book.title}' -> {isbn13}"))
+                    msg = f"ISBN conflict on save: '{book.title}' -> {isbn13}"
+                    self.stdout.write(self.style.WARNING(f"  {msg}"))
+                    logger.warning(f"backfill_isbn: {msg}")
                     conflicts += 1
 
                 time.sleep(1.2)
 
+        summary = f"Done. Updated: {updated}, Not found: {not_found}, Conflicts: {conflicts}, API errors: {skipped}"
         self.stdout.write("")
         self.stdout.write(f"Updated: {updated}")
         self.stdout.write(f"Not found: {not_found}")
         self.stdout.write(f"Conflicts: {conflicts}")
         self.stdout.write(f"API errors: {skipped}")
         self.stdout.write(self.style.SUCCESS(f"Done. {updated} books updated with ISBN13."))
+        logger.info(f"backfill_isbn: {summary}")

--- a/core/management/commands/backfill_isbn.py
+++ b/core/management/commands/backfill_isbn.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--dry-run",
             action="store_true",
-            help="Show what would be updated without saving.",
+            help="Show count of books missing ISBN13 without making API calls.",
         )
         parser.add_argument(
             "--limit",
@@ -51,7 +51,10 @@ class Command(BaseCommand):
             self.stdout.write(self.style.NOTICE(f"Limiting to {options['limit']} books."))
 
         if options["dry_run"]:
-            self.stdout.write(self.style.WARNING("Dry run — no changes will be saved."))
+            for book in queryset.iterator():
+                self.stdout.write(f"  Missing ISBN: '{book.title}' by {book.author.name}")
+            self.stdout.write(self.style.WARNING(f"Dry run — {total} books need ISBN13. No API calls made."))
+            return
 
         updated = 0
         skipped = 0
@@ -95,25 +98,21 @@ class Command(BaseCommand):
                     time.sleep(1.2)
                     continue
 
-                if options["dry_run"]:
-                    self.stdout.write(f"  Would set: '{book.title}' -> {isbn13}")
-                    updated += 1
-                else:
-                    # Check for existing book with this ISBN before saving
-                    if Book.objects.filter(isbn13=isbn13).exists():
-                        self.stdout.write(self.style.WARNING(f"  ISBN conflict: '{book.title}' -> {isbn13} (already taken)"))
-                        conflicts += 1
-                        time.sleep(1.2)
-                        continue
+                # Check for existing book with this ISBN before saving
+                if Book.objects.filter(isbn13=isbn13).exists():
+                    self.stdout.write(self.style.WARNING(f"  ISBN conflict: '{book.title}' -> {isbn13} (already taken)"))
+                    conflicts += 1
+                    time.sleep(1.2)
+                    continue
 
-                    book.isbn13 = isbn13
-                    try:
-                        book.save(update_fields=["isbn13"])
-                        self.stdout.write(self.style.SUCCESS(f"  Updated: '{book.title}' -> {isbn13}"))
-                        updated += 1
-                    except IntegrityError:
-                        self.stdout.write(self.style.WARNING(f"  ISBN conflict on save: '{book.title}' -> {isbn13}"))
-                        conflicts += 1
+                book.isbn13 = isbn13
+                try:
+                    book.save(update_fields=["isbn13"])
+                    self.stdout.write(self.style.SUCCESS(f"  Updated: '{book.title}' -> {isbn13}"))
+                    updated += 1
+                except IntegrityError:
+                    self.stdout.write(self.style.WARNING(f"  ISBN conflict on save: '{book.title}' -> {isbn13}"))
+                    conflicts += 1
 
                 time.sleep(1.2)
 
@@ -122,8 +121,4 @@ class Command(BaseCommand):
         self.stdout.write(f"Not found: {not_found}")
         self.stdout.write(f"Conflicts: {conflicts}")
         self.stdout.write(f"API errors: {skipped}")
-
-        if options["dry_run"]:
-            self.stdout.write(self.style.WARNING("Dry run complete. No changes saved."))
-        else:
-            self.stdout.write(self.style.SUCCESS(f"Done. {updated} books updated with ISBN13."))
+        self.stdout.write(self.style.SUCCESS(f"Done. {updated} books updated with ISBN13."))

--- a/core/management/commands/enrich_books.py
+++ b/core/management/commands/enrich_books.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 
@@ -7,6 +8,8 @@ from django.db.models import Q
 
 from core.book_enrichment_service import enrich_book_from_apis
 from core.models import Author, Book
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -39,41 +42,45 @@ class Command(BaseCommand):
         self.gb_api_calls = 0
         self.ol_api_calls = 0
 
+    def _log(self, msg):
+        self.stdout.write(msg)
+        logger.info(f"enrich_books: {msg}")
+
+    def _warn(self, msg):
+        self.stdout.write(self.style.WARNING(msg))
+        logger.warning(f"enrich_books: {msg}")
+
     def handle(self, *args, **options):
-        self.stdout.write("🚀 Starting enrichment of Book entries with external APIs...")
+        self._log("Starting enrichment of Book entries with external APIs...")
 
         gb_limit = options["limit"] or self.GOOGLE_BOOKS_API_LIMIT
-        self.stdout.write(self.style.NOTICE(f"Google Books API request limit for this run is set to {gb_limit}."))
+        self._log(f"Google Books API request limit for this run is set to {gb_limit}.")
 
         if options["process_all"]:
-            self.stdout.write(self.style.WARNING("--process-all flag set. Re-checking all books."))
+            self._warn("--process-all flag set. Re-checking all books.")
             queryset = Book.objects.all()
         else:
-            self.stdout.write(
-                self.style.NOTICE("Processing books that have not been checked or are missing genres/publish year.")
-            )
+            self._log("Processing books that have not been checked or are missing genres/publish year.")
             queryset = Book.objects.filter(
                 Q(google_books_last_checked__isnull=True) | Q(genres__isnull=True) | Q(publish_year__isnull=True)
             ).distinct()
 
         total_books_to_process = queryset.count()
         if total_books_to_process == 0:
-            self.stdout.write(self.style.SUCCESS("No books found that need enrichment. All done!"))
+            self._log("No books found that need enrichment. All done!")
             return
 
-        self.stdout.write(f"Found {total_books_to_process} books to process.")
+        self._log(f"Found {total_books_to_process} books to process.")
 
         processed_books = 0
         for book in queryset.iterator():
             # The check now only applies to the Google Books counter
             if self.gb_api_calls >= gb_limit:
-                self.stdout.write(
-                    self.style.WARNING(f"\nGoogle Books API request limit of {gb_limit} reached. Stopping.")
-                )
+                self._warn(f"Google Books API request limit of {gb_limit} reached. Stopping.")
                 break
 
             processed_books += 1
-            self.stdout.write(
+            self._log(
                 f'  -> Processing: "{book.title}" ({processed_books}/{total_books_to_process}) | OL Calls: {self.ol_api_calls} | GB Calls: {self.gb_api_calls}'
             )
 
@@ -86,10 +93,7 @@ class Command(BaseCommand):
 
             # The polite delay is now correctly handled inside the service, so we don't need a sleep here.
 
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"\n✅ Finished enriching books. Processed {processed_books} books."
-                f"\n   - Open Library Calls: {self.ol_api_calls}"
-                f"\n   - Google Books Calls: {self.gb_api_calls}"
-            )
+        self._log(
+            f"Finished enriching books. Processed {processed_books} books. "
+            f"Open Library Calls: {self.ol_api_calls}, Google Books Calls: {self.gb_api_calls}"
         )

--- a/core/management/commands/rebuild_analytics.py
+++ b/core/management/commands/rebuild_analytics.py
@@ -1,40 +1,44 @@
+import logging
+
 from django.core.management.base import BaseCommand
 
 from core.models import AggregateAnalytics, UserProfile
-
-# We'll reuse the same function that the live app uses!
 from core.percentile_engine import update_analytics_from_stats
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
     help = "Rebuilds the AggregateAnalytics data from all existing UserProfiles."
 
-    def handle(self, *args, **kwargs):
-        self.stdout.write(self.style.WARNING("Rebuilding aggregate analytics from scratch..."))
+    def _log(self, msg):
+        self.stdout.write(msg)
+        logger.info(f"rebuild_analytics: {msg}")
 
-        # Step 1: Clear the old analytics data
-        self.stdout.write("  -> Deleting old aggregate analytics...")
+    def _warn(self, msg):
+        self.stdout.write(self.style.WARNING(msg))
+        logger.warning(f"rebuild_analytics: {msg}")
+
+    def handle(self, *args, **kwargs):
+        self._log("Rebuilding aggregate analytics from scratch...")
+
+        self._log("  -> Deleting old aggregate analytics...")
         AggregateAnalytics.objects.all().delete()
-        # Create a fresh, empty instance
         analytics = AggregateAnalytics.get_instance()
 
-        # Step 2: Get all user profiles that have DNA data
         profiles_with_dna = UserProfile.objects.exclude(dna_data__isnull=True)
         total_profiles = profiles_with_dna.count()
 
         if total_profiles == 0:
-            self.stdout.write(self.style.SUCCESS("No user profiles with DNA found. Analytics table is now empty."))
+            self._log("No user profiles with DNA found. Analytics table is now empty.")
             return
 
-        self.stdout.write(f"  -> Found {total_profiles} user profiles with DNA data to process.")
+        self._log(f"  -> Found {total_profiles} user profiles with DNA data to process.")
 
-        # Step 3: Loop through each profile and re-run the analytics update
         for i, profile in enumerate(profiles_with_dna):
-            # Extract the specific `user_stats` dictionary from the larger JSON blob
             user_stats = profile.dna_data.get("user_stats")
 
             if user_stats:
-                # Backfill avg_books_per_year if missing from stored data
                 if "avg_books_per_year" not in user_stats:
                     stats_by_year = profile.dna_data.get("stats_by_year", [])
                     if stats_by_year:
@@ -44,12 +48,8 @@ class Command(BaseCommand):
                         user_stats["num_reading_years"] = num_years
 
                 update_analytics_from_stats(user_stats)
-                self.stdout.write(f"     - Processed profile {i+1}/{total_profiles} for user {profile.user.username}")
+                self._log(f"     - Processed profile {i+1}/{total_profiles} for user {profile.user.username}")
             else:
-                self.stdout.write(
-                    self.style.WARNING(f"     - Skipped profile for {profile.user.username} (missing user_stats).")
-                )
+                self._warn(f"     - Skipped profile for {profile.user.username} (missing user_stats).")
 
-        self.stdout.write(
-            self.style.SUCCESS(f"\nSuccessfully rebuilt aggregate analytics from {total_profiles} profiles.")
-        )
+        self._log(f"Successfully rebuilt aggregate analytics from {total_profiles} profiles.")

--- a/core/management/commands/regenerate_dna.py
+++ b/core/management/commands/regenerate_dna.py
@@ -17,6 +17,14 @@ class Command(BaseCommand):
         "for users from their current Book data. Use after enrichment backfills."
     )
 
+    def _log(self, msg):
+        self.stdout.write(msg)
+        logger.info(f"regenerate_dna: {msg}")
+
+    def _warn(self, msg):
+        self.stdout.write(self.style.WARNING(msg))
+        logger.warning(f"regenerate_dna: {msg}")
+
     def add_arguments(self, parser):
         parser.add_argument(
             "--dry-run",
@@ -46,10 +54,10 @@ class Command(BaseCommand):
         profiles = list(profiles)
 
         if not profiles:
-            self.stdout.write(self.style.SUCCESS("No profiles with DNA data found."))
+            self._log("No profiles with DNA data found.")
             return
 
-        self.stdout.write(f"Found {len(profiles)} profiles to regenerate.")
+        self._log(f"Found {len(profiles)} profiles to regenerate.")
         updated = 0
 
         for profile in profiles:
@@ -61,7 +69,7 @@ class Command(BaseCommand):
             )
 
             if not user_books.exists():
-                self.stdout.write(f"  {user.username}: no UserBook records, skipping.")
+                self._log(f"  {user.username}: no UserBook records, skipping.")
                 continue
 
             # Collect current genres from enriched books
@@ -121,10 +129,10 @@ class Command(BaseCommand):
                 changes.append(f"mainstream: {old_mainstream}% -> {new_mainstream_score}%")
 
             if not changes:
-                self.stdout.write(f"  {user.username}: no changes needed.")
+                self._log(f"  {user.username}: no changes needed.")
                 continue
 
-            self.stdout.write(f"  {user.username}: {', '.join(changes)}")
+            self._log(f"  {user.username}: {', '.join(changes)}")
 
             if not options["dry_run"]:
                 dna = profile.dna_data.copy()
@@ -142,6 +150,6 @@ class Command(BaseCommand):
                 updated += 1
 
         if options["dry_run"]:
-            self.stdout.write(self.style.WARNING("Dry run complete. No changes saved."))
+            self._warn("Dry run complete. No changes saved.")
         else:
-            self.stdout.write(self.style.SUCCESS(f"Updated {updated} profiles."))
+            self._log(f"Updated {updated} profiles.")

--- a/core/management/commands/research_publishers.py
+++ b/core/management/commands/research_publishers.py
@@ -1,15 +1,16 @@
-# In core/management/commands/research_publishers.py
-
+import logging
 import time
+
 import requests
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from django.utils import timezone
-from datetime import timedelta
 from django.db.models import Q
+from django.utils import timezone
 
-from core.models import Author, Publisher  # Need Author for _normalize
+from core.models import Author, Publisher
 from core.services.publisher_service import research_publisher_identity
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -19,14 +20,21 @@ class Command(BaseCommand):
         parser.add_argument("--recheck-all", action="store_true", help="Re-research all publishers.")
         parser.add_argument("--limit", type=int, default=50, help="Limit the number of publishers to check in one run.")
 
+    def _log(self, msg):
+        self.stdout.write(msg)
+        logger.info(f"research_publishers: {msg}")
+
+    def _warn(self, msg):
+        self.stdout.write(self.style.WARNING(msg))
+        logger.warning(f"research_publishers: {msg}")
+
     @transaction.atomic
     def handle(self, *args, **options):
-        self.stdout.write(self.style.NOTICE("🚀 Starting AI-powered publisher research..."))
+        self._log("Starting AI-powered publisher research...")
 
         if options["recheck_all"]:
             publishers_to_check = Publisher.objects.all()
         else:
-            # Check publishers that have never been checked and have no parent
             publishers_to_check = Publisher.objects.filter(
                 Q(mainstream_last_checked__isnull=True) & Q(parent__isnull=True)
             )
@@ -34,41 +42,36 @@ class Command(BaseCommand):
         publishers_to_check = list(publishers_to_check[: options["limit"]])
 
         if not publishers_to_check:
-            self.stdout.write(self.style.SUCCESS("✅ No publishers need researching at this time."))
+            self._log("No publishers need researching at this time.")
             return
 
-        self.stdout.write(f"Found {len(publishers_to_check)} publishers to research.")
+        self._log(f"Found {len(publishers_to_check)} publishers to research.")
         updated_count = 0
 
         with requests.Session() as session:
             session.headers.update({"User-Agent": "BibliotypeApp/1.0 (contact@yourdomain.com)"})
 
             for publisher in publishers_to_check:
-                self.stdout.write(f"  -> Researching: {publisher.name}...")
+                self._log(f"  -> Researching: {publisher.name}...")
 
                 findings = research_publisher_identity(publisher.name, session)
 
                 if findings["error"]:
-                    self.stdout.write(self.style.ERROR(f"     - Error: {findings['error']}"))
-                    # Mark as checked even if it fails, to avoid retrying bad names
+                    self._warn(f"     - Error for '{publisher.name}': {findings['error']}")
                     publisher.mainstream_last_checked = timezone.now()
                 else:
-                    self.stdout.write(self.style.SUCCESS(f"     - AI Reason: {findings.get('reasoning')}"))
+                    self._log(f"     - AI Reason: {findings.get('reasoning')}")
 
                     is_mainstream_result = findings.get("is_mainstream")
 
-                    # Explicitly check if the result is a boolean. If not, default to False.
                     if isinstance(is_mainstream_result, bool):
                         publisher.is_mainstream = is_mainstream_result
                     else:
-                        # This is our safety net. If the AI returns null or something unexpected,
-                        # we force the value to False.
                         publisher.is_mainstream = False
 
                     publisher.mainstream_last_checked = timezone.now()
 
                     if parent_name := findings.get("parent_company_name"):
-                        # Find or create the parent and link it
                         parent_obj, _ = Publisher.objects.get_or_create(
                             normalized_name=Author._normalize(parent_name),
                             defaults={"name": parent_name, "is_mainstream": True},
@@ -78,6 +81,6 @@ class Command(BaseCommand):
                     updated_count += 1
 
                 publisher.save()
-                time.sleep(2)  # Be extra polite to the APIs
+                time.sleep(2)
 
-        self.stdout.write(self.style.SUCCESS(f"\n✅ Finished. Updated {updated_count} publisher entries."))
+        self._log(f"Finished. Updated {updated_count} publisher entries.")

--- a/core/management/commands/review_publishers.py
+++ b/core/management/commands/review_publishers.py
@@ -1,17 +1,27 @@
-# In core/management/commands/review_publishers.py
+import logging
 
 from django.core.management.base import BaseCommand
 from django.db.models import Count
+
 from core.models import Publisher
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
     help = "Lists non-mainstream publishers ordered by popularity to help with admin review."
 
-    def handle(self, *args, **options):
-        self.stdout.write(self.style.NOTICE("🔎 Finding popular, non-mainstream publishers to review..."))
+    def _log(self, msg):
+        self.stdout.write(msg)
+        logger.info(f"review_publishers: {msg}")
 
-        # Find all non-mainstream publishers, count their books, and order by that count
+    def _warn(self, msg):
+        self.stdout.write(self.style.WARNING(msg))
+        logger.warning(f"review_publishers: {msg}")
+
+    def handle(self, *args, **options):
+        self._log("Finding popular, non-mainstream publishers to review...")
+
         publishers_to_review = (
             Publisher.objects.filter(is_mainstream=False)
             .annotate(book_count=Count("books"))
@@ -20,15 +30,11 @@ class Command(BaseCommand):
         )
 
         if not publishers_to_review.exists():
-            self.stdout.write(self.style.SUCCESS("✅ No new publishers need reviewing at this time."))
+            self._log("No new publishers need reviewing at this time.")
             return
 
-        self.stdout.write(
-            self.style.WARNING(
-                "The following publishers are popular in your database but are not flagged as mainstream:"
-            )
-        )
-        self.stdout.write("Consider reviewing them in the Django Admin and ticking 'is_mainstream' if appropriate.")
+        self._warn("The following publishers are popular but not flagged as mainstream:")
+        self._log("Consider reviewing them in the Django Admin and ticking 'is_mainstream' if appropriate.")
 
         for pub in publishers_to_review:
-            self.stdout.write(f"  - {pub.name} ({pub.book_count} books)")
+            self._log(f"  - {pub.name} ({pub.book_count} books)")

--- a/core/management/commands/update_author_status.py
+++ b/core/management/commands/update_author_status.py
@@ -1,11 +1,16 @@
+import logging
 import time
+from datetime import timedelta
+
 import requests
 from django.core.management.base import BaseCommand
-from django.utils import timezone
-from datetime import timedelta
-from core.models import Author
 from django.db import models
+from django.utils import timezone
+
+from core.models import Author
 from core.services.author_service import check_author_mainstream_status
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -24,14 +29,21 @@ class Command(BaseCommand):
             help="Re-check authors whose status was last checked more than this many days ago.",
         )
 
+    def _log(self, msg):
+        self.stdout.write(msg)
+        logger.info(f"update_author_status: {msg}")
+
+    def _warn(self, msg):
+        self.stdout.write(self.style.WARNING(msg))
+        logger.warning(f"update_author_status: {msg}")
+
     def handle(self, *args, **options):
-        self.stdout.write("🚀 Starting author mainstream status update...")
+        self._log("Starting author mainstream status update...")
 
         if options["recheck_all"]:
-            self.stdout.write(self.style.WARNING("Re-checking all authors."))
+            self._warn("Re-checking all authors.")
             authors_to_check = Author.objects.all()
         else:
-            # Check authors that have never been checked OR were checked long ago
             age_limit = timezone.now() - timedelta(days=options["age_days"])
             authors_to_check = Author.objects.filter(
                 models.Q(mainstream_last_checked__isnull=True) | models.Q(mainstream_last_checked__lte=age_limit)
@@ -39,42 +51,32 @@ class Command(BaseCommand):
 
         total_authors = authors_to_check.count()
         if total_authors == 0:
-            self.stdout.write(self.style.SUCCESS("✅ No authors need checking at this time."))
+            self._log("No authors need checking at this time.")
             return
 
-        self.stdout.write(f"Found {total_authors} authors to check.")
+        self._log(f"Found {total_authors} authors to check.")
         updated_count = 0
 
         with requests.Session() as session:
-            headers = {
-                # Replace with your app name and a contact email/URL.
-                # This is crucial for being a good API citizen.
-                "User-Agent": "BibliotypeApp/1.0 (contact@yourdomain.com)"
-            }
-            session.headers.update(headers)
+            session.headers.update({"User-Agent": "BibliotypeApp/1.0 (contact@yourdomain.com)"})
             for i, author in enumerate(authors_to_check):
-                self.stdout.write(f"  ({i+1}/{total_authors}) Checking: {author.name}...")
+                self._log(f"  ({i+1}/{total_authors}) Checking: {author.name}...")
 
                 status_data = check_author_mainstream_status(author.name, session)
 
                 if status_data["error"]:
-                    self.stdout.write(self.style.ERROR(f"    -> API Error: {status_data['error']}"))
+                    self._warn(f"    -> API Error for '{author.name}': {status_data['error']}")
                 else:
                     if author.is_mainstream != status_data["is_mainstream"]:
                         author.is_mainstream = status_data["is_mainstream"]
                         updated_count += 1
-                        self.stdout.write(
-                            self.style.NOTICE(
-                                f"    -> Status changed to: {author.is_mainstream}. Reason: {status_data.get('reason', 'N/A')}"
-                            )
+                        self._log(
+                            f"    -> Status changed to: {author.is_mainstream}. Reason: {status_data.get('reason', 'N/A')}"
                         )
 
-                    # Always update the last_checked timestamp
                     author.mainstream_last_checked = timezone.now()
                     author.save()
 
-                # Be a polite API consumer
-                time.sleep(1)  # 1-second delay between authors
+                time.sleep(1)
 
-        self.stdout.write("\n" + self.style.SUCCESS("✅ Finished."))
-        self.stdout.write(f"Updated the mainstream status for {updated_count} authors.")
+        self._log(f"Finished. Updated the mainstream status for {updated_count} authors.")

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -448,17 +448,31 @@ def run_management_command_task(command_name: str, args: list = None, kwargs: di
 
     try:
         call_command(command_name, *args, stdout=stdout_buffer, stderr=stderr_buffer, **kwargs)
+        stdout_output = stdout_buffer.getvalue()
+        stderr_output = stderr_buffer.getvalue()
+
+        if stdout_output:
+            logger.info(f"[{command_name}] stdout:\n{stdout_output}")
+        if stderr_output:
+            logger.warning(f"[{command_name}] stderr:\n{stderr_output}")
+
         result = {
             "status": "success",
-            "stdout": stdout_buffer.getvalue(),
-            "stderr": stderr_buffer.getvalue(),
+            "stdout": stdout_output,
+            "stderr": stderr_output,
         }
     except Exception as e:
+        stdout_output = stdout_buffer.getvalue()
+        stderr_output = stderr_buffer.getvalue()
+
+        if stdout_output:
+            logger.info(f"[{command_name}] stdout:\n{stdout_output}")
+
         logger.error(f"Management command '{command_name}' failed: {e}", exc_info=True)
         result = {
             "status": "error",
-            "stdout": stdout_buffer.getvalue(),
-            "stderr": stderr_buffer.getvalue(),
+            "stdout": stdout_output,
+            "stderr": stderr_output,
             "error": str(e),
         }
 


### PR DESCRIPTION
## Summary

Adds a new management command to backfill ISBN13 for books that are missing it, by querying the Open Library and Google Books APIs. This is designed to be run **before** `backfill_enrichment` so that the enrichment pipeline can use ISBN-based API lookups (exact match) instead of fuzzy title+author search.

Also adds real-time logger output to **all 9 admin command runner management commands**, so their progress is visible in worker logs via `docker logs -f worker`.

## Problem

Both the Open Library and Google Books enrichment functions use `isbn:{isbn13}` for lookups when available, which returns exact matches. Without an ISBN, they fall back to title+author search which is unreliable — especially for books with subtitles, series info, or special characters (e.g., "Iron Flame (The Empyrean, #2)").

Additionally, when management commands are run via the admin command runner (Celery), their `self.stdout.write()` output only appears after the command finishes — there's no real-time visibility in worker logs.

## Intended workflow

```bash
# 1. Backfill ISBNs from Open Library + Google Books
python manage.py backfill_isbn

# 2. Then run enrichment (now with ISBN-based lookups)
python manage.py backfill_enrichment
```

## Changes

### New: `core/management/commands/backfill_isbn.py`
- Finds all books with `isbn13=NULL`
- Queries Open Library search API by cleaned title + author name
- Falls back to Google Books API if Open Library returns no results
- Converts ISBN-10 to ISBN-13 when only ISBN-10 is available
- Cleans Goodreads-style titles for better API matches (removes series info, subtitles, publisher suffixes)
- Checks for conflicts before saving (unique constraint on isbn13)
- Rate-limited: 1.2s sleep between API calls
- Supports `--dry-run` and `--limit` flags
- **Dry run is instant** — only queries the DB and lists books missing ISBN13, no API calls or sleeps
- Prints summary: updated / not found / conflicts

### Modified: `core/admin.py`
- Added `backfill_isbn` to `ADMIN_COMMANDS` list so it appears in the admin command runner

### Modified: `core/tasks.py`
- `run_management_command_task` now logs stdout/stderr to the worker logs via `logger.info`/`logger.warning` after command completion

### Real-time logging added to all 9 admin command runner commands
Each command now has `_log()` and `_warn()` helpers that write to both `self.stdout` (for Celery task capture) and the Python `logger` (for real-time worker log visibility):

- `backfill_isbn` — ISBN backfill progress
- `backfill_enrichment` — enrichment dispatch counts
- `enrich_books` — per-book enrichment progress with API call counts
- `regenerate_dna` — per-profile DNA regeneration changes
- `research_publishers` — per-publisher AI research results
- `update_author_status` — per-author API check results
- `analyze_genres` — unmapped genre audit results
- `rebuild_analytics` — per-profile analytics rebuild progress
- `review_publishers` — non-mainstream publisher listing

## Test plan

- [x] Tested with `--dry-run --limit 2` — instantly lists books, no API calls
- [x] Tested without dry-run `--limit 2` — correctly finds and saves ISBNs from Open Library and Google Books
- [x] All existing integration tests pass (23/23)
- [ ] Run on production: `backfill_isbn` then `backfill_enrichment` and verify enrichment quality improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)