### PR TITLE
Update currently-reading and mainstream meter subtitles

### DIFF
--- a/core/templates/core/partials/dna/currently_reading_card.html
+++ b/core/templates/core/partials/dna/currently_reading_card.html
@@ -2,12 +2,7 @@
     <div class="border-brand-text shadow-neo border-2 bg-white p-6">
         <h2 class="mb-1 text-2xl font-bold uppercase">Currently Reading</h2>
         <p class="mb-4 text-base text-gray-500 italic">
-            We found {{ dna.currently_reading_count }} book{{ dna.currently_reading_count|pluralize }}
-            {{ pronoun_sub|default:"you're" }}
-            currently
-            reading{% if dna.custom_shelf_count %}
-                , and {{ dna.custom_shelf_count }} on custom shelves
-            {% endif %}
+            We found {{ dna.currently_reading_count }} book{{ dna.currently_reading_count|pluralize }} on {{ pronoun_pos|default:"your" }} currently-reading shelf — here are the most recent
         </p>
         {% if dna.currently_reading_books %}
             <div

--- a/core/templates/core/partials/dna/mainstream_gauge_card.html
+++ b/core/templates/core/partials/dna/mainstream_gauge_card.html
@@ -1,6 +1,6 @@
 <div class="border-brand-text shadow-neo border-2 bg-white p-6">
     <h2 class="mb-1 text-center text-2xl font-bold uppercase">Mainstream Meter</h2>
-    <p class="mb-4 text-center text-base italic text-gray-500">How mainstream is {{ pronoun_pos|default:"your" }} taste?</p>
+    <p class="mb-4 text-center text-base italic text-gray-500">How mainstream the books in {{ pronoun_pos|default:"your" }} library are</p>
     <!-- Alpine.js component for the gauge logic -->
     {# djlint:off #}
     <div x-data="{


### PR DESCRIPTION
## Summary
- **Currently reading:** changed to "We found X books on your currently-reading shelf — here are the most recent"
- **Mainstream meter:** replaced "How mainstream is your taste?" with "How mainstream the books in your library are" to match the declarative style of all other card subtitles

## Test plan
- [ ] Check currently-reading card subtitle on own profile and public profiles
- [ ] Check mainstream meter subtitle on own profile and public profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)