### PR TITLE
Fix avg books/year to use only books with recorded dates

### DIFF
--- a/core/management/commands/rebuild_analytics.py
+++ b/core/management/commands/rebuild_analytics.py
@@ -42,9 +42,11 @@ class Command(BaseCommand):
                 if "avg_books_per_year" not in user_stats:
                     stats_by_year = profile.dna_data.get("stats_by_year", [])
                     if stats_by_year:
-                        total_books = user_stats.get("total_books_read", 0)
+                        total_books_with_dates = sum(y.get("count", 0) for y in stats_by_year)
                         num_years = len(stats_by_year)
-                        user_stats["avg_books_per_year"] = round(total_books / num_years, 1) if num_years > 0 else 0
+                        user_stats["avg_books_per_year"] = (
+                            round(total_books_with_dates / num_years, 1) if num_years > 0 else 0
+                        )
                         user_stats["num_reading_years"] = num_years
 
                 update_analytics_from_stats(user_stats)

--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -409,6 +409,7 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
         stats_by_year_list = []
         avg_books_per_year = 0
         num_reading_years = 0
+        books_with_dates = 0
 
         if "Date Read" in read_df.columns and not read_df["Date Read"].dropna().empty:
             yearly_df = read_df.dropna(subset=["Date Read"])
@@ -427,12 +428,13 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                 item["avg_rating"] = float(item["avg_rating"])
 
             num_reading_years = len(stats_by_year_list)
-            total_books = int(len(read_df))
+            books_with_dates = int(yearly_df.shape[0])
             if num_reading_years > 0:
