### PR TITLE
refactor: consolidate cache utilities and fix caching strategy

### DIFF
--- a/core/cache_utils.py
+++ b/core/cache_utils.py
@@ -1,0 +1,35 @@
+import logging
+
+from django.core.cache import cache
+
+from .analytics.events import track_redis_cache_error
+
+logger = logging.getLogger(__name__)
+
+
+def safe_cache_get(key, default=None):
+    """Safely get a value from cache, handling Redis connection errors gracefully."""
+    try:
+        return cache.get(key, default)
+    except Exception as e:
+        logger.warning(f"Cache get failed for key '{key}': {e}. Continuing without cache.")
+        track_redis_cache_error(operation="get", key=key, error_type=type(e).__name__, error_message=str(e))
+        return default
+
+
+def safe_cache_set(key, value, timeout=None):
+    """Safely set a value in cache, handling Redis connection errors gracefully."""
+    try:
+        cache.set(key, value, timeout)
+    except Exception as e:
+        logger.warning(f"Cache set failed for key '{key}': {e}. Continuing without cache.")
+        track_redis_cache_error(operation="set", key=key, error_type=type(e).__name__, error_message=str(e))
+
+
+def safe_cache_delete(key):
+    """Safely delete a cache key, handling Redis connection errors gracefully."""
+    try:
+        cache.delete(key)
+    except Exception as e:
+        logger.warning(f"Cache delete failed for key '{key}': {e}. Continuing without cache.")
+        track_redis_cache_error(operation="delete", key=key, error_type=type(e).__name__, error_message=str(e))

--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -143,6 +143,12 @@ def _save_dna_to_profile(profile, dna_data):
             ]
         )
 
+        # Invalidate stale caches for this user
+        from ..cache_utils import safe_cache_delete
+
+        safe_cache_delete(f"similar_users_{profile.user.id}")
+        safe_cache_delete(f"user_recommendations_{profile.user.id}")
+
         # Trigger async recommendation generation
         # Import here to avoid circular imports
         from ..tasks import generate_recommendations_task

--- a/core/services/recommendation_service.py
+++ b/core/services/recommendation_service.py
@@ -424,7 +424,7 @@ class RecommendationEngine:
         read_book_ids = user_context["read_book_ids"]
 
         # Source 1: Similar registered users (highest quality)
-        similar_users = find_similar_users(user, top_n=30, min_similarity=self.min_similarity)
+        similar_users = find_similar_users(user, min_similarity=self.min_similarity)
         self._collect_candidates_from_similar_users(similar_users, read_book_ids, candidates)
 
         # Source 2: Anonymized profiles (medium quality)

--- a/core/services/recommendation_service.py
+++ b/core/services/recommendation_service.py
@@ -1,7 +1,6 @@
 from collections import Counter
 from django.utils import timezone
 from django.db.models import Q
-from django.core.cache import cache
 import math
 import logging
 
@@ -14,46 +13,9 @@ from .user_similarity_service import (
     _bulk_build_user_contexts,
 )
 from ..models import UserBook, Book, User, AnonymousUserSession, AnonymizedReadingProfile, Genre, Author
-from ..analytics.events import track_redis_cache_error
+from ..cache_utils import safe_cache_delete, safe_cache_get, safe_cache_set  # noqa: F401 - re-exported
 
 logger = logging.getLogger(__name__)
-
-
-def safe_cache_get(key, default=None):
-    """
-    Safely get a value from cache, handling Redis connection errors gracefully.
-    Returns default value if cache is unavailable.
-    """
-    try:
-        return cache.get(key, default)
-    except Exception as e:
-        logger.warning(f"Cache get failed for key '{key}': {e}. Continuing without cache.")
-        # Track Redis error in production
-        track_redis_cache_error(
-            operation="get",
-            key=key,
-            error_type=type(e).__name__,
-            error_message=str(e),
-        )
-        return default
-
-
-def safe_cache_set(key, value, timeout=None):
-    """
-    Safely set a value in cache, handling Redis connection errors gracefully.
-    Silently fails if cache is unavailable.
-    """
-    try:
-        cache.set(key, value, timeout)
-    except Exception as e:
-        logger.warning(f"Cache set failed for key '{key}': {e}. Continuing without cache.")
-        # Track Redis error in production
-        track_redis_cache_error(
-            operation="set",
-            key=key,
-            error_type=type(e).__name__,
-            error_message=str(e),
-        )
 
 
 class RecommendationEngine:
