### PR TITLE
Sanitise review HTML, fix flaky test, and use third-person on public profiles

### DIFF
--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import re
 
 from django.db import IntegrityError
 from django.db.models import F
@@ -17,6 +18,18 @@ from django.db.models import F
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 
 logger = logging.getLogger(__name__)
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _sanitize_review_text(text):
+    """Strip HTML tags from review text, preserving <br> variants as newlines."""
+    if not text or not isinstance(text, str):
+        return text
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = _HTML_TAG_RE.sub("", text)
+    return text.strip()
+
 
 from ..models import Author, Book, Genre
 from ..percentile_engine import (
@@ -525,12 +538,14 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
             ].to_dict()
 
             most_positive_review["sentiment"] = float(most_positive_review["sentiment"])
+            most_positive_review["my_review"] = _sanitize_review_text(most_positive_review.get("my_review", ""))
 
             most_negative_review = neg_review_row.rename({"My Review": "my_review"})[
                 ["Title", "Author", "my_review", "sentiment"]
             ].to_dict()
 
             most_negative_review["sentiment"] = float(most_negative_review["sentiment"])
+            most_negative_review["my_review"] = _sanitize_review_text(most_negative_review.get("my_review", ""))
 
         mainstream_score = 0
         if user_book_objects:

--- a/core/services/recommendation_service.py
+++ b/core/services/recommendation_service.py
@@ -837,6 +837,15 @@ class RecommendationEngine:
 
     def _add_explanations(self, recommendations, context):
         """Add human-readable explanation components for why each book was recommended."""
+        # Build possessive form of owner's display name for public profile text
+        owner_user = context.get("user")
+        if owner_user:
+            owner_name = owner_user.first_name or owner_user.username
+            owner_possessive = f"{owner_name}'" if owner_name.endswith("s") else f"{owner_name}'s"
+        else:
+            owner_name = None
+            owner_possessive = None
+
         for rec in recommendations:
             # Use a dictionary to hold the separate parts of the explanation
             rec["explanation_components"] = {}
@@ -848,20 +857,36 @@ class RecommendationEngine:
             # --- Component 1: Shared Books ---
             if best_source["type"] == "similar_user":
                 shared_count = best_source.get("shared_books", 0)
+                recommender_name = best_source.get("username", "")
                 if shared_count > 1:  # Only show if there's a meaningful overlap
                     rec["explanation_components"]["shared"] = f"You share {shared_count} books in common"
-                    rec["explanation_components"]["shared_public"] = f"They share {shared_count} books in common"
+                    if owner_name and recommender_name:
+                        rec["explanation_components"]["shared_public"] = (
+                            f"{owner_name} and {recommender_name} share {shared_count} books in common"
+                        )
+                    else:
+                        rec["explanation_components"]["shared_public"] = (
+                            f"They share {shared_count} books in common"
+                        )
 
             # --- Component 2: Genre Match ---
             if rec.get("genre_alignment", 0) > 0.6:
                 # Use prefetched genres - should not trigger query
                 book_genres = [genre.name for genre in rec["book"].genres.all()[:2]]
                 if book_genres:
-                    rec["explanation_components"]["genre"] = f"Matches your interest in {', '.join(book_genres)}"
+                    genre_str = ", ".join(book_genres)
+                    rec["explanation_components"]["genre"] = f"Matches your interest in {genre_str}"
+                    if owner_possessive:
+                        rec["explanation_components"]["genre_public"] = (
+                            f"Matches {owner_possessive} interest in {genre_str}"
+                        )
 
             # --- Component 3: Popularity among similar readers ---
             if rec["recommender_count"] >= 3:
                 rec["explanation_components"]["popularity"] = f"Loved by {rec['recommender_count']} similar readers"
+                rec["explanation_components"]["popularity_public"] = (
+                    f"Loved by {rec['recommender_count']} other similar readers"
+                )
 
             # --- Component 4: Quality indicator ---
             if rec["book"].average_rating and rec["book"].average_rating >= 4.2:

--- a/core/services/recommendation_service.py
+++ b/core/services/recommendation_service.py
@@ -875,33 +875,33 @@ class RecommendationEngine:
                 book_genres = [genre.name for genre in rec["book"].genres.all()[:2]]
                 if book_genres:
                     genre_str = ", ".join(book_genres)
-                    rec["explanation_components"]["genre"] = f"Matches your interest in {genre_str}"
+                    rec["explanation_components"]["genre"] = f"matches your interest in {genre_str}"
                     if owner_possessive:
                         rec["explanation_components"]["genre_public"] = (
-                            f"Matches {owner_possessive} interest in {genre_str}"
+                            f"matches {owner_possessive} interest in {genre_str}"
                         )
 
             # --- Component 3: Popularity among similar readers ---
             if rec["recommender_count"] >= 3:
-                rec["explanation_components"]["popularity"] = f"Loved by {rec['recommender_count']} similar readers"
+                rec["explanation_components"]["popularity"] = f"loved by {rec['recommender_count']} similar readers"
                 rec["explanation_components"]["popularity_public"] = (
-                    f"Loved by {rec['recommender_count']} other similar readers"
+                    f"loved by {rec['recommender_count']} other similar readers"
                 )
 
             # --- Component 4: Quality indicator ---
             if rec["book"].average_rating and rec["book"].average_rating >= 4.2:
-                rec["explanation_components"]["rating"] = f"Highly rated ({rec['book'].average_rating:.1f}★)"
+                rec["explanation_components"]["rating"] = f"highly rated ({rec['book'].average_rating:.1f}★)"
 
             # --- Component 5: Global popularity fallback ---
             if any(s.get("type") == "global_popularity" for s in sources):
-                rec["explanation_components"]["discovery"] = "Popular across the Bibliotype community"
+                rec["explanation_components"]["discovery"] = "popular across the Bibliotype community"
 
             # --- Ensure at least one explanation always exists ---
             if not rec["explanation_components"]:
                 if rec["book"].average_rating:
-                    rec["explanation_components"]["rating"] = f"Highly rated ({rec['book'].average_rating:.1f}★)"
+                    rec["explanation_components"]["rating"] = f"highly rated ({rec['book'].average_rating:.1f}★)"
                 else:
-                    rec["explanation_components"]["discovery"] = "Popular across the Bibliotype community"
+                    rec["explanation_components"]["discovery"] = "popular across the Bibliotype community"
 
         return recommendations
 

--- a/core/templates/core/partials/dna/recommendations_grid.html
+++ b/core/templates/core/partials/dna/recommendations_grid.html
@@ -51,12 +51,28 @@
                                 • {{ rec.explanation_components.shared }}
                             </p>{% endif %}
                         {% endif %}
-                        {% if rec.explanation_components.genre %}<p>
-                            • {{ rec.explanation_components.genre }}
-                        </p>{% endif %}
-                        {% if rec.explanation_components.popularity %}<p>
-                            • {{ rec.explanation_components.popularity }}
-                        </p>{% endif %}
+                        {% if is_public_view %}
+                            {% if rec.explanation_components.genre_public %}<p>
+                                • {{ rec.explanation_components.genre_public }}
+                            </p>{% elif rec.explanation_components.genre %}<p>
+                                • {{ rec.explanation_components.genre }}
+                            </p>{% endif %}
+                        {% else %}
+                            {% if rec.explanation_components.genre %}<p>
+                                • {{ rec.explanation_components.genre }}
+                            </p>{% endif %}
+                        {% endif %}
+                        {% if is_public_view %}
+                            {% if rec.explanation_components.popularity_public %}<p>
+                                • {{ rec.explanation_components.popularity_public }}
+                            </p>{% elif rec.explanation_components.popularity %}<p>
+                                • {{ rec.explanation_components.popularity }}
+                            </p>{% endif %}
+                        {% else %}
+                            {% if rec.explanation_components.popularity %}<p>
+                                • {{ rec.explanation_components.popularity }}
+                            </p>{% endif %}
+                        {% endif %}
                         {% if rec.explanation_components.rating %}<p>
                             • {{ rec.explanation_components.rating }}
                         </p>{% endif %}

