### PR TITLE
Fix email button padding and center Turnstile widgets

### DIFF
--- a/core/templates/core/password_reset_email.html
+++ b/core/templates/core/password_reset_email.html
@@ -22,10 +22,8 @@
                         <td align="center">
                             <a
                                 href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}"
-                                style="display: inline-block; background-color: #40e7aa; color: #1a1a1a; border: 2px solid #1a1a1a; padding: 14px 32px; font-size: 18px; font-weight: bold; text-transform: uppercase; text-decoration: none; font-family: 'Courier New', Courier, monospace; letter-spacing: 1px;"
-                            >
-                                Reset Password
-                            </a>
+                                style="display: inline-block; background-color: #40e7aa; color: #1a1a1a; border: 2px solid #1a1a1a; padding: 14px 40px; font-size: 18px; font-weight: bold; text-transform: uppercase; text-decoration: none; font-family: 'Courier New', Courier, monospace; letter-spacing: 1px; line-height: 1;"
+                            >Reset Password</a>
                         </td>
                     </tr>
                 </table>

--- a/core/templates/core/password_reset_form.html
+++ b/core/templates/core/password_reset_form.html
@@ -38,7 +38,9 @@
                         />
                     </div>
                     {% if TURNSTILE_SITE_KEY %}
-                        <div class="cf-turnstile" data-sitekey="{{ TURNSTILE_SITE_KEY }}" data-theme="light"></div>
+                        <div class="flex justify-center">
+                            <div class="cf-turnstile" data-sitekey="{{ TURNSTILE_SITE_KEY }}" data-theme="light"></div>
+                        </div>
                         <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
                     {% endif %}
                     {% include 'core/partials/buttons/primary_button.html' with text="Send Reset Link" %}

--- a/core/templates/core/signup.html
+++ b/core/templates/core/signup.html
@@ -89,7 +89,9 @@ account{% endblock %}
                         {% endif %}
                     {% endfor %}
                     {% if TURNSTILE_SITE_KEY %}
-                        <div class="cf-turnstile" data-sitekey="{{ TURNSTILE_SITE_KEY }}" data-theme="light"></div>
+                        <div class="flex justify-center">
+                            <div class="cf-turnstile" data-sitekey="{{ TURNSTILE_SITE_KEY }}" data-theme="light"></div>
+                        </div>
                         <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
                     {% endif %}
                     {% include 'core/partials/buttons/primary_button.html' with text="Create Account & Save Bibliotype" %}


### PR DESCRIPTION
## Summary
- Fix uneven vertical padding on the password reset email button by inlining the text content and adding `line-height: 1` (eliminates whitespace-induced gap above text)
- Increase horizontal button padding from 32px to 40px for better proportions
- Center Cloudflare Turnstile CAPTCHA widget on both the password reset form and signup page using `flex justify-center` wrapper

## Test plan
- [ ] Send a password reset email and verify the button has even vertical padding
- [ ] Check the forgot password page — Turnstile widget should be centered under the email input
- [ ] Check the signup page — Turnstile widget should be centered under the form fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)