### PR TITLE
Add server_hostname to PostHog events

### DIFF
--- a/core/analytics/middleware.py
+++ b/core/analytics/middleware.py
@@ -5,6 +5,7 @@ Middleware for tracking pageviews and catching unhandled exceptions.
 """
 
 import logging
+import socket
 from django.utils.deprecation import MiddlewareMixin
 from .posthog_client import get_environment, get_distinct_id, capture_exception
 
@@ -62,6 +63,7 @@ class PostHogPageviewMiddleware(MiddlewareMixin):
                 properties={
                     **properties,
                     "environment": environment,
+                    "server_hostname": socket.gethostname(),
                 },
             )
         except Exception as e:

--- a/core/analytics/posthog_client.py
+++ b/core/analytics/posthog_client.py
@@ -6,6 +6,7 @@ Provides environment-aware PostHog client with helper functions for event tracki
 
 import os
 import logging
+import socket
 import posthog
 from django.conf import settings
 
@@ -88,7 +89,8 @@ def capture_event(distinct_id, event_name, properties=None, environment=None):
         environment = get_environment()
     
     properties["environment"] = environment
-    
+    properties["server_hostname"] = socket.gethostname()
+
     try:
         posthog.capture(
             distinct_id=distinct_id,
@@ -140,7 +142,8 @@ def capture_exception(distinct_id, exception, context=None, environment=None):
         environment = get_environment()
     
     properties["environment"] = environment
-    
+    properties["server_hostname"] = socket.gethostname()
+
     try:
         posthog.capture(
             distinct_id=distinct_id,


### PR DESCRIPTION
## Summary
- Adds `server_hostname` (via `socket.gethostname()`) to all PostHog events
- Covers `capture_event()`, `capture_exception()`, and the pageview middleware's direct `posthog.capture()` call
- Enables filtering dashboard data by hostname to distinguish production server events from local dev runs

## Context
Local development events were showing up as "production" in PostHog because `get_environment()` falls back to `settings.DEBUG` when `DJANGO_ENV` is unset. Adding hostname makes it easy to filter to only the actual production server regardless of the environment tag.

## Test plan
- [ ] Verify events include `server_hostname` property in PostHog after deploy
- [ ] Update PostHog dashboard filters to use hostname for production filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)