--- a/core/templates/core/partials/dna/review_analysis_card.html
+++ b/core/templates/core/partials/dna/review_analysis_card.html
@@ -5,8 +5,9 @@
             <h3 class="text-xl font-bold uppercase">Most Positive Review</h3>
             {% if dna.most_positive_review %}
                 <p class="mt-2 font-bold">{{ dna.most_positive_review.Title }}</p>
+                {# Review text is sanitized at ingestion - never use |safe here #}
                 <blockquote class="border-brand-text shadow-neo-sm mt-2 border-2 bg-gray-100 p-3">
-                    "{{ dna.most_positive_review.my_review }}"
+                    "{{ dna.most_positive_review.my_review|linebreaksbr }}"
                 </blockquote>
             {% else %}
                 <p class="mt-2">No reviews found.</p>
@@ -16,8 +17,9 @@
             <h3 class="text-xl font-bold uppercase">Most Negative Review</h3>
             {% if dna.most_negative_review %}
                 <p class="mt-2 font-bold">{{ dna.most_negative_review.Title }}</p>
+                {# Review text is sanitized at ingestion - never use |safe here #}
                 <blockquote class="border-brand-text shadow-neo-sm mt-2 border-2 bg-gray-100 p-3">
-                    "{{ dna.most_negative_review.my_review }}"
+                    "{{ dna.most_negative_review.my_review|linebreaksbr }}"
                 </blockquote>
             {% else %}
                 <p class="mt-2">No reviews found.</p>

--- a/core/tests/test_recommendations.py
+++ b/core/tests/test_recommendations.py
@@ -4,6 +4,7 @@ Tests for the book recommendation system
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.test import TestCase
 from core.models import Book, Author, Genre, Publisher, UserBook, UserProfile
 from core.services.user_similarity_service import (
@@ -21,6 +22,12 @@ class RecommendationTestCase(TestCase):
     
     def setUp(self):
         """Set up test data"""
+        # Clear cache to prevent stale similarity/recommendation results between tests
+        try:
+            cache.clear()
+        except Exception:
+            pass
+
         # Create authors
         self.author1 = Author.objects.create(name="J.R.R. Tolkien", normalized_name="tolkien, j.r.r.")
         self.author2 = Author.objects.create(name="George R.R. Martin", normalized_name="martin, george r.r.")
@@ -256,14 +263,14 @@ class RecommendationTestCase(TestCase):
         """Test that recommendations include source information"""
         # User1 reads book1
         UserBook.objects.create(user=self.user1, book=self.book1, user_rating=5, is_top_book=True, top_book_position=1)
-        
+
         # User2 reads book1 and book2
         UserBook.objects.create(user=self.user2, book=self.book1, user_rating=5)
         UserBook.objects.create(user=self.user2, book=self.book2, user_rating=4, is_top_book=True, top_book_position=1)
-        
+
         # Get recommendations for user1
         recommendations = get_recommendations_for_user(self.user1, limit=10)
-        
+
         # Should have recommendations from user2
         found_user2_rec = False
         for rec in recommendations:
@@ -276,7 +283,7 @@ class RecommendationTestCase(TestCase):
                         if source.get('username') == self.user2.username:
                             self.assertEqual(source['username'], self.user2.username)
                             break
-        
+
         self.assertTrue(found_user2_rec)
     
     def test_top_books_sentiment_analysis(self):

--- a/core/tests/test_sanitize_review.py
+++ b/core/tests/test_sanitize_review.py
@@ -1,0 +1,66 @@
+from django.test import TestCase
+
+from core.services.dna_analyser import _sanitize_review_text
+
+
+class SanitizeReviewTextTests(TestCase):
+    """Tests for _sanitize_review_text used to strip HTML from user reviews."""
+
+    def test_plain_text_unchanged(self):
+        self.assertEqual(_sanitize_review_text("A great book!"), "A great book!")
+
+    def test_br_tags_become_newlines(self):
+        self.assertEqual(
+            _sanitize_review_text("First paragraph.<br/>Second paragraph."),
+            "First paragraph.\nSecond paragraph.",
+        )
+
+    def test_br_tag_variants(self):
+        self.assertEqual(_sanitize_review_text("a<br>b"), "a\nb")
+        self.assertEqual(_sanitize_review_text("a<br/>b"), "a\nb")
+        self.assertEqual(_sanitize_review_text("a<br />b"), "a\nb")
+        self.assertEqual(_sanitize_review_text("a<BR>b"), "a\nb")
+        self.assertEqual(_sanitize_review_text("a<BR/>b"), "a\nb")
+
+    def test_strips_script_tags(self):
+        self.assertEqual(
+            _sanitize_review_text('<script>alert("xss")</script>Loved it'),
+            'alert("xss")Loved it',
+        )
+
+    def test_strips_arbitrary_html(self):
+        self.assertEqual(
+            _sanitize_review_text("<b>Bold</b> and <i>italic</i>"),
+            "Bold and italic",
+        )
+
+    def test_strips_nested_html(self):
+        self.assertEqual(
+            _sanitize_review_text('<div class="foo"><p>Hello</p></div>'),
+            "Hello",
+        )
+
+    def test_none_returns_none(self):
+        self.assertIsNone(_sanitize_review_text(None))
+
+    def test_empty_string_returns_empty(self):
+        self.assertEqual(_sanitize_review_text(""), "")
+
+    def test_non_string_returns_unchanged(self):
+        self.assertEqual(_sanitize_review_text(123), 123)
+
+    def test_whitespace_stripped(self):
+        self.assertEqual(_sanitize_review_text("  hello  "), "hello")
+
+    def test_real_world_goodreads_review(self):
+        review = (
+            "After reading this book - I changed my rating.<br/><br/>"
+            "The storyline felt very different.<br/><br/>"
+            "I love the constant surprises."
+        )
+        expected = (
+            "After reading this book - I changed my rating.\n\n"
+            "The storyline felt very different.\n\n"
+            "I love the constant surprises."
+        )
+        self.assertEqual(_sanitize_review_text(review), expected)


### PR DESCRIPTION
## Summary
- **Sanitise review HTML at ingestion**: Strip HTML tags from review text, converting `<br>` variants to newlines and removing all other tags (prevents stored XSS)
- **Render line breaks properly**: Use Django `|linebreaksbr` filter in the review template so paragraph breaks from Goodreads/StoryGraph reviews display correctly
- **Fix flaky recommendation test**: Clear cache in `setUp` to prevent stale similarity results from earlier tests poisoning `test_recommendations_include_sources`
- **Third-person language on public profiles**: Recommendation explanations now use the profile owner's name instead of your/you:
  - "Matches your interest in X" → "Matches Zoe's interest in X" (correct possessive for names ending in s)
  - "You share N books in common" → "Zoe and alice share N books in common"
  - "Loved by N similar readers" → "Loved by N other similar readers"
  - Falls back gracefully for existing stored recommendations

## Test plan
- [x] 11 unit tests for `_sanitize_review_text`
- [x] Fixed pre-existing `test_recommendations_include_sources` failure (cache pollution)
- [ ] Upload CSV with `<br/>` tag reviews and verify line breaks render
- [ ] Upload CSV with `<script>` tag review and verify it is stripped
- [ ] Check public profile — explanations should use third-person
- [ ] Check own dashboard — explanations should still use second-person

🤖 Generated with [Claude Code](https://claude.com/claude-code)