### PR TITLE
Fix broken font in share card images on mobile

### DIFF
--- a/core/templates/core/partials/share/share_modal.html
+++ b/core/templates/core/partials/share/share_modal.html
@@ -137,6 +137,37 @@
 </style>
 
 <script>
+    var _cachedFontEmbedCSS = null;
+
+    async function getEmbeddedFontCSS() {
+        if (_cachedFontEmbedCSS) return _cachedFontEmbedCSS;
+
+        try {
+            const cssResponse = await fetch("https://fonts.googleapis.com/css2?family=VT323&display=swap");
+            let css = await cssResponse.text();
+
+            const urlRegex = /url\((https:\/\/fonts\.gstatic\.com[^)]+)\)/g;
+            const matches = [...css.matchAll(urlRegex)];
+
+            for (const match of matches) {
+                const fontResponse = await fetch(match[1]);
+                const fontBlob = await fontResponse.blob();
+                const base64 = await new Promise((resolve) => {
+                    const reader = new FileReader();
+                    reader.onload = () => resolve(reader.result);
+                    reader.readAsDataURL(fontBlob);
+                });
+                css = css.replace(match[0], `url(${base64})`);
+            }
+
+            _cachedFontEmbedCSS = css;
+            return css;
+        } catch (e) {
+            console.error("Failed to embed font:", e);
+            return null;
+        }
+    }
+
     function shareModalData() {
         return {
             shareModalOpen: false,
@@ -149,11 +180,15 @@
                 }
 
                 await document.fonts.ready;
+                const fontEmbedCSS = await getEmbeddedFontCSS();
 
                 try {
-                    const blob = await htmlToImage.toBlob(cardEl, {
-                        pixelRatio: 2,
-                    });
+                    const options = { pixelRatio: 2 };
+                    if (fontEmbedCSS) {
+                        options.fontEmbedCSS = fontEmbedCSS;
+                    }
+
+                    const blob = await htmlToImage.toBlob(cardEl, options);
 
                     if (!blob) return;
 


### PR DESCRIPTION
## Summary
- Share card images on mobile were rendering with a system sans-serif font instead of VT323, breaking spacing on all cards
- `html-to-image` serializes DOM to SVG which can't resolve external Google Fonts references
- Now fetches the VT323 font, converts to base64, and passes it inline via `fontEmbedCSS` so the font is embedded directly in the generated image
- Font data is cached per page load so subsequent shares are instant

## Test plan
- [ ] Open dashboard on mobile, tap Share, generate an image — VT323 font should render correctly
- [ ] Verify all 7 share card variants render with correct font
- [ ] Verify desktop share still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)