@@ -73,7 +35,7 @@ class RecommendationEngine:
         Returns list of dicts with: book, score, confidence, explanation, sources
         """
         # Cache key based on user ID and limit
-        cache_key = f"user_recommendations_{user.id}_{limit}"
+        cache_key = f"user_recommendations_{user.id}"
         cached_result = safe_cache_get(cache_key)
         if cached_result is not None:
             return cached_result
@@ -466,10 +428,10 @@ class RecommendationEngine:
         self._collect_candidates_from_similar_users(similar_users, read_book_ids, candidates)
 
         # Source 2: Anonymized profiles (medium quality)
-        cache_key = f"anon_profiles_sample_{user.id}"
+        cache_key = "anon_profiles_sample"
         anonymized_profiles = safe_cache_get(cache_key)
         if anonymized_profiles is None:
-            anonymized_profiles = list(AnonymizedReadingProfile.objects.all()[:100])
+            anonymized_profiles = list(AnonymizedReadingProfile.objects.order_by("?")[:100])
             safe_cache_set(cache_key, anonymized_profiles, 3600)
 
         user_ctx = _build_user_context_for_similarity(user)
@@ -524,8 +486,12 @@ class RecommendationEngine:
 
         self._collect_candidates_from_similar_users(similar_users, read_book_ids, candidates)
 
-        # Source 2: Anonymized profiles
-        anonymized_profiles = list(AnonymizedReadingProfile.objects.all()[:100])
+        # Source 2: Anonymized profiles (use global cached sample)
+        cache_key = "anon_profiles_sample"
+        anonymized_profiles = safe_cache_get(cache_key)
+        if anonymized_profiles is None:
+            anonymized_profiles = list(AnonymizedReadingProfile.objects.order_by("?")[:100])
+            safe_cache_set(cache_key, anonymized_profiles, 3600)
         matching_profiles = []
         for anon_profile in anonymized_profiles:
             similarity_data = calculate_similarity_with_anonymized(anon_session, anon_profile)
@@ -885,5 +851,12 @@ def get_recommendations_for_user(user, limit=10):
 
 def get_recommendations_for_anonymous(session_key, limit=10):
     """Get recommendations for an anonymous user"""
+    cache_key = f"anon_recommendations_{session_key}"
+    cached_result = safe_cache_get(cache_key)
+    if cached_result is not None:
+        return cached_result
+
     engine = RecommendationEngine()
-    return engine.get_recommendations_for_anonymous(session_key, limit=limit)
+    result = engine.get_recommendations_for_anonymous(session_key, limit=limit)
+    safe_cache_set(cache_key, result, 900)
+    return result

--- a/core/services/user_similarity_service.py
+++ b/core/services/user_similarity_service.py
@@ -320,16 +320,15 @@ def _bulk_build_user_contexts(user_ids):
     return contexts
 
 
-def find_similar_users(user, top_n=20, min_similarity=0.2):
+def find_similar_users(user, top_n=30, min_similarity=0.15):
     """
     Find registered users similar to the given user.
     Returns list of (user, similarity_data) tuples sorted by similarity.
     OPTIMIZED: Uses bulk loading to avoid N+1 queries.
     """
-    from .recommendation_service import safe_cache_get, safe_cache_set
+    from ..cache_utils import safe_cache_get, safe_cache_set
 
-    # Cache key for this user's similar users
-    cache_key = f"similar_users_{user.id}_{top_n}_{min_similarity}"
+    cache_key = f"similar_users_{user.id}"
     cached_result = safe_cache_get(cache_key)
     if cached_result is not None:
         return cached_result

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -98,7 +98,7 @@ def claim_anonymous_dna_task(self, user_id: int, task_id: str):
         logger.error(f"User with id {user_id} not found. Cannot claim task")
         return
 
-    from .services.recommendation_service import safe_cache_get
+    from .cache_utils import safe_cache_get
 
     cached_dna = safe_cache_get(f"dna_result_{task_id}")
     cached_session_key = safe_cache_get(f"session_key_{task_id}")
@@ -261,7 +261,7 @@ def generate_reading_dna_task(self, csv_file_content: str, user_id: int | None, 
             )
 
             if self.request.id:
-                from .services.recommendation_service import safe_cache_set
+                from .cache_utils import safe_cache_set
 
                 safe_cache_set(f"dna_result_{self.request.id}", result_data, timeout=3600)
                 # Also cache the session_key so we can find AnonymousUserSession when claiming
@@ -370,7 +370,7 @@ def run_management_command_task(command_name: str, args: list = None, kwargs: di
     """Run a Django management command and store the output in cache."""
     import io
     from django.core.management import call_command
-    from .services.recommendation_service import safe_cache_set
+    from .cache_utils import safe_cache_set
 
     args = args or []
     kwargs = kwargs or {}
@@ -480,10 +480,9 @@ def generate_recommendations_task(self, user_id: int):
         profile.save(update_fields=["recommendations_data", "recommendations_generated_at"])
 
         # Also clear the cache so fresh data is used
-        from .services.recommendation_service import safe_cache_set
+        from .cache_utils import safe_cache_delete
 
-        cache_key = f"user_recommendations_{user_id}_6"
-        safe_cache_set(cache_key, None, 1)  # Invalidate cache
+        safe_cache_delete(f"user_recommendations_{user_id}")
 
         logger.info(f"Successfully generated and stored {len(processed_recs)} recommendations for user {user_id}")
         return len(processed_recs)

--- a/core/tests/test_cache_refactor.py
+++ b/core/tests/test_cache_refactor.py
@@ -1,0 +1,552 @@
+"""
+Tests for the cache refactoring: cache_utils extraction, key simplification,
+invalidation on re-upload, community means caching, percentile TTL, anon
+recommendation caching, and global anon_profiles_sample key.
+"""
+
+from collections import Counter
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from core.cache_utils import safe_cache_delete, safe_cache_get, safe_cache_set
+from core.models import (
+    AnonymizedReadingProfile,
+    AnonymousUserSession,
+    Author,
+    Book,
+    Genre,
+    Publisher,
+    UserBook,
+)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class SafeCacheUtilsTests(TestCase):
+    """Unit tests for core/cache_utils.py functions."""
+
+    def setUp(self):
+        cache.clear()
+
+    def test_safe_cache_get_returns_value(self):
+        cache.set("test_key", "test_value", 60)
+        result = safe_cache_get("test_key")
+        self.assertEqual(result, "test_value")
+
+    def test_safe_cache_get_returns_default_on_miss(self):
+        result = safe_cache_get("missing_key", default="fallback")
+        self.assertEqual(result, "fallback")
+
+    def test_safe_cache_get_returns_none_by_default_on_miss(self):
+        result = safe_cache_get("missing_key")
+        self.assertIsNone(result)
+
+    def test_safe_cache_set_stores_value(self):
+        safe_cache_set("test_key", {"data": 123}, 60)
+        result = cache.get("test_key")
+        self.assertEqual(result, {"data": 123})
+
+    def test_safe_cache_delete_removes_value(self):
+        cache.set("test_key", "value", 60)
+        safe_cache_delete("test_key")
+        result = cache.get("test_key")
+        self.assertIsNone(result)
+
+    def test_safe_cache_delete_noop_on_missing_key(self):
+        # Should not raise
+        safe_cache_delete("nonexistent_key")
+
+    @patch("core.cache_utils.cache")
+    @patch("core.cache_utils.track_redis_cache_error")
+    def test_safe_cache_get_handles_exception(self, mock_track, mock_cache):
+        mock_cache.get.side_effect = ConnectionError("Redis down")
+        result = safe_cache_get("key", default="safe")
+        self.assertEqual(result, "safe")
+        mock_track.assert_called_once()
+        self.assertEqual(mock_track.call_args.kwargs["operation"], "get")
+
+    @patch("core.cache_utils.cache")
+    @patch("core.cache_utils.track_redis_cache_error")
+    def test_safe_cache_set_handles_exception(self, mock_track, mock_cache):
+        mock_cache.set.side_effect = ConnectionError("Redis down")
+        # Should not raise
+        safe_cache_set("key", "value", 60)
+        mock_track.assert_called_once()
+        self.assertEqual(mock_track.call_args.kwargs["operation"], "set")
+
+    @patch("core.cache_utils.cache")
+    @patch("core.cache_utils.track_redis_cache_error")
+    def test_safe_cache_delete_handles_exception(self, mock_track, mock_cache):
+        mock_cache.delete.side_effect = ConnectionError("Redis down")
+        # Should not raise
+        safe_cache_delete("key")
+        mock_track.assert_called_once()
+        self.assertEqual(mock_track.call_args.kwargs["operation"], "delete")
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class ReExportBackwardCompatTests(TestCase):
+    """Verify backward-compat re-exports from recommendation_service still work."""
+
+    def test_safe_cache_get_importable_from_recommendation_service(self):
+        from core.services.recommendation_service import safe_cache_get as imported_fn
+
+        self.assertIs(imported_fn, safe_cache_get)
+
+    def test_safe_cache_set_importable_from_recommendation_service(self):
+        from core.services.recommendation_service import safe_cache_set as imported_fn
+
+        self.assertIs(imported_fn, safe_cache_set)
+
+    def test_safe_cache_delete_importable_from_recommendation_service(self):
+        from core.services.recommendation_service import safe_cache_delete as imported_fn
+
+        self.assertIs(imported_fn, safe_cache_delete)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class UserRecommendationsCacheKeyTests(TestCase):
+    """Fix 5: user_recommendations key no longer includes limit param."""
+
+    def setUp(self):
+        cache.clear()
+        self.author = Author.objects.create(name="Test Author")
+        self.genre = Genre.objects.create(name="fantasy")
+
+        self.user = User.objects.create_user(username="cacheuser", password="test123")
+        self.user.userprofile.is_public = True
+        self.user.userprofile.visible_in_recommendations = True
+        self.user.userprofile.dna_data = {"top_genres": [("fantasy", 5)], "top_authors": []}
+        self.user.userprofile.save()
+
+        self.book = Book.objects.create(title="Test Book", author=self.author, average_rating=4.5)
+        self.book.genres.add(self.genre)
+        UserBook.objects.create(user=self.user, book=self.book, user_rating=5, is_top_book=True, top_book_position=1)
+
+    def test_cache_key_does_not_include_limit(self):
+        """After Fix 5, the cache key should be user_recommendations_{id} without limit suffix."""
+        from core.services.recommendation_service import RecommendationEngine
+
+        engine = RecommendationEngine()
+        engine.get_recommendations_for_user(self.user, limit=6)
+
+        # The key should be just user_recommendations_{id}
+        cached = cache.get(f"user_recommendations_{self.user.id}")
+        self.assertIsNotNone(cached)
+
+        # Old-style key with limit should NOT exist
+        cached_old = cache.get(f"user_recommendations_{self.user.id}_6")
+        self.assertIsNone(cached_old)
+
+    def test_different_limits_share_same_cache(self):
+        """Calling with limit=6 then limit=10 should return cached result from first call."""
+        from core.services.recommendation_service import RecommendationEngine
+
+        engine = RecommendationEngine()
+        result1 = engine.get_recommendations_for_user(self.user, limit=6)
+        result2 = engine.get_recommendations_for_user(self.user, limit=10)
+
+        # Both should return the same cached result (from the first call)
+        self.assertEqual(len(result1), len(result2))
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class SimilarUsersCacheKeyTests(TestCase):
+    """Fix 4: similar_users key simplified and defaults aligned."""
+
+    def setUp(self):
+        cache.clear()
+
+    def test_find_similar_users_defaults_match_production_usage(self):
+        """Function defaults should be top_n=30, min_similarity=0.15."""
+        from core.services.user_similarity_service import find_similar_users
+        import inspect
+
+        sig = inspect.signature(find_similar_users)
+        self.assertEqual(sig.parameters["top_n"].default, 30)
+        self.assertEqual(sig.parameters["min_similarity"].default, 0.15)
+
+    def test_cache_key_is_simplified(self):
+        """Cache key should be similar_users_{id} without top_n and min_similarity."""
+        from core.models import Author, Book, UserBook
+        from core.services.user_similarity_service import find_similar_users
+
+        user = User.objects.create_user(username="simuser", password="test123")
+        user.userprofile.dna_data = {"top_genres": []}
+        user.userprofile.visible_in_recommendations = True
+        user.userprofile.save()
+
+        user2 = User.objects.create_user(username="simuser2", password="test123")
+        user2.userprofile.dna_data = {"top_genres": []}
+        user2.userprofile.visible_in_recommendations = True
+        user2.userprofile.save()
+
+        # Create shared book data so find_similar_users doesn't bail early
+        author = Author.objects.create(name="Test Author")
+        book = Book.objects.create(title="Shared Book", author=author)
+        UserBook.objects.create(user=user, book=book, user_rating=5)
+        UserBook.objects.create(user=user2, book=book, user_rating=4)
+
+        find_similar_users(user, top_n=30, min_similarity=0.15)
+
+        # Simplified key should exist (even if value is an empty list)
+        cached = cache.get(f"similar_users_{user.id}")
+        self.assertIsNotNone(cached)
+
+        # Old-style key should NOT exist
+        cached_old = cache.get(f"similar_users_{user.id}_30_0.15")
+        self.assertIsNone(cached_old)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class SaveDnaInvalidationTests(TestCase):
+    """Fix 2: _save_dna_to_profile invalidates similar_users and user_recommendations caches."""
+
+    def setUp(self):
+        cache.clear()
+        self.user = User.objects.create_user(username="invaluser", password="test123")
+
+    @patch("core.tasks.generate_recommendations_task")
+    def test_save_dna_invalidates_similar_users_cache(self, mock_rec_task):
+        mock_rec_task.delay = MagicMock()
+
+        # Pre-populate cache
+        cache.set(f"similar_users_{self.user.id}", [("fake", "data")], 1800)
+        self.assertIsNotNone(cache.get(f"similar_users_{self.user.id}"))
+
+        from core.services.dna_analyser import _save_dna_to_profile
+
+        dna = {"reader_type": "Test", "user_stats": {}, "reading_vibe": [], "vibe_data_hash": "h"}
+        _save_dna_to_profile(self.user.userprofile, dna)
+
+        # Cache should be cleared
+        self.assertIsNone(cache.get(f"similar_users_{self.user.id}"))
+
+    @patch("core.tasks.generate_recommendations_task")
+    def test_save_dna_invalidates_user_recommendations_cache(self, mock_rec_task):
+        mock_rec_task.delay = MagicMock()
+
+        # Pre-populate cache
+        cache.set(f"user_recommendations_{self.user.id}", [{"fake": "rec"}], 900)
+        self.assertIsNotNone(cache.get(f"user_recommendations_{self.user.id}"))
+
+        from core.services.dna_analyser import _save_dna_to_profile
+
+        dna = {"reader_type": "Test", "user_stats": {}, "reading_vibe": [], "vibe_data_hash": "h"}
+        _save_dna_to_profile(self.user.userprofile, dna)
+
+        # Cache should be cleared
+        self.assertIsNone(cache.get(f"user_recommendations_{self.user.id}"))
+
+    @patch("core.tasks.generate_recommendations_task")
+    def test_save_dna_triggers_recommendation_generation(self, mock_rec_task):
+        mock_rec_task.delay = MagicMock()
+
+        from core.services.dna_analyser import _save_dna_to_profile
+
+        dna = {"reader_type": "Test", "user_stats": {}, "reading_vibe": [], "vibe_data_hash": "h"}
+        _save_dna_to_profile(self.user.userprofile, dna)
+
+        mock_rec_task.delay.assert_called_once_with(self.user.id)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class TaskInvalidationTests(TestCase):
+    """Fix 2 continued: generate_recommendations_task uses safe_cache_delete."""
+
+    def setUp(self):
+        cache.clear()
+
+    @patch("core.services.recommendation_service.RecommendationEngine.get_recommendations_for_user")
+    def test_recommendations_task_uses_delete_not_set_none(self, mock_get_recs):
+        """generate_recommendations_task should use safe_cache_delete, not safe_cache_set(key, None, 1)."""
+        mock_get_recs.return_value = []
+
+        user = User.objects.create_user(username="deltaskuser", password="test123")
+        user.userprofile.dna_data = {"reader_type": "Test"}
+        user.userprofile.save()
+
+        # Pre-populate cache with old key format
+        cache.set(f"user_recommendations_{user.id}", [{"old": "data"}], 900)
+
+        from core.tasks import generate_recommendations_task
+
+        generate_recommendations_task(user.id)
+
+        # Cache should be deleted, not set to None
+        result = cache.get(f"user_recommendations_{user.id}")
+        self.assertIsNone(result)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class AnonProfilesSampleTests(TestCase):
+    """Fix 3: Global anon_profiles_sample key + random sampling."""
+
+    def setUp(self):
+        cache.clear()
+
+        self.author = Author.objects.create(name="Anon Author")
+        self.genre = Genre.objects.create(name="fantasy")
+
+        # Create test users
+        self.user1 = User.objects.create_user(username="anontest1", password="test123")
+        self.user1.userprofile.is_public = True
+        self.user1.userprofile.visible_in_recommendations = True
+        self.user1.userprofile.dna_data = {"top_genres": [("fantasy", 5)], "top_authors": []}
+        self.user1.userprofile.save()
+
+        self.book1 = Book.objects.create(title="Anon Book 1", author=self.author, average_rating=4.5)
+        self.book1.genres.add(self.genre)
+        UserBook.objects.create(
+            user=self.user1, book=self.book1, user_rating=5, is_top_book=True, top_book_position=1
+        )
+
+    def test_cache_key_is_global_not_per_user(self):
+        """After Fix 3, anon_profiles_sample should be a global key without user_id."""
+        from core.services.recommendation_service import RecommendationEngine
+
+        engine = RecommendationEngine()
+        user_context = engine._build_user_context(self.user1)
+        engine._collect_candidates_for_user(self.user1, user_context, limit=10)
+
+        # Global key should exist
+        cached = cache.get("anon_profiles_sample")
+        self.assertIsNotNone(cached)
+
+        # Old per-user key should NOT exist
+        cached_old = cache.get(f"anon_profiles_sample_{self.user1.id}")
+        self.assertIsNone(cached_old)
+
+    def test_anonymous_candidate_collection_uses_same_global_cache(self):
+        """_collect_candidates_for_anonymous should use the same global cache key."""
+        from datetime import timedelta
+
+        # Create an AnonymousUserSession
+        anon_session = AnonymousUserSession.objects.create(
+            session_key="test_session_123",
+            dna_data={"top_genres": [("fantasy", 5)]},
+            books_data=[self.book1.id],
+            top_books_data=[self.book1.id],
+            genre_distribution={"fantasy": 5},
+            author_distribution={},
+            book_ratings={str(self.book1.id): 5},
+            expires_at=timezone.now() + timedelta(days=7),
+        )
+
+        from core.services.recommendation_service import RecommendationEngine
+
+        engine = RecommendationEngine()
+        anon_context = engine._build_anonymous_context(anon_session)
+        engine._collect_candidates_for_anonymous(anon_session, anon_context)
+
+        # Should use the same global key
+        cached = cache.get("anon_profiles_sample")
+        self.assertIsNotNone(cached)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class AnonymousRecommendationCacheTests(TestCase):
+    """Fix 6: Anonymous recommendations are now cached."""
+
+    def setUp(self):
+        cache.clear()
+        self.author = Author.objects.create(name="Cache Author")
+        self.genre = Genre.objects.create(name="fantasy")
+        self.book = Book.objects.create(title="Cache Book", author=self.author, average_rating=4.5)
+        self.book.genres.add(self.genre)
+
+    def _create_anon_session(self, session_key="anon_cache_test"):
+        from datetime import timedelta
+
+        return AnonymousUserSession.objects.create(
+            session_key=session_key,
+            dna_data={"top_genres": [("fantasy", 5)]},
+            books_data=[self.book.id],
+            top_books_data=[self.book.id],
+            genre_distribution={"fantasy": 5},
+            author_distribution={},
+            book_ratings={str(self.book.id): 5},
+            expires_at=timezone.now() + timedelta(days=7),
+        )
+
+    def test_anonymous_recommendations_are_cached(self):
+        """After Fix 6, get_recommendations_for_anonymous should cache results."""
+        self._create_anon_session()
+        from core.services.recommendation_service import get_recommendations_for_anonymous
+
+        result = get_recommendations_for_anonymous("anon_cache_test", limit=6)
+
+        cached = cache.get("anon_recommendations_anon_cache_test")
+        self.assertIsNotNone(cached)
+        self.assertEqual(len(cached), len(result))
+
+    def test_anonymous_recommendations_served_from_cache(self):
+        """Second call should return cached result without re-running pipeline."""
+        self._create_anon_session()
+        from core.services.recommendation_service import RecommendationEngine
+
+        engine = RecommendationEngine()
+
+        # First call populates cache
+        result1 = engine.get_recommendations_for_anonymous("anon_cache_test", limit=6)
+
+        # Manually verify cache hit by checking the cached object is identical
+        result2 = engine.get_recommendations_for_anonymous("anon_cache_test", limit=6)
+        self.assertEqual(len(result1), len(result2))
+
+    def test_anonymous_cache_returns_empty_for_missing_session(self):
+        """Should return [] for nonexistent session, and not cache the empty result."""
+        from core.services.recommendation_service import RecommendationEngine
+
+        engine = RecommendationEngine()
+        result = engine.get_recommendations_for_anonymous("nonexistent_session")
+
+        self.assertEqual(result, [])
+        # Empty result from missing session should not be cached
+        cached = cache.get("anon_recommendations_nonexistent_session")
+        self.assertIsNone(cached)
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class CommunityMeansCacheTests(TestCase):
+    """Fix 1: _enrich_dna_for_display caches community means."""
+
+    def setUp(self):
+        cache.clear()
+
+    def test_community_means_cached_on_first_call(self):
+        """calculate_community_means() result should be cached with key 'community_means'."""
+        from core.views import _enrich_dna_for_display
+
+        dna_data = {
+            "user_stats": {"avg_book_length": 300, "total_books_read": 50, "avg_publish_year": 2010},
+            "stats_by_year": [],
+            "bibliotype_percentiles": {},
+        }
+
+        _enrich_dna_for_display(dna_data)
+
+        cached = cache.get("community_means")
+        self.assertIsNotNone(cached)
+        self.assertIsInstance(cached, dict)
+
+    @patch("core.percentile_engine.calculate_community_means")
+    def test_community_means_served_from_cache_on_second_call(self, mock_calc):
+        """Second call should use cache, not recalculate."""
+        mock_calc.return_value = {"avg_book_length": 320, "avg_publish_year": 2015, "avg_books_per_year": 12}
+
+        from core.views import _enrich_dna_for_display
+
+        dna_base = {
+            "user_stats": {"avg_book_length": 300, "total_books_read": 50, "avg_publish_year": 2010},
+            "stats_by_year": [],
+            "bibliotype_percentiles": {},
+        }
+
+        # First call: populates cache
+        _enrich_dna_for_display(dict(dna_base))
+        self.assertEqual(mock_calc.call_count, 1)
+
+        # Second call: should use cache
+        _enrich_dna_for_display(dict(dna_base))
+        self.assertEqual(mock_calc.call_count, 1)  # Still 1 — cache hit
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class PercentilesCacheTTLTests(TestCase):
+    """Fix 1: Percentiles cache uses safe_cache_get/set and 600s TTL."""
+
+    def setUp(self):
+        cache.clear()
+
+    def test_percentiles_cached_with_safe_wrappers(self):
+        """Fresh percentiles should be cached using safe_cache_set."""
+        from core.views import _enrich_dna_for_display
+
+        dna_data = {
+            "user_stats": {"avg_book_length": 300, "total_books_read": 50, "avg_publish_year": 2010},
+            "stats_by_year": [],
+            "bibliotype_percentiles": {},
+        }
+
+        _enrich_dna_for_display(dna_data)
+
+        # Check that the percentile cache key exists
+        cache_key = f"fresh_pct_{300}_{50}_{0}_{2010}"
+        cached = cache.get(cache_key)
+        self.assertIsNotNone(cached)
+
+    @patch("core.percentile_engine.calculate_percentiles_from_aggregates")
+    def test_percentiles_served_from_cache(self, mock_calc):
+        """Second call with same stats should use cached percentiles."""
+        mock_calc.return_value = {"avg_book_length": 60, "avg_publish_year": 55}
+
+        from core.views import _enrich_dna_for_display
+
+        dna_base = {
+            "user_stats": {"avg_book_length": 300, "total_books_read": 50, "avg_publish_year": 2010},
+            "stats_by_year": [],
+            "bibliotype_percentiles": {},
+        }
+
+        _enrich_dna_for_display(dict(dna_base))
+        self.assertEqual(mock_calc.call_count, 1)
+
+        _enrich_dna_for_display(dict(dna_base))
+        self.assertEqual(mock_calc.call_count, 1)  # Still 1 — cache hit
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "cache-refactor-tests"}}
+)
+class ImportPathTests(TestCase):
+    """Verify all import paths work correctly after the refactor."""
+
+    def test_cache_utils_importable_from_core(self):
+        from core.cache_utils import safe_cache_delete, safe_cache_get, safe_cache_set
+
+        self.assertTrue(callable(safe_cache_get))
+        self.assertTrue(callable(safe_cache_set))
+        self.assertTrue(callable(safe_cache_delete))
+
+    def test_user_similarity_imports_from_cache_utils(self):
+        """find_similar_users should import from cache_utils, not recommendation_service."""
+        import inspect
+
+        from core.services.user_similarity_service import find_similar_users
+
+        source = inspect.getsource(find_similar_users)
+        self.assertIn("cache_utils", source)
+        self.assertNotIn("recommendation_service", source)
+
+    def test_tasks_import_from_cache_utils(self):
+        """Tasks should import safe_cache_* from cache_utils."""
+        import inspect
+
+        from core.tasks import generate_recommendations_task
+
+        source = inspect.getsource(generate_recommendations_task)
+        self.assertIn("cache_utils", source)

--- a/core/tests/test_tasks_integration.py
+++ b/core/tests/test_tasks_integration.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.test import TestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 
 from core.tasks import claim_anonymous_dna_task, generate_reading_dna_task
 
@@ -10,20 +10,29 @@ from core.tasks import claim_anonymous_dna_task, generate_reading_dna_task
 # This setting makes Celery tasks run synchronously in the test
 @override_settings(
     CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=True,
     CELERY_RESULT_BACKEND="django-db",
     CACHES={
         "default": {
-            "BACKEND": "django.core.cache.backends.redis.RedisCache",
-            "LOCATION": "redis://redis:6379/1",
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "task-integration-tests",
         }
     },
 )
-class TaskIntegrationTests(TestCase):
+class TaskIntegrationTests(TransactionTestCase):
+
+    def setUp(self):
+        try:
+            cache.clear()
+        except Exception:
+            pass
 
     # Mock the slow, external network calls
+    @patch("core.tasks.generate_recommendations_task.delay")
+    @patch("core.tasks.check_author_mainstream_status_task.delay")
     @patch("core.tasks.enrich_book_task.delay")
     @patch("core.services.dna_analyser.generate_vibe_with_llm")
-    def test_generate_dna_for_authenticated_user(self, mock_generate_vibe, mock_enrich_delay):
+    def test_generate_dna_for_authenticated_user(self, mock_generate_vibe, mock_enrich_delay, mock_author_check, mock_rec_task):
         """
         Tests the full DNA generation task for a logged-in user.
         """
@@ -43,9 +52,10 @@ class TaskIntegrationTests(TestCase):
         self.assertIsNotNone(user.userprofile.dna_data)
         self.assertEqual(user.userprofile.reader_type, "Novella Navigator")
 
+    @patch("core.tasks.check_author_mainstream_status_task.delay")
     @patch("core.tasks.enrich_book_task.delay")
     @patch("core.services.dna_analyser.generate_vibe_with_llm")
-    def test_generate_dna_for_anonymous_user(self, mock_generate_vibe, mock_enrich_delay):
+    def test_generate_dna_for_anonymous_user(self, mock_generate_vibe, mock_enrich_delay, mock_author_check):
         """
         Tests that anonymous generation saves its result to the cache.
         """
@@ -62,8 +72,9 @@ class TaskIntegrationTests(TestCase):
         self.assertIsNotNone(cached_data)
         self.assertEqual(cached_data["reader_type"], "Novella Navigator")
 
+    @patch("core.tasks.generate_recommendations_task.delay")
     @patch("core.tasks.AsyncResult")
-    def test_claim_anonymous_dna_task(self, mock_async_result):
+    def test_claim_anonymous_dna_task(self, mock_async_result, mock_rec_task):
         """
         Tests the claiming task's ability to fetch a result from the Celery backend
         and save it to a profile.

