### PR TITLE
Generate recommendations inline during DNA task

### DIFF
--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -164,12 +164,17 @@ def _save_dna_to_profile(profile, dna_data):
         safe_cache_delete(f"similar_users_{profile.user.id}")
         safe_cache_delete(f"user_recommendations_{profile.user.id}")
 
-        # Trigger async recommendation generation
-        # Import here to avoid circular imports
+        # Generate recommendations inline — the caller is already in an async task,
+        # so there's no benefit to spawning another. This ensures recommendations
+        # are ready when the dashboard loads.
         from ..tasks import generate_recommendations_task
 
-        generate_recommendations_task.delay(profile.user.id)
-        logger.info(f"Triggered recommendation generation task for user {profile.user.username}")
+        try:
+            generate_recommendations_task(profile.user.id)
+            logger.info(f"Generated recommendations inline for user {profile.user.username}")
+        except Exception as e:
+            logger.error(f"Inline recommendation generation failed for {profile.user.username}: {e}", exc_info=True)
+            # Non-fatal — dashboard will show pending state and the view will retry
 
     except Exception as e:
         logger.error(f"Error saving profile for user {profile.user.username}: {e}")

--- a/core/tests/test_cache_refactor.py
+++ b/core/tests/test_cache_refactor.py
@@ -253,14 +253,12 @@ class SaveDnaInvalidationTests(TestCase):
 
     @patch("core.tasks.generate_recommendations_task")
     def test_save_dna_triggers_recommendation_generation(self, mock_rec_task):
-        mock_rec_task.delay = MagicMock()
-
         from core.services.dna_analyser import _save_dna_to_profile
 
         dna = {"reader_type": "Test", "user_stats": {}, "reading_vibe": [], "vibe_data_hash": "h"}
         _save_dna_to_profile(self.user.userprofile, dna)
 
-        mock_rec_task.delay.assert_called_once_with(self.user.id)
+        mock_rec_task.assert_called_once_with(self.user.id)
 
 
 @override_settings(


### PR DESCRIPTION
## Summary
- Recommendations were fired as a separate Celery task via `.delay()` after DNA was saved
- This caused a race: the dashboard loaded before recommendations were ready, showing a "Generating..." placeholder
- Since the caller (`generate_reading_dna_task`) is already an async Celery task, there's no benefit to spawning another — the user is already waiting on the progress spinner
- Now runs `generate_recommendations_task()` synchronously (direct call, not `.delay()`) at the end of the DNA pipeline
- If recommendation generation fails, it's caught and logged — the dashboard falls back to the polling mechanism from PR #83

## Test plan
- [x] All 230 tests pass
- [ ] Upload a CSV — recommendations should be visible immediately when the dashboard loads (no "Generating..." state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)