### PR TITLE
Add missing env vars to Docker compose files

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -45,6 +45,7 @@ services:
             - SECRET_KEY=${SECRET_KEY}
             - POSTHOG_API_KEY=${POSTHOG_API_KEY}
             - GEMINI_API_KEY=${GEMINI_API_KEY}
+            - GOOGLE_BOOKS_API_KEY=${GOOGLE_BOOKS_API_KEY}
             - POSTGRES_DB=${POSTGRES_DB}
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -66,7 +67,9 @@ services:
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
             - REDIS_CACHE_URL=redis://redis:6379/1
             - SECRET_KEY=${SECRET_KEY}
+            - POSTHOG_API_KEY=${POSTHOG_API_KEY}
             - GEMINI_API_KEY=${GEMINI_API_KEY}
+            - GOOGLE_BOOKS_API_KEY=${GOOGLE_BOOKS_API_KEY}
             - DEBUG=True
             - ALLOWED_HOSTS=localhost,127.0.0.1
             - POSTGRES_DB=${POSTGRES_DB}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,6 +41,7 @@ services:
             - SECRET_KEY=${SECRET_KEY}
             - POSTHOG_API_KEY=${POSTHOG_API_KEY}
             - GEMINI_API_KEY=${GEMINI_API_KEY}
+            - GOOGLE_BOOKS_API_KEY=${GOOGLE_BOOKS_API_KEY}
             - DEBUG=${DEBUG}
             - ALLOWED_HOSTS=${ALLOWED_HOSTS}
             - POSTGRES_DB=${POSTGRES_DB}
@@ -63,7 +64,9 @@ services:
             - CELERY_RESULT_BACKEND=redis://redis:6379/0
             - REDIS_CACHE_URL=redis://redis:6379/1
             - SECRET_KEY=${SECRET_KEY}
+            - POSTHOG_API_KEY=${POSTHOG_API_KEY}
             - GEMINI_API_KEY=${GEMINI_API_KEY}
+            - GOOGLE_BOOKS_API_KEY=${GOOGLE_BOOKS_API_KEY}
             - DEBUG=${DEBUG}
             - ALLOWED_HOSTS=${ALLOWED_HOSTS}
             - POSTGRES_DB=${POSTGRES_DB}


### PR DESCRIPTION
## Summary

- Add `GOOGLE_BOOKS_API_KEY` to web and worker services in both prod and local compose files
- Add `POSTHOG_API_KEY` to worker service in both compose files

## Problem

The `.env` file has these keys but they were never passed into the containers:
- `GOOGLE_BOOKS_API_KEY` was missing from all services — the `backfill_isbn` command's Google Books fallback was silently disabled
- `POSTHOG_API_KEY` was missing from the worker — causing the "POSTHOG_API_KEY not found" warning on every worker start

## Test plan

- [ ] Redeploy and verify `backfill_isbn` no longer shows "GOOGLE_BOOKS_API_KEY not set" warning
- [ ] Verify worker no longer shows "POSTHOG_API_KEY not found" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)