--- a/core/views.py
+++ b/core/views.py
@@ -11,7 +11,6 @@ from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.models import User
-from django.core.cache import cache
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
@@ -171,6 +170,7 @@ def _enrich_dna_for_display(dna_data):
     if not dna_data:
         return dna_data
 
+    from .cache_utils import safe_cache_get, safe_cache_set
     from .dna_constants import GLOBAL_AVERAGES
     from .percentile_engine import calculate_community_means, calculate_percentiles_from_aggregates
 
@@ -185,8 +185,12 @@ def _enrich_dna_for_display(dna_data):
         "avg_books_per_year": GLOBAL_AVERAGES["avg_books_per_year"],
     }
 
-    # Always compute fresh community averages from current histogram data
-    raw_community = calculate_community_means()
+    # Always compute fresh community averages from current histogram data (cached 10 min)
+    community_cache_key = "community_means"
+    raw_community = safe_cache_get(community_cache_key)
+    if raw_community is None:
+        raw_community = calculate_community_means()
+        safe_cache_set(community_cache_key, raw_community, 600)
     dna_data["community_averages"] = {
         k: v if v is not None else COMMUNITY_FALLBACKS.get(k, 0) for k, v in raw_community.items()
     }
@@ -215,10 +219,10 @@ def _enrich_dna_for_display(dna_data):
     bpy = user_stats.get("avg_books_per_year", 0)
     py = user_stats.get("avg_publish_year", 0)
     cache_key = f"fresh_pct_{bl}_{br}_{bpy}_{py}"
