### PR TITLE
Poll for recommendations after fresh CSV upload

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -186,6 +186,35 @@
 
                 {% if recommendations %}
                     {% include 'core/partials/dna/recommendations_grid.html' with is_public_view=False %}
+                {% elif recommendations_pending %}
+                    {# djlint:off #}
+                    <div
+                        class="border-brand-text shadow-neo border-2 bg-white p-6"
+                        x-data="{
+                            init() {
+                                this.poll();
+                            },
+                            poll() {
+                                const interval = setInterval(async () => {
+                                    try {
+                                        const res = await fetch('{% url "core:api_check_recommendations_status" %}');
+                                        const data = await res.json();
+                                        if (data.status === 'ready') {
+                                            clearInterval(interval);
+                                            window.location.reload();
+                                        }
+                                    } catch (e) {}
+                                }, 3000);
+                            }
+                        }"
+                        x-init="init()"
+                    >
+                    {# djlint:on #}
+                        <h2 class="mb-4 text-2xl font-bold uppercase">Recommended for You</h2>
+                        <p class="text-lg opacity-70">
+                            Generating your recommendations<span x-data="{ dots: '' }" x-init="setInterval(() => dots = dots.length >= 3 ? '' : dots + '.', 500)" x-text="dots"></span>
+                        </p>
+                    </div>
                 {% else %}
                     <div class="border-brand-text shadow-neo border-2 bg-white p-6">
                         <h2 class="mb-4 text-2xl font-bold uppercase">Recommended for You</h2>

--- a/core/urls.py
+++ b/core/urls.py
@@ -29,4 +29,5 @@ urlpatterns = [
     path("task/<str:task_id>/", views.task_status_view, name="task_status"),
     path("api/task-result/<str:task_id>/", views.get_task_result_view, name="get_task_result"),
     path("api/dna-status/", views.check_dna_status_view, name="api_check_dna_status"),
+    path("api/recommendations-status/", views.check_recommendations_status_view, name="api_check_recommendations_status"),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -533,12 +533,21 @@ def display_dna_view(request):
     if request.user.is_authenticated and user_profile:
         recommendations_meta = user_profile.recommendations_meta or {}
 
+    # Flag to tell the template to poll for recommendations
+    recommendations_pending = (
+        request.user.is_authenticated
+        and user_profile
+        and user_profile.dna_data
+        and not recommendations
+    )
+
     context = {
         "dna": dna_data,
         "user_profile": user_profile,
         "is_processing": False,
         "recommendations": recommendations,
         "recommendations_meta": recommendations_meta,
+        "recommendations_pending": recommendations_pending,
         "title": title,
     }
 
@@ -844,6 +853,17 @@ def check_dna_status_view(request):
         return JsonResponse({"status": "SUCCESS"})
     else:
         return JsonResponse({"status": "PENDING"})
+
+
+@login_required
+def check_recommendations_status_view(request):
+    """AJAX endpoint to check if recommendations have been generated."""
+    profile = request.user.userprofile
+    profile.refresh_from_db()
+
+    if profile.recommendations_data:
+        return JsonResponse({"status": "ready"})
+    return JsonResponse({"status": "pending"})
 
 
 def public_profile_view(request, username):


### PR DESCRIPTION
## Summary
- After uploading a CSV, recommendations are generated asynchronously and weren't ready when the dashboard first loaded — showing "No recommended books yet" until manual reload
- Added `/api/recommendations-status/` endpoint that checks if `recommendations_data` is populated
- Dashboard now shows "Generating your recommendations..." with animated dots and polls every 3s, auto-reloading when ready
- The static "No recommended books yet" fallback still shows for users who genuinely have no recommendations

## Test plan
- [ ] Upload a CSV, verify "Generating your recommendations..." appears and the page auto-reloads when they're ready
- [ ] Verify existing dashboards with recommendations still render normally
- [ ] Verify the "No recommended books yet" fallback still shows for users without recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)