-                avg_books_per_year = round(total_books / num_reading_years, 1)
+                avg_books_per_year = round(books_with_dates / num_reading_years, 1)
 
         user_base_stats = {
             "total_books_read": int(len(read_df)),
+            "books_with_dates": books_with_dates,
             "total_pages_read": int(read_df["Number of Pages"].dropna().sum()),
             "avg_book_length": (
                 int(round(read_df["Number of Pages"].dropna().mean()))

--- a/core/templates/core/partials/dna/comparative_analytics_card.html
+++ b/core/templates/core/partials/dna/comparative_analytics_card.html
@@ -41,13 +41,13 @@
             <!-- Books Per Year -->
             <div class="border-brand-text shadow-neo-sm border-2 bg-gray-50 p-3">
                 <p>
-                    {{ pronoun_sub|default:"You"|title }}'ve read a total of
-                    <strong>{{ dna.user_stats.total_books_read }} books</strong>
+                    {{ pronoun_sub|default:"You"|title }}'ve read
+                    <strong>{{ dna.user_stats.books_with_dates }} books</strong>
                     {% if dna.user_stats.num_reading_years %}
                         across <strong>{{ dna.user_stats.num_reading_years }} year{{ dna.user_stats.num_reading_years|pluralize }}</strong>, averaging
                         <strong>{{ dna.user_stats.avg_books_per_year }} books a year</strong>.
                     {% else %}
-                        in total.
+                        with a recorded finish date.
                     {% endif %}
                 </p>
                 {% if dna.user_stats.avg_books_per_year and dna.comparative_text.bpy_pct %}
@@ -68,6 +68,10 @@
                         other Bibliotype readers.
                     </p>
                 {% endif %}
+                <p class="mt-2 text-xs text-gray-400">
+                    * Based on books with a recorded finish date. If this seems low, some books
+                    on {{ pronoun_pos|lower|default:"your" }} "read" shelf may be missing a read date.
+                </p>
             </div>
         </div>
     {% else %}

--- a/core/tests/test_number_line.py
+++ b/core/tests/test_number_line.py
@@ -200,7 +200,7 @@ class EnrichDnaTests(TestCase):
         self.assertLessEqual(result["number_line_ranges"]["year"]["min"], 1950)
 
     def test_enrich_dna_backfills_avg_books_per_year(self):
-        """Old DNA without avg_books_per_year is backfilled using total_books_read / num_years."""
+        """Old DNA without avg_books_per_year is backfilled using dated books / num_years."""
         dna = _make_dna_data()
         del dna["user_stats"]["avg_books_per_year"]
         del dna["user_stats"]["num_reading_years"]
@@ -208,16 +208,16 @@ class EnrichDnaTests(TestCase):
         us = result["user_stats"]
         self.assertIn("avg_books_per_year", us)
         self.assertIn("num_reading_years", us)
-        # 5 years of data with total 80 books → 16.0
+        # 5 years of data, sum of counts = 15+18+20+14+13 = 80 → 80/5 = 16.0
         self.assertEqual(us["num_reading_years"], 5)
         self.assertEqual(us["avg_books_per_year"], 16.0)
 
-    def test_backfill_uses_total_books_not_dated_books(self):
-        """Backfill should use total_books_read, not sum of stats_by_year counts."""
+    def test_backfill_uses_dated_books_not_total_books(self):
+        """Backfill should use sum of stats_by_year counts, not total_books_read."""
         dna = _make_dna_data()
         del dna["user_stats"]["avg_books_per_year"]
         del dna["user_stats"]["num_reading_years"]
-        # Set total_books_read higher than sum of stats_by_year counts (80 vs 60)
+        # Set total_books_read higher than sum of stats_by_year counts (100 vs 60)
         dna["user_stats"]["total_books_read"] = 100
         dna["stats_by_year"] = [
             {"year": 2022, "count": 25, "avg_rating": 3.9},
@@ -226,9 +226,28 @@ class EnrichDnaTests(TestCase):
         ]
         result = _enrich_dna_for_display(dna)
         us = result["user_stats"]
-        # Should be 100/3 = 33.3, NOT 60/3 = 20.0
+        # Should be 60/3 = 20.0, NOT 100/3 = 33.3
         self.assertEqual(us["num_reading_years"], 3)
-        self.assertAlmostEqual(us["avg_books_per_year"], 33.3, places=1)
+        self.assertAlmostEqual(us["avg_books_per_year"], 20.0, places=1)
+
+    def test_backfill_adds_books_with_dates(self):
+        """Old DNA without books_with_dates is backfilled from stats_by_year."""
+        dna = _make_dna_data()
+        # Remove books_with_dates if present
+        dna["user_stats"].pop("books_with_dates", None)
+        result = _enrich_dna_for_display(dna)
+        us = result["user_stats"]
+        self.assertIn("books_with_dates", us)
+        # Sum of stats_by_year counts: 15+18+20+14+13 = 80
+        self.assertEqual(us["books_with_dates"], 80)
+
+    def test_backfill_books_with_dates_empty_stats_by_year(self):
+        """When stats_by_year is empty, books_with_dates backfills to 0."""
+        dna = _make_dna_data()
+        dna["user_stats"].pop("books_with_dates", None)
+        dna["stats_by_year"] = []
+        result = _enrich_dna_for_display(dna)
+        self.assertEqual(result["user_stats"]["books_with_dates"], 0)
 
     def test_enrich_dna_recalculates_fresh_percentiles(self):
         """Stored stale percentiles should be replaced with fresh calculations."""

--- a/core/views.py
+++ b/core/views.py
@@ -198,18 +198,22 @@ def _enrich_dna_for_display(dna_data):
         for k, v in raw_community.items()
     }
 
-    # Backfill avg_books_per_year into user_stats if missing (old DNA)
+    # Backfill missing fields for old DNA data
     user_stats = dna_data.get("user_stats", {})
+    stats_by_year = dna_data.get("stats_by_year", [])
+    dated_book_count = sum(y.get("count", 0) for y in stats_by_year)
+
     if "avg_books_per_year" not in user_stats:
-        stats_by_year = dna_data.get("stats_by_year", [])
         if stats_by_year:
-            total_books = user_stats.get("total_books_read", 0)
             num_years = len(stats_by_year)
-            user_stats["avg_books_per_year"] = round(total_books / num_years, 1) if num_years > 0 else 0
+            user_stats["avg_books_per_year"] = round(dated_book_count / num_years, 1) if num_years > 0 else 0
             user_stats["num_reading_years"] = num_years
         else:
             user_stats["avg_books_per_year"] = 0
             user_stats["num_reading_years"] = 0
+
+    if "books_with_dates" not in user_stats:
+        user_stats["books_with_dates"] = dated_book_count
 
     # Recalculate percentiles from current aggregate data so they're never stale.
     # Cached for 60s to avoid a DB hit on every page load while still staying fresh.


### PR DESCRIPTION
## Summary

- **Reverts the `avg_books_per_year` numerator** from `total_books_read` (all books on the "read" shelf) back to only books with a non-null "Date Read" value. PR #60 introduced a regression where books missing a read date inflated the average (e.g. 218 total books across 4 years showed 54.5/year, when only 28 had dates — the correct average is 7.0).
- **Adds `books_with_dates`** to `user_stats` in the DNA data dict so the template can display the accurate count alongside the per-year average.
- **Adds a disclaimer** below the books-per-year section explaining the methodology: _"Based on books with a recorded finish date. If this seems low, some books on your 'read' shelf may be missing a read date."_
- **Fixes pronoun casing** on public profiles — uses `|lower` filter so "Their" renders as "their" mid-sentence, matching the pattern in `mainstream_gauge_card.html` and `niche_read_card.html`.

## What changed and why

### `core/services/dna_analyser.py`
The source-of-truth DNA generator. Changed the numerator from `int(len(read_df))` (all books) to `int(yearly_df.shape[0])` (only books with a Date Read value). Added `books_with_dates` to the `user_base_stats` dict so it persists in the stored DNA JSON.

### `core/views.py` — `_enrich_dna_for_display()`
The display-time backfill for old DNA data. Two changes:
1. Reverted the `avg_books_per_year` backfill to use `sum(stats_by_year counts)` instead of `total_books_read`.
2. Added a `books_with_dates` backfill for old DNA missing the field.
3. Consolidated both backfills to share a single `stats_by_year` fetch and `dated_book_count` computation (was previously duplicated).

### `core/management/commands/rebuild_analytics.py`
The batch recomputation command. Same numerator fix — uses `sum(stats_by_year counts)` instead of `total_books_read` when backfilling `avg_books_per_year` for old profiles. Note: this command only rebuilds aggregate histograms, it doesn't persist changes back to profile DNA, so `books_with_dates` backfill is not needed here.

### `core/templates/core/partials/dna/comparative_analytics_card.html`
- Displays `books_with_dates` instead of `total_books_read` in the books-per-year sentence.
- Changed fallback text (when no reading years) from "in total" to "with a recorded finish date".
- Added footnote disclaimer with `|lower` filter on `pronoun_pos` for correct casing on public profiles.

### `core/tests/test_number_line.py`
- Renamed `test_backfill_uses_total_books_not_dated_books` → `test_backfill_uses_dated_books_not_total_books` with inverted assertions (expects 20.0, not 33.3).
- Added `test_backfill_adds_books_with_dates` — verifies the new field is backfilled from `stats_by_year`.
- Added `test_backfill_books_with_dates_empty_stats_by_year` — verifies backfill produces 0 when `stats_by_year` is empty.

## Test plan

- [x] `poetry run python manage.py test core.tests.test_number_line core.tests.test_percentile_engine -v 2` — all 42 tests pass
- [ ] Manual verification: DNA with 218 total books but only 28 with dates across 4 years → avg should be 7.0, not 54.5
- [ ] Template shows "You've read 28 books across 4 years, averaging 7.0 books a year" with disclaimer below
- [ ] Public profile renders "their" (lowercase) in the disclaimer
- [ ] Post-deploy: run `rebuild_analytics` to recompute community histograms with dated-books-only values

🤖 Generated with [Claude Code](https://claude.com/claude-code)