### PR TITLE
Prevent content overflow on full share cards

### DIFF
--- a/core/templates/core/partials/share/card_full_miami.html
+++ b/core/templates/core/partials/share/card_full_miami.html
@@ -1,6 +1,6 @@
 {% load humanize %}
 <div class="flex h-[568px] w-[320px] flex-col justify-between border-2 border-brand-text bg-brand-purple p-5">
-    <div>
+    <div class="min-h-0 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
         <div class="mt-3 border-2 border-brand-text bg-brand-cyan p-2.5 text-center shadow-neo-sm">
             <p class="text-xs uppercase">My Reader Type is...</p>

--- a/core/templates/core/partials/share/card_full_neon_picnic.html
+++ b/core/templates/core/partials/share/card_full_neon_picnic.html
@@ -1,6 +1,6 @@
 {% load humanize %}
 <div class="flex h-[568px] w-[320px] flex-col justify-between border-2 border-brand-text bg-brand-purple p-5">
-    <div>
+    <div class="min-h-0 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
         <div class="mt-3 border-2 border-brand-text bg-brand-green p-2.5 text-center shadow-neo-sm">
             <p class="text-xs uppercase">My Reader Type is...</p>

--- a/core/templates/core/partials/share/card_full_sherbet.html
+++ b/core/templates/core/partials/share/card_full_sherbet.html
@@ -1,6 +1,6 @@
 {% load humanize %}
 <div class="flex h-[568px] w-[320px] flex-col justify-between border-2 border-brand-text bg-brand-purple p-5">
-    <div>
+    <div class="min-h-0 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
         <div class="mt-3 border-2 border-brand-text bg-brand-pink p-2.5 text-center shadow-neo-sm">
             <p class="text-xs uppercase">My Reader Type is...</p>


### PR DESCRIPTION
## Summary
- When reader types at the bottom of full share cards wrap to a second line, content overflowed the fixed 568px height and cut off the footer URL
- Added `min-h-0 overflow-hidden` to the content div on all 3 full card variants (sherbet, neon picnic, miami vice) so the content shrinks within the flex container and the footer stays visible

## Test plan
- [ ] Check all 3 full share card variants with reader types that wrap (e.g. "Small Press Supporter" + "Fantasy Fanatic" + "Novella Navigator")
- [ ] Verify footer URL is always visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)