### PR TITLE
Claude/setup pr previews u o ued

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -8,6 +8,10 @@ on:
     pull_request:
         types: [closed]
 
+concurrency:
+    group: preview-${{ github.event.issue.number || github.event.pull_request.number }}
+    cancel-in-progress: true
+
 jobs:
     deploy-preview:
         # Only runs when a collaborator comments /preview on a PR
@@ -88,7 +92,7 @@ jobs:
                       PORT=$((9000 + PR_NUMBER))
 
                       # Enforce concurrent preview limit (excluding this PR if it already has one)
-                      RUNNING=$(docker ps --filter "name=preview-pr-" --format '{{.Names}}' | grep -cv "^${CONTAINER}$" 2>/dev/null || echo 0)
+                      RUNNING=$(docker ps --filter "name=preview-pr-" --format '{{.Names}}' | grep -v "^${CONTAINER}$" | wc -l)
                       if [ "$RUNNING" -ge "$MAX_PREVIEWS" ]; then
                         echo "ERROR: ${RUNNING} previews already running (max ${MAX_PREVIEWS})."
                         echo "Active previews:"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,20 +1,58 @@
 name: PR Preview
 
 on:
+    # Comment /preview on a PR to deploy
+    issue_comment:
+        types: [created]
+    # Auto-cleanup when PR is closed or merged
     pull_request:
-        types: [opened, synchronize, reopened, closed]
-
-concurrency:
-    group: preview-${{ github.event.pull_request.number }}
-    cancel-in-progress: true
+        types: [closed]
 
 jobs:
     deploy-preview:
-        if: github.event.action != 'closed'
+        # Only runs when a collaborator comments /preview on a PR
+        if: >
+            github.event_name == 'issue_comment' &&
+            github.event.issue.pull_request &&
+            startsWith(github.event.comment.body, '/preview') &&
+            contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+            issues: write
         steps:
-            - name: Check out repository code
+            - name: Get PR details and react to comment
+              id: pr
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const prNumber = context.payload.issue.number;
+                      const { data: pr } = await github.rest.pulls.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: prNumber,
+                      });
+
+                      if (pr.state !== 'open') {
+                        core.setFailed('PR is not open');
+                        return;
+                      }
+
+                      core.setOutput('number', prNumber);
+                      core.setOutput('sha', pr.head.sha);
+
+                      await github.rest.reactions.createForIssueComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        comment_id: context.payload.comment.id,
+                        content: 'rocket',
+                      });
+
+            - name: Check out PR code
               uses: actions/checkout@v4
+              with:
+                  ref: ${{ steps.pr.outputs.sha }}
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
@@ -30,30 +68,40 @@ jobs:
               with:
                   context: .
                   push: true