-    fresh_percentiles = cache.get(cache_key)
+    fresh_percentiles = safe_cache_get(cache_key)
     if fresh_percentiles is None:
         fresh_percentiles = calculate_percentiles_from_aggregates(user_stats)
-        cache.set(cache_key, fresh_percentiles or {}, 60)
+        safe_cache_set(cache_key, fresh_percentiles or {}, 600)
     if fresh_percentiles:
         dna_data["bibliotype_percentiles"] = fresh_percentiles
 
@@ -902,7 +906,7 @@ def task_status_view(request, task_id):
 
 def get_task_result_view(request, task_id):
     from .models import AnonymousUserSession
-    from .services.recommendation_service import safe_cache_get
+    from .cache_utils import safe_cache_get
 
     cached_result = safe_cache_get(f"dna_result_{task_id}")
     if cached_result is not None:

--- a/core/views.py
+++ b/core/views.py
@@ -213,7 +213,7 @@ def _enrich_dna_for_display(dna_data):
         user_stats["books_with_dates"] = dated_book_count
 
     # Recalculate percentiles from current aggregate data so they're never stale.
-    # Cached for 60s to avoid a DB hit on every page load while still staying fresh.
+    # Cached for 10 minutes to avoid a DB hit on every page load while still staying fresh.
     bl = user_stats.get("avg_book_length", 0)
     br = user_stats.get("total_books_read", 0)
     bpy = user_stats.get("avg_books_per_year", 0)

