### PR TITLE
Fix shared books count exceeding user's actual library size

### DIFF
--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -452,6 +452,14 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
         if user and results:
             from ..models import UserBook
 
+            # Collect current book IDs from this upload
+            current_book_ids = {book.id for book, genres, original_row in results if book}
+
+            # Delete stale UserBook records from previous uploads that are no longer in the CSV
+            stale_count, _ = UserBook.objects.filter(user=user).exclude(book_id__in=current_book_ids).delete()
+            if stale_count:
+                logger.info(f"Removed {stale_count} stale UserBook records for user {user.id}")
+
             # Store book data with ratings and reviews - now we have the original row
             for book, genres, original_row in results:
                 if book:


### PR DESCRIPTION
## Summary
- When re-uploading a CSV, old `UserBook` records from previous uploads were never deleted
- The similarity engine uses `UserBook` records to compute shared books, so stale records inflated the count (e.g. "You share 88 books in common" when the user only has 77 books)
- Now deletes `UserBook` records for books no longer in the uploaded CSV before creating/updating new ones
- Existing users will get corrected data on their next re-upload

## Test plan
- [ ] Upload a CSV, note book count in DNA stats
- [ ] Check recommendations — shared books count should never exceed your total books
- [ ] Re-upload with a smaller CSV — stale records should be cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)