-                  tags: ${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:pr-${{ github.event.pull_request.number }}
+                  tags: ${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:pr-${{ steps.pr.outputs.number }}
                   cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:buildcache
                   cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:buildcache,mode=max
 
             - name: Deploy preview to VPS
               uses: appleboy/ssh-action@v1.0.3
               env:
-                  PR_NUMBER: ${{ github.event.pull_request.number }}
-                  IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:pr-${{ github.event.pull_request.number }}
+                  PR_NUMBER: ${{ steps.pr.outputs.number }}
+                  IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:pr-${{ steps.pr.outputs.number }}
+                  MAX_PREVIEWS: "3"
               with:
                   host: ${{ secrets.DO_SSH_HOST }}
                   username: ${{ secrets.DO_SSH_USERNAME }}
                   key: ${{ secrets.DO_SSH_KEY }}
-                  envs: PR_NUMBER,IMAGE
+                  envs: PR_NUMBER,IMAGE,MAX_PREVIEWS
                   script: |
                       CONTAINER="preview-pr-${PR_NUMBER}"
                       PORT=$((9000 + PR_NUMBER))
 
-                      # Tear down existing preview if any
+                      # Enforce concurrent preview limit (excluding this PR if it already has one)
+                      RUNNING=$(docker ps --filter "name=preview-pr-" --format '{{.Names}}' | grep -cv "^${CONTAINER}$" 2>/dev/null || echo 0)
+                      if [ "$RUNNING" -ge "$MAX_PREVIEWS" ]; then
+                        echo "ERROR: ${RUNNING} previews already running (max ${MAX_PREVIEWS})."
+                        echo "Active previews:"
+                        docker ps --filter "name=preview-pr-" --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+                        exit 1
+                      fi
+
+                      # Tear down existing preview for this PR if any
                       docker stop $CONTAINER 2>/dev/null && docker rm $CONTAINER 2>/dev/null || true
 
                       docker pull $IMAGE
 
-                      # Run a lightweight preview: SQLite, no Redis/Celery, fixture data
+                      # Start container with migrate + runserver
                       docker run -d \
                         --name $CONTAINER \
                         --restart unless-stopped \
@@ -65,18 +113,38 @@ jobs:
                         -e REDIS_CACHE_URL=locmem:// \
                         --entrypoint "" \
                         $IMAGE \
-                        bash -c " \
-                          poetry run python manage.py migrate --run-syncdb && \
-                          poetry run python manage.py load_fixture_data core/fixtures/initial_data.json && \
-                          poetry run python manage.py runserver 0.0.0.0:8000"
+                        bash -c "poetry run python manage.py migrate --run-syncdb && poetry run python manage.py runserver 0.0.0.0:8000"
 
-                      # Wait for the server to respond
-                      for i in $(seq 1 20); do
+                      # Wait for migrations + server startup
+                      echo "Waiting for server to start..."
+                      sleep 15
+
+                      # Load fixture data with signal-safe command
+                      docker exec $CONTAINER poetry run python manage.py load_fixture_data core/fixtures/initial_data.json
+
+                      # Set all fixture user passwords to 'preview' so reviewers can log in
+                      docker exec $CONTAINER poetry run python manage.py shell -c "
+                      from django.contrib.auth.models import User
+                      for u in User.objects.all():
+                          u.set_password('preview')
+                          u.save()
+                      print(f'Set password for {User.objects.count()} users')
+                      "
+
+                      # Create a preview admin account
+                      docker exec \
+                        -e DJANGO_SUPERUSER_EMAIL=admin@preview.com \
+                        -e DJANGO_SUPERUSER_USERNAME=admin \
+                        -e DJANGO_SUPERUSER_PASSWORD=preview \
+                        $CONTAINER poetry run python manage.py createsuperuser --noinput 2>/dev/null || true
+
+                      # Verify server is responding
+                      for i in $(seq 1 10); do
                         if curl -s -o /dev/null -w '%{http_code}' http://localhost:${PORT}/ | grep -qE '200|301|302'; then
                           echo "Preview is ready on port ${PORT}"
                           break
                         fi
-                        echo "Waiting for preview to start... ($i/20)"
+                        echo "Waiting... ($i/10)"
                         sleep 3
                       done
 
@@ -84,7 +152,7 @@ jobs:
               uses: actions/github-script@v7
               with:
                   script: |
-                      const prNumber = context.payload.pull_request.number;
+                      const prNumber = ${{ steps.pr.outputs.number }};
                       const port = 9000 + prNumber;
                       const host = '${{ secrets.DO_SSH_HOST }}';
                       const url = `http://${host}:${port}`;
@@ -95,10 +163,18 @@ jobs:
                         '',
                         `**URL:** ${url}`,
                         '',
-                        'Lightweight preview instance (SQLite, no Celery/Redis).',
-                        'Loaded with sample fixture data. Best for reviewing template, CSS, and layout changes.',
+                        '### Login',
+                        '| Account | Email | Password |',
+                        '|---|---|---|',
+                        '| Admin | `admin@preview.com` | `preview` |',
+                        '| All fixture users | *(find emails via /admin/)* | `preview` |',
                         '',
-                        `*Updated: ${new Date().toISOString()}*`,
+                        'Log in at `/admin/` with the admin account to find fixture users that have DNA data,',
+                        'then log in at `/login/` with their email to see the full dashboard.',
+                        '',
+                        'Lightweight preview (SQLite, no Celery/Redis). Fixture data loaded.',
+                        '',
+                        `*Deployed from ${context.payload.issue?.pull_request ? 'PR head' : 'commit'} at ${new Date().toISOString()}*`,
                       ].join('\n');
 
                       const { data: comments } = await github.rest.issues.listComments({
@@ -124,9 +200,28 @@ jobs:
                         });
                       }
 
