### PR TITLE
Center title and subtitle on niche read card

### DIFF
--- a/core/templates/core/partials/dna/niche_read_card.html
+++ b/core/templates/core/partials/dna/niche_read_card.html
@@ -1,9 +1,9 @@
 <div class="border-brand-text shadow-neo border-2 bg-white p-6">
-    <h2 class="mb-1 text-2xl font-bold uppercase">Most Niche Read</h2>
+    <h2 class="mb-1 text-center text-2xl font-bold uppercase">Most Niche Read</h2>
     {% if dna.niche_books_count %}
-        <p class="mb-4 text-base italic text-gray-500">We found {{ dna.niche_books_count }} book{{ dna.niche_books_count|pluralize }} in {{ pronoun_pos|default:"your" }} library read by {{ dna.niche_threshold }} or fewer people</p>
+        <p class="mb-4 text-center text-base italic text-gray-500">We found {{ dna.niche_books_count }} book{{ dna.niche_books_count|pluralize }} in {{ pronoun_pos|default:"your" }} library read by {{ dna.niche_threshold }} or fewer people</p>
     {% elif dna.most_niche_book %}
-        <p class="mb-4 text-base italic text-gray-500">{{ pronoun_pos|default:"Your"|capfirst }} rarest find on Bibliotype — read by only {{ dna.most_niche_book.read_count }} people</p>
+        <p class="mb-4 text-center text-base italic text-gray-500">{{ pronoun_pos|default:"Your"|capfirst }} rarest find on Bibliotype — read by only {{ dna.most_niche_book.read_count }} people</p>
     {% endif %}
     {% if dna.most_niche_book %}
         <div class="flex flex-1 flex-col items-center justify-center" x-data="{ imgFailed: false }">


### PR DESCRIPTION
## Summary
- Added `text-center` to the h2 and subtitle on the Most Niche Read card to match the Mainstream Meter card's centered layout

## Test plan
- [ ] Verify niche read card title and subtitle are centered on dashboard and public profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)