--- a/docs/plans/2026-02-27-refactor-caching-strategy-cleanup-plan.md
+++ b/docs/plans/2026-02-27-refactor-caching-strategy-cleanup-plan.md
@@ -1,0 +1,439 @@
+---
+title: "refactor: Clean up caching strategy"
+type: refactor
+status: active
+date: 2026-02-27
+---
+
+# refactor: Clean up caching strategy
+
+## Overview
+
+Address caching inefficiencies across the recommendation engine and supporting services. Eight changes total: one prerequisite extraction, six concrete fixes, and one analysis of the anonymous triple-storage pattern.
+
+## Problem Statement
+
+1. **`safe_cache_get`/`safe_cache_set` live in `recommendation_service.py`** — They're general-purpose cache utilities that force cross-layer imports (e.g., views importing from a service). There's also no `safe_cache_delete`, so invalidation uses the fragile `safe_cache_set(key, None, 1)` pattern.
+2. **Percentiles cached for only 60 seconds** — `AggregateAnalytics` is a singleton updated infrequently. A 60s TTL means nearly every page load recalculates from DB. Additionally, `calculate_community_means()` in the same function has **no caching at all**.
+3. **No cache invalidation for similar users on re-upload** — `_save_dna_to_profile()` clears `recommendations_data` but not `similar_users_{user_id}_*`. Stale data persists for up to 30 minutes.
+4. **`anon_profiles_sample_{user_id}` key is per-user but data is global** — The query is `AnonymizedReadingProfile.objects.all()[:100]` (same profiles for everyone). There's also a second uncached call site in `_collect_candidates_for_anonymous()`. The query always returns the 100 most recent profiles rather than a representative random sample.
+5. **`similar_users` cache key includes params that never vary** — Always called with `top_n=30, min_similarity=0.15`, but the function defaults are `top_n=20, min_similarity=0.2` — a mismatch between signature and usage.
+6. **`user_recommendations` cache key includes `limit` param** — The task invalidates `_6` but the convenience function defaults to `limit=10`, creating a potential stale-cache gap.
+7. **Anonymous recommendations are uncached** — `get_recommendations_for_anonymous()` runs the full recommendation pipeline (500-user comparison, 100-profile comparison, scoring, ranking) on every single dashboard page load. This is the most expensive uncached path in the system.
+8. **Anonymous flow stores data in 3 places simultaneously** — Session, Redis cache, and `AnonymousUserSession` DB model.
+
+---
+
+## Prerequisite: Extract cache utilities to `core/cache_utils.py`
+
+**Current:** `safe_cache_get` and `safe_cache_set` live in `core/services/recommendation_service.py` (lines 22-56). Any module that wants safe cache access must import from the recommendation service — a layering violation.
+
+**Change:** Create `core/cache_utils.py` with three functions:
+
+```python
+# core/cache_utils.py
+from django.core.cache import cache
+import logging
+
+from .analytics.events import track_redis_cache_error
+
+logger = logging.getLogger(__name__)
+
+
+def safe_cache_get(key, default=None):
+    """Safely get a value from cache, handling Redis connection errors gracefully."""
+    try:
+        return cache.get(key, default)
+    except Exception as e:
+        logger.warning(f"Cache get failed for key '{key}': {e}. Continuing without cache.")
+        track_redis_cache_error(operation="get", key=key, error_type=type(e).__name__, error_message=str(e))
+        return default
+
+
+def safe_cache_set(key, value, timeout=None):
+    """Safely set a value in cache, handling Redis connection errors gracefully."""
+    try:
+        cache.set(key, value, timeout)
+    except Exception as e:
+        logger.warning(f"Cache set failed for key '{key}': {e}. Continuing without cache.")
+        track_redis_cache_error(operation="set", key=key, error_type=type(e).__name__, error_message=str(e))
+
+
+def safe_cache_delete(key):
+    """Safely delete a cache key, handling Redis connection errors gracefully."""
+    try:
+        cache.delete(key)
+    except Exception as e:
+        logger.warning(f"Cache delete failed for key '{key}': {e}. Continuing without cache.")
+        track_redis_cache_error(operation="delete", key=key, error_type=type(e).__name__, error_message=str(e))
+```
+
+**Then update `recommendation_service.py`:** Replace the inline definitions with re-exports for backward compatibility:
+
+```python
+# core/services/recommendation_service.py (top of file)
+from ..cache_utils import safe_cache_get, safe_cache_set, safe_cache_delete  # noqa: F401 - re-exported
+```
+
+This keeps all existing imports working (`from .services.recommendation_service import safe_cache_get`) while allowing new code to import from the proper location (`from .cache_utils import safe_cache_get`).
+
+**All other modules in this plan** should import from `core.cache_utils` directly.
+
+---
+
+## Fix 1: Increase percentiles cache TTL + cache community means
+
+**File:** `core/views.py` (lines 188-221 in `_enrich_dna_for_display`)
+
+### 1a. Cache `calculate_community_means()` (currently uncached)
+
+**Current** (line 189):
+```python
+raw_community = calculate_community_means()
+```
+
+This calls `AggregateAnalytics.get_instance()` (a DB read) on **every single page load** — both dashboard and public profile views. The data changes only when new DNA is generated or the daily anonymization task runs.
+
+**Change:** Add a global cache key with 600s TTL:
+
+```python
+from .cache_utils import safe_cache_get, safe_cache_set
+
+community_cache_key = "community_means"
+raw_community = safe_cache_get(community_cache_key)
+if raw_community is None:
+    raw_community = calculate_community_means()
+    safe_cache_set(community_cache_key, raw_community, 600)
+```
+
+### 1b. Increase percentiles cache TTL
+
+**Current** (lines 217-221):
+```python
+cache_key = f"fresh_pct_{bl}_{br}_{bpy}_{py}"
+fresh_percentiles = cache.get(cache_key)
+if fresh_percentiles is None:
+    fresh_percentiles = calculate_percentiles_from_aggregates(user_stats)
+    cache.set(cache_key, fresh_percentiles or {}, 60)
+```
+
+**Change:** Increase TTL from `60` to `600` (10 minutes) and use safe wrappers:
+
+```python
+fresh_percentiles = safe_cache_get(cache_key)
+if fresh_percentiles is None:
+    fresh_percentiles = calculate_percentiles_from_aggregates(user_stats)
+    safe_cache_set(cache_key, fresh_percentiles or {}, 600)
+```
+
+**Rationale:** `AggregateAnalytics` is a singleton row that changes only when a new user generates DNA or the daily anonymization task runs. Percentile shifts from a single new user are negligible. 10 minutes eliminates ~10x redundant DB reads while staying fresh enough for bursts of new signups.
+
+**Note on per-user cache keys:** The `fresh_pct_{stats}` key is content-addressed — users with identical stats share the same entry. This is a good design. The cache primarily helps same-user page refreshes within the TTL window. A future improvement could cache the `AggregateAnalytics` histograms globally and compute percentiles in Python, reducing DB reads to O(1) per TTL regardless of unique users. Not needed at current scale.
+
+**Combined impact:** Reduces `AggregateAnalytics` DB reads from 2 per page load to ~2 per 10 minutes.
+
+---
+
+## Fix 2: Invalidate similar users cache on DNA re-upload
+
+**File:** `core/services/dna_analyser.py` (lines 117-155)
+
+**Current:** `_save_dna_to_profile()` clears `recommendations_data` and triggers `generate_recommendations_task.delay()`, but does not touch the `similar_users` cache. The newly triggered recommendations task calls `find_similar_users()`, which returns stale cached data.
+
+**Change:** Add explicit cache invalidation using `safe_cache_delete` after saving profile, before triggering the recommendations task:
+
+```python
+def _save_dna_to_profile(profile, dna_data):
+    # ... existing code ...
+
+    profile.save(update_fields=[...])
+
+    # Invalidate stale caches for this user
+    from ..cache_utils import safe_cache_delete
+    safe_cache_delete(f"similar_users_{profile.user.id}")
+    safe_cache_delete(f"user_recommendations_{profile.user.id}")
+
+    # Trigger async recommendation generation
+    from ..tasks import generate_recommendations_task
+    generate_recommendations_task.delay(profile.user.id)
+```
+
+**Also update** the existing invalidation in `generate_recommendations_task` (`core/tasks.py:485-486`):
+
+```python
+# Before (fragile set-to-None pattern):
+safe_cache_set(cache_key, None, 1)
+
+# After (explicit delete):
+from .cache_utils import safe_cache_delete
+safe_cache_delete(f"user_recommendations_{user_id}")
+```
+
+**Note on cross-user staleness:** We only invalidate the *current user's* similar users entry. Other users who had *this user* in their cached similar list will pick up the change when their own 30-minute TTL expires. Building a reverse index to proactively invalidate all referencing users is not worth the complexity.
+
+---
+
+## Fix 3: Global anon_profiles_sample key + random sampling + second call site
+
+**Files:** `core/services/recommendation_service.py` (lines 469-473 and line 528)
+
+### 3a. Fix the cache key and add random sampling
+
+**Current** (lines 469-473 in `_collect_candidates_for_user`):
+```python
+cache_key = f"anon_profiles_sample_{user.id}"
+anonymized_profiles = safe_cache_get(cache_key)
+if anonymized_profiles is None:
+    anonymized_profiles = list(AnonymizedReadingProfile.objects.all()[:100])
+    safe_cache_set(cache_key, anonymized_profiles, 3600)
+```
+
+**Problems:**
+1. `user.id` in the key creates N redundant cache entries storing identical data
+2. `AnonymizedReadingProfile` has `ordering = ["-created_at"]`, so `.all()[:100]` always returns the 100 most recent profiles — not a representative sample of the community
+3. As the table grows, the recommendation engine only ever compares against the newest cohort
+
+**Change:** Remove `user.id` from key and use random sampling:
+
+```python
+cache_key = "anon_profiles_sample"
+anonymized_profiles = safe_cache_get(cache_key)
+if anonymized_profiles is None:
+    anonymized_profiles = list(AnonymizedReadingProfile.objects.order_by("?")[:100])
+    safe_cache_set(cache_key, anonymized_profiles, 3600)
+```
+
+`order_by("?")` triggers `ORDER BY RANDOM()` in PostgreSQL. This is normally expensive on large tables (full sequential scan), but since the result is cached for 1 hour, it only runs on cache miss — at most once per hour for the entire application. Acceptable at any realistic table size for this app.
+
+**Impact:** Single global cache entry instead of N per-user entries. Each hourly refresh gets a fresh random sample, improving recommendation diversity over time.
+
+### 3b. Fix the second uncached call site
+
+**Current** (line 528 in `_collect_candidates_for_anonymous`):
+```python
+anonymized_profiles = list(AnonymizedReadingProfile.objects.all()[:100])
+```
+
+This is completely uncached — hits the DB on every anonymous dashboard load.
+
+**Change:** Use the same global cache key:
+
+```python
+cache_key = "anon_profiles_sample"
+anonymized_profiles = safe_cache_get(cache_key)
+if anonymized_profiles is None:
+    anonymized_profiles = list(AnonymizedReadingProfile.objects.order_by("?")[:100])
+    safe_cache_set(cache_key, anonymized_profiles, 3600)
+```
+
+---
+
+## Fix 4: Simplify `similar_users` cache key + align function defaults
+
+**File:** `core/services/user_similarity_service.py` (lines 323, 332-333)
+
+### 4a. Simplify the cache key
+
+**Current** (line 332):
+```python
+cache_key = f"similar_users_{user.id}_{top_n}_{min_similarity}"
+```
+
+**Change:**
+```python
+cache_key = f"similar_users_{user.id}"
+```
+
+**Rationale:** `find_similar_users()` is called in exactly one production location — `_collect_candidates_for_user()` at line 465 of `recommendation_service.py` — always with `top_n=30, min_similarity=0.15`. The parameterized key creates the illusion of flexibility that doesn't exist and would silently return stale data if someone later called with different params.
+
+### 4b. Align function defaults with actual usage
+
+**Current** (line 323):
+```python
+def find_similar_users(user, top_n=20, min_similarity=0.2):
+```
+
+**Change:**
+```python
+def find_similar_users(user, top_n=30, min_similarity=0.15):
+```
+
+The current defaults (`20`, `0.2`) are never used — the single production call site always overrides them. Aligning the defaults with reality makes the simplified cache key honest and prevents confusion if someone calls the function without explicit params.
+
+---
+
+## Fix 5: Simplify `user_recommendations` cache key
+
+**Files:** `core/services/recommendation_service.py` (line 76), `core/tasks.py` (line 485)
+
+**Current:**
+
+In `recommendation_service.py:76`:
+```python
+cache_key = f"user_recommendations_{user.id}_{limit}"
+```
+
+In `tasks.py:485` (invalidation):
+```python
+cache_key = f"user_recommendations_{user_id}_6"
+```
+
+**Problem:** The task hardcodes `_6` (matching its `limit=6` call), but `get_recommendations_for_user()` defaults to `limit=10`. If the convenience function is ever called with the default limit, it creates a `_10` cache entry that the task's invalidation never clears.
+
+**Change:** Remove `limit` from the cache key in both locations:
+
+```python
+# recommendation_service.py
+cache_key = f"user_recommendations_{user.id}"
+
+# tasks.py (already handled by Fix 2's safe_cache_delete)
+safe_cache_delete(f"user_recommendations_{user_id}")
+```
+
+Same rationale as Fix 4: the parameterized key encodes flexibility that doesn't exist in practice and creates invalidation gaps.
+
+---
+
+## Fix 6: Cache anonymous recommendations
+
+**File:** `core/services/recommendation_service.py` (lines 103-136)
+
+**Current:** `get_recommendations_for_anonymous()` runs the full recommendation pipeline on every dashboard page load for anonymous users:
+1. Queries `AnonymousUserSession` from DB
+2. Builds anonymous context (DB query for books and authors)
+3. Fetches up to 500 public users (cached for 30 min, good)
+4. Bulk-builds user contexts for all 500 users (large DB query)
+5. Computes similarity against all 500 users
+6. Queries 100 anonymized profiles
+7. Scores, ranks, and filters with diversity + explanations
+
+For an anonymous user who refreshes their dashboard 5 times, this runs 5 times. This is the most expensive uncached path in the system.
+
+**Change:** Add a session-key-based cache with 15-minute TTL (matching the authenticated user caching):
+
+```python
+def get_recommendations_for_anonymous(self, session_key, limit=10, include_explanations=True):
+    """Get recommendations for an anonymous user."""
+    # Check cache first
+    cache_key = f"anon_recommendations_{session_key}"
+    cached_result = safe_cache_get(cache_key)
+    if cached_result is not None:
+        return cached_result
+
+    try:
+        anon_session = AnonymousUserSession.objects.get(session_key=session_key)
+    except AnonymousUserSession.DoesNotExist:
+        logger.warning(f"AnonymousUserSession not found for session_key: {session_key}")
+        return []
+
+    # ... existing recommendation pipeline (unchanged) ...
+
+    result = final_recommendations[:limit]
+
+    # Cache for 15 minutes
+    safe_cache_set(cache_key, result, 900)
+    return result
+```
+
+**Why 15 minutes?** Matches the TTL for authenticated user recommendations. Anonymous users can't re-upload without the page reloading (which clears context), so there's no invalidation concern — the cache naturally expires.
+
+**Impact:** Reduces DB queries and CPU-intensive similarity computations from O(page_loads) to O(1) per 15 minutes per anonymous session.
+
+---
+
+## Item 7: Anonymous Triple-Storage Analysis
+
+### What's happening today
+
+When an anonymous user uploads a CSV, their data ends up in **three places**:
+
+| Store | What | Set when | Read when | Lifetime |
+|---|---|---|---|---|
+| **Redis cache** | Full DNA dict (`dna_result_{task_id}`) + session key mapping (`session_key_{task_id}`) | Celery task completes | `get_task_result_view` polls for result; `claim_anonymous_dna_task` on signup | 1 hour TTL |
+| **Django session** | `dna_data`, `book_ids`, `top_book_ids`, `book_ratings` | `get_task_result_view` on SUCCESS | `display_dna_view` renders dashboard | Until session expires |
+| **AnonymousUserSession** (DB) | `dna_data`, `books_data`, `top_books_data`, `genre_distribution`, `author_distribution`, `book_ratings` | `save_anonymous_session_data()` during DNA generation | Recommendation engine (similarity comparisons); `get_task_result_view` (to populate session); `claim_anonymous_dna_task` (to create UserBooks); `display_dna_view` (to recreate if expired) | 7 days, then anonymized |
+
+### Why each store exists
+
+**Redis cache (`dna_result_{task_id}`)**: Bridges the async gap. The Celery task runs in a separate process, and the frontend polls via AJAX. Redis is the fast handoff mechanism — the task writes the result, the polling view reads it. Without this, you'd have to call `AsyncResult.get()` every poll, which is slower and depends on the Celery result backend configuration.
+
+**Django session**: The dashboard view needs DNA data on every page load. Session is the natural place for request-scoped data for anonymous users (no UserProfile to persist to). It's also what survives across page navigations without requiring another DB query.
+
+**AnonymousUserSession (DB)**: Serves three purposes that session and Redis cannot:
+1. **Recommendation engine input** — `get_recommendations_for_anonymous()` needs `genre_distribution`, `author_distribution`, `book_ratings` for similarity calculations. These aren't in the DNA dict (DNA has `top_genres`/`top_authors` as lists, not the full distributions).
+2. **Claim flow** — When a user signs up, `claim_anonymous_dna_task` needs to create `UserBook` records from `books_data`. The Redis cache may have expired by then (1h TTL vs. signup could be days later). The session is tied to the browser, not accessible from a Celery task.
+3. **Anonymization pipeline** — After 7 days, expired sessions become `AnonymizedReadingProfile` records that feed the recommendation engine for other users.
+
+### Can it be simplified?
+
+**The Redis cache layer is the most redundant.** Its only purpose is fast polling during the ~30 seconds of DNA processing. Without it, `get_task_result_view` falls back to `AsyncResult(task_id)` which works fine — it's just a Redis read from the Celery result backend (db 0) instead of the cache backend (db 1). The code already has this fallback at `views.py:929-952`.
+
+**Potential simplification: Remove `dna_result_{task_id}` and `session_key_{task_id}` from the cache layer entirely.** Rely on `AsyncResult` for the polling handoff, and `AnonymousUserSession` for the claim flow.
+
+**Pros:**
+- Eliminates one storage layer and the `safe_cache_set` calls in the task
+- `claim_anonymous_dna_task` already queries `AnonymousUserSession` for `books_data` — it could also read `dna_data` from there instead of Redis cache
+- Removes the confusing dual-path in `get_task_result_view` (check cache, then check AsyncResult)
+
+**Cons:**
+- `AsyncResult.get()` blocks if the task isn't done yet (but the view already handles PENDING state)
+- The claim flow currently tries Redis first, then falls back to AsyncResult with retry. Removing Redis means it always goes to AsyncResult, which is fine but slightly slower on the happy path
+- `session_key_{task_id}` mapping is used by `claim_anonymous_dna_task` to find the `AnonymousUserSession`. Without this, the claim task would need to receive the `session_key` directly (passed from the signup view instead of looked up from cache)
+
+**Note on race conditions:** There's a subtle timing issue in the current flow — when `get_task_result_view` receives SUCCESS from Redis cache (lines 907-927), it simultaneously queries `AnonymousUserSession` to populate session data. If the Celery task has written to Redis but `save_anonymous_session_data()` hasn't committed yet, the `AnonymousUserSession.DoesNotExist` is silently caught and session data is incomplete. This is extremely unlikely under normal load and self-heals on the next page load.
+
+**Recommendation:** Leave the anonymous triple-storage as-is for now. Each layer genuinely serves a different consumer (polling view, dashboard rendering, background tasks). The Redis cache layer adds ~4 lines of code and makes the polling path faster. The complexity cost is low and the fallback paths already work.
+
+If we wanted to simplify in the future, the cleanest approach would be to pass `session_key` directly to `claim_anonymous_dna_task` from `signup_view` (instead of looking it up via `session_key_{task_id}` in Redis), which would eliminate the `session_key_{task_id}` cache entry.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `core/cache_utils.py` exists with `safe_cache_get`, `safe_cache_set`, `safe_cache_delete`
+- [ ] `recommendation_service.py` re-exports from `cache_utils` (backward compat)
+- [ ] All existing `safe_cache_set(key, None, 1)` invalidation calls replaced with `safe_cache_delete(key)`
+- [ ] `_enrich_dna_for_display()` caches `calculate_community_means()` with 600s TTL
+- [ ] Percentiles cache TTL increased to 600s and uses `safe_cache_get`/`safe_cache_set` from `cache_utils`
+- [ ] `_save_dna_to_profile()` invalidates both `similar_users_{user_id}` and `user_recommendations_{user_id}` caches
+- [ ] `anon_profiles_sample` uses a global cache key (no `user_id`)
+- [ ] Both call sites (authenticated + anonymous candidate collection) use the cached global key
+- [ ] Anonymized profile sample uses `order_by("?")` for random sampling
+- [ ] `similar_users` cache key simplified to `similar_users_{user_id}`
+- [ ] `find_similar_users()` function defaults updated to `top_n=30, min_similarity=0.15`
+- [ ] `user_recommendations` cache key simplified to `user_recommendations_{user_id}`
+- [ ] `get_recommendations_for_anonymous()` caches results with 15-minute TTL keyed by session key
+- [ ] All existing tests pass
+
+## Implementation Order
+
+Fixes should be implemented in this order due to dependencies:
+
+1. **Prerequisite** — Extract `cache_utils.py`, update imports
+2. **Fix 1** — Percentiles + community means caching (uses new imports)
+3. **Fix 3** — Global anon_profiles_sample + random sampling (independent)
+4. **Fix 4** — Simplify similar_users key + align defaults (independent)
+5. **Fix 5** — Simplify user_recommendations key (independent)
+6. **Fix 2** — Similar users invalidation (depends on Fix 4 + Fix 5 key formats)
+7. **Fix 6** — Cache anonymous recommendations (independent, biggest impact)
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `core/cache_utils.py` | **New file** — `safe_cache_get`, `safe_cache_set`, `safe_cache_delete` |
+| `core/services/recommendation_service.py` | Re-export from cache_utils; global anon_profiles_sample key (2 locations); random sampling; simplify user_recommendations key; cache anonymous recommendations |
+| `core/views.py:188-221` | Cache community means; increase percentiles TTL; import from cache_utils |
+| `core/services/dna_analyser.py:117-155` | Add similar_users + user_recommendations cache invalidation via safe_cache_delete |
+| `core/services/user_similarity_service.py:323,332-333` | Simplify cache key; update function defaults |
+| `core/tasks.py:485-486` | Replace `safe_cache_set(key, None, 1)` with `safe_cache_delete(key)` |
+
+## References
+
+- `core/services/recommendation_service.py` — RecommendationEngine class, safe_cache wrappers
+- `core/services/user_similarity_service.py` — find_similar_users(), bulk context building
+- `core/services/dna_analyser.py` — _save_dna_to_profile(), save_anonymous_session_data()
+- `core/views.py` — _enrich_dna_for_display(), get_task_result_view(), display_dna_view()
+- `core/tasks.py` — generate_reading_dna_task, claim_anonymous_dna_task, generate_recommendations_task
+- `core/percentile_engine.py` — calculate_percentiles_from_aggregates(), calculate_community_means()
+- `core/models.py` — AnonymizedReadingProfile (ordering: `-created_at`), AnonymousUserSession, AggregateAnalytics