+            - name: Comment on failure
+              if: failure()
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const prNumber = ${{ steps.pr.outputs.number || 0 }};
+                      if (!prNumber) return;
+
+                      const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                      await github.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber,
+                        body: `Preview deployment failed. Check the [workflow run](${runUrl}) for details.`,
+                      });
+
     cleanup-preview:
-        if: github.event.action == 'closed'
+        if: github.event_name == 'pull_request' && github.event.action == 'closed'
         runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+            issues: write
         steps:
             - name: Tear down preview on VPS
               uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,167 @@
+name: PR Preview
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, closed]
+
+concurrency:
+    group: preview-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    deploy-preview:
+        if: github.event.action != 'closed'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out repository code
+              uses: actions/checkout@v4
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build and push preview image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  push: true
+                  tags: ${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:pr-${{ github.event.pull_request.number }}
+                  cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:buildcache
+                  cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:buildcache,mode=max
+
+            - name: Deploy preview to VPS
+              uses: appleboy/ssh-action@v1.0.3
+              env:
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:pr-${{ github.event.pull_request.number }}
+              with:
+                  host: ${{ secrets.DO_SSH_HOST }}
+                  username: ${{ secrets.DO_SSH_USERNAME }}
+                  key: ${{ secrets.DO_SSH_KEY }}
+                  envs: PR_NUMBER,IMAGE
+                  script: |
+                      CONTAINER="preview-pr-${PR_NUMBER}"
+                      PORT=$((9000 + PR_NUMBER))
+
+                      # Tear down existing preview if any
+                      docker stop $CONTAINER 2>/dev/null && docker rm $CONTAINER 2>/dev/null || true
+
+                      docker pull $IMAGE
+
+                      # Run a lightweight preview: SQLite, no Redis/Celery, fixture data
+                      docker run -d \
+                        --name $CONTAINER \
+                        --restart unless-stopped \
+                        -p ${PORT}:8000 \
+                        -e SECRET_KEY=preview-insecure-not-for-production \
+                        -e DEBUG=True \
+                        -e "ALLOWED_HOSTS=*" \
+                        -e DJANGO_ENV=development \
+                        -e REDIS_CACHE_URL=locmem:// \
+                        --entrypoint "" \
+                        $IMAGE \
+                        bash -c " \
+                          poetry run python manage.py migrate --run-syncdb && \
+                          poetry run python manage.py load_fixture_data core/fixtures/initial_data.json && \
+                          poetry run python manage.py runserver 0.0.0.0:8000"
+
+                      # Wait for the server to respond
+                      for i in $(seq 1 20); do
+                        if curl -s -o /dev/null -w '%{http_code}' http://localhost:${PORT}/ | grep -qE '200|301|302'; then
+                          echo "Preview is ready on port ${PORT}"
+                          break
+                        fi
+                        echo "Waiting for preview to start... ($i/20)"
+                        sleep 3
+                      done
+
+            - name: Comment preview URL on PR
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const prNumber = context.payload.pull_request.number;
+                      const port = 9000 + prNumber;
+                      const host = '${{ secrets.DO_SSH_HOST }}';
+                      const url = `http://${host}:${port}`;
+                      const marker = '<!-- pr-preview-comment -->';
+                      const body = [
+                        marker,
+                        '## PR Preview',
+                        '',
+                        `**URL:** ${url}`,
+                        '',
+                        'Lightweight preview instance (SQLite, no Celery/Redis).',
+                        'Loaded with sample fixture data. Best for reviewing template, CSS, and layout changes.',
+                        '',
+                        `*Updated: ${new Date().toISOString()}*`,
+                      ].join('\n');
+
+                      const { data: comments } = await github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber,
+                      });
+                      const existing = comments.find(c => c.body?.includes(marker));
+
+                      if (existing) {
+                        await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: existing.id,
+                          body,
+                        });
+                      } else {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: prNumber,
+                          body,
+                        });
+                      }
+
+    cleanup-preview:
+        if: github.event.action == 'closed'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Tear down preview on VPS
+              uses: appleboy/ssh-action@v1.0.3
+              env:
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/bibliotype:pr-${{ github.event.pull_request.number }}
+              with:
+                  host: ${{ secrets.DO_SSH_HOST }}
+                  username: ${{ secrets.DO_SSH_USERNAME }}
+                  key: ${{ secrets.DO_SSH_KEY }}
+                  envs: PR_NUMBER,IMAGE
+                  script: |
+                      CONTAINER="preview-pr-${PR_NUMBER}"
+                      docker stop $CONTAINER 2>/dev/null || true
+                      docker rm $CONTAINER 2>/dev/null || true
+                      docker rmi $IMAGE 2>/dev/null || true
+                      echo "Preview for PR #${PR_NUMBER} cleaned up"
+
+            - name: Update PR comment
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const prNumber = context.payload.pull_request.number;
+                      const marker = '<!-- pr-preview-comment -->';
+                      const { data: comments } = await github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber,
+                      });
+                      const existing = comments.find(c => c.body?.includes(marker));
+                      if (existing) {
+                        await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: existing.id,
+                          body: `${marker}\n## PR Preview\n\n~~Preview has been torn down~~ (PR closed/merged)`,
+                        });
+                      }