### PR DESCRIPTION
## Summary

- **Extract `core/cache_utils.py`**: Centralizes `safe_cache_get`, `safe_cache_set`, and `safe_cache_delete` to eliminate circular imports between services and tasks
- **Fix cache invalidation on DNA re-upload**: `_save_dna_to_profile()` now invalidates `similar_users_{user_id}` and `user_recommendations_{user_id}` caches so stale data doesn't persist
- **Make `anon_profiles_sample` global**: Changed from per-user key (`anon_profiles_sample_{user_id}`) to a shared `anon_profiles_sample` key with random sampling (`order_by("?")`)
- **Simplify cache keys**: Removed redundant parameters from `similar_users` (was `_{top_n}_{min_similarity}`) and `user_recommendations` (was `_{limit}`) cache keys
- **Align `find_similar_users` defaults**: Changed from `top_n=20, min_similarity=0.2` to `top_n=30, min_similarity=0.15` to match caller expectations
- **Cache community means**: Added 600s caching for `calculate_community_means()` results and increased percentiles TTL from 60s to 600s
- **Cache anonymous recommendations**: `get_recommendations_for_anonymous()` now caches results with key `anon_recommendations_{session_key}` for 900s
- **Use `safe_cache_delete`** instead of `safe_cache_set(key, None, 1)` for cache invalidation in `generate_recommendations_task`

## Test plan

- [x] All 159 tests pass (including 32 new cache-specific tests in `test_cache_refactor.py`)
- [ ] Verify cache invalidation works on DNA re-upload in staging
- [ ] Monitor Redis key patterns in production to confirm simplified keys
- [ ] Check anonymous recommendation response times with caching enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)