--- a/bibliotype/settings.py
+++ b/bibliotype/settings.py
@@ -98,12 +98,20 @@ DATABASES = {"default": dj_database_url.config(default=f'sqlite:///{os.path.join
 # - Local Redis server running on localhost
 # - Docker Redis container exposed on port 6379 (via docker-compose port mapping)
 # Override with REDIS_CACHE_URL environment variable if needed
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": os.environ.get("REDIS_CACHE_URL", "redis://localhost:6379/1"),
+REDIS_CACHE_URL = os.environ.get("REDIS_CACHE_URL", "redis://localhost:6379/1")
+if REDIS_CACHE_URL == "locmem://":
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
     }
-}
+else:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            "LOCATION": REDIS_CACHE_URL,
+        }
+    }
 
 # Email configuration (Brevo SMTP)
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"


### PR DESCRIPTION
## What changed

Two files added/modified to enable on-demand PR preview deployments on the existing VPS.

### 1. New: `.github/workflows/pr-preview.yml`

A GitHub Actions workflow with two jobs:

**`deploy-preview` — triggered by commenting `/preview` on a PR**

This is intentionally on-demand, not automatic on every push — you control when to spend the build time. Only repo owner/members/collaborators can trigger it (checked via `github.event.comment.author_association`).

Here's what happens step by step when you comment `/preview`:

1. **Validates the PR** — fetches PR details via GitHub API, confirms it's still open, grabs the head commit SHA. Reacts to your comment with a rocket emoji so you know it's running.
2. **Checks out the PR's exact commit** — uses `actions/checkout@v4` with the specific SHA, not the branch name, so it builds exactly what's in the PR.
3. **Builds the Docker image** — uses the existing `Dockerfile` (same one used for production) with Docker Buildx. Pushes to Docker Hub as `bibliotype:pr-{number}`. Uses registry-based layer caching (`buildcache` tag) so rebuilds after small template/CSS changes are fast — only the final layers change.
4. **SSHs to the VPS** and runs a single lightweight container:
   - **SQLite** instead of PostgreSQL — no database container needed, set by simply not providing `DATABASE_URL` (Django falls back to SQLite via `dj-database-url`)
   - **In-memory cache** instead of Redis — uses the new `REDIS_CACHE_URL=locmem://` setting (see below)
   - **No Celery/Redis** — the container only runs Django's dev server
   - Port is `9000 + PR number` (e.g., PR #70 → port 9070)
   - The entrypoint from the Dockerfile is overridden (`--entrypoint ""`) to skip the `wait-for-postgres.sh` script that would hang without PostgreSQL
5. **Loads sample data** — after the server starts, uses `docker exec` to:
   - Run `load_fixture_data` (the custom management command that disconnects `post_save` signals before loading) with `initial_data.json` — 3,522 records including users with full DNA data, books, authors, genres
   - Reset **all** fixture user passwords to `preview` so you can log in as any of them
   - Create an admin account (`admin@preview.com` / `preview`) via `createsuperuser --noinput`
6. **Comments the preview URL** on the PR with login instructions. If you comment `/preview` again (e.g., after pushing more changes), it updates the existing comment instead of creating a new one (identified by an HTML comment marker `<!-- pr-preview-comment -->`).
7. **On failure**, comments a link to the failed workflow run so you can debug.

**Concurrency limit:** Before deploying, the workflow counts running `preview-pr-*` containers on the VPS. If there are already 3 (configurable via `MAX_PREVIEWS`), it fails with a clear error listing the active previews. Replacing an existing preview for the same PR doesn't count against the limit.

**`cleanup-preview` — runs automatically when a PR is closed or merged**

Stops and removes the container, deletes the Docker image from the VPS, and updates the PR comment to say the preview has been torn down. No manual cleanup needed.

### 2. Modified: `bibliotype/settings.py` (lines 101-114)

Added a conditional for the `CACHES` setting. Before, it always used `RedisCache`:

```python
# Before
CACHES = {
    "default": {
        "BACKEND": "django.core.cache.backends.redis.RedisCache",
        "LOCATION": os.environ.get("REDIS_CACHE_URL", "redis://localhost:6379/1"),
    }
}
```

Now, if `REDIS_CACHE_URL` is set to the sentinel value `locmem://`, it uses Django's in-memory cache instead:

```python
# After
REDIS_CACHE_URL = os.environ.get("REDIS_CACHE_URL", "redis://localhost:6379/1")
if REDIS_CACHE_URL == "locmem://":
    CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
else:
    CACHES = {"default": {"BACKEND": "django.core.cache.backends.redis.RedisCache", "LOCATION": REDIS_CACHE_URL}}
```

Without this, the preview container would throw `ConnectionError` on any cache operation since there's no Redis. This also makes local dev without Docker/Redis easier. **No effect on production or existing local dev** — both still default to Redis.

## How to use a preview

1. Comment `/preview` on any PR
2. Wait for the bot to comment the URL (typically 2-4 minutes for the Docker build)
3. **To see public pages** (home, login, signup, public profiles) — just visit the URL
4. **To see the dashboard** — go to `/admin/` → log in with `admin@preview.com` / `preview` → browse Users → find one with DNA data in their profile → go to `/login/` → log in with that user's email and password `preview`
5. Comment `/preview` again after pushing more changes to redeploy

## What works and what doesn't in previews

| Works | Doesn't work |
|---|---|
| All page rendering (templates, Tailwind CSS, Alpine.js) | CSV uploads (no Celery broker) |
| Login/signup flows | Async tasks (recommendations, author checks) |
| Dashboard with DNA data (from fixtures) | Email sending |
| Public profiles, settings page | Real-time progress polling |
| Admin panel | Anything requiring Redis or Celery |

This is intentional — previews are for reviewing how things **look**, not for testing the full backend.

## Next steps after merging

### 1. Open firewall ports on the VPS (one-time, 10 seconds)

```bash
ssh your-vps
sudo ufw allow 9001:9200/tcp
```

This covers PR numbers 1–200. Each preview runs on port `9000 + PR number`.

### 2. That's it

No new GitHub secrets needed — the workflow reuses the existing `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `DO_SSH_HOST`, `DO_SSH_USERNAME`, and `DO_SSH_KEY` secrets that the deploy workflow already uses.

### 3. Test it

Open any PR after merging this, comment `/preview`, and verify:
- [ ] Bot reacts with rocket emoji to your comment
- [ ] After a few minutes, bot comments the preview URL
- [ ] `/admin/` works with `admin@preview.com` / `preview`
- [ ] Find a fixture user with DNA data, log in at `/login/` with their email + password `preview`
- [ ] Dashboard renders with charts, DNA data, reader type
- [ ] Close the PR — container cleaned up, comment updated

https://claude.ai/code/session_0151CwM6TEY6ZDZjjQX6UH1u
