### PR TITLE
Add fiction/nonfiction split and book extremes cards

### DIFF
--- a/core/dna_constants.py
+++ b/core/dna_constants.py
@@ -1556,6 +1556,7 @@ FICTION_GENRES = {
     "comics & graphic novels",
     "holiday fiction",
     "fairy tales & fables",
+    "plays & drama",
 }
 
 NONFICTION_GENRES = {
@@ -1571,7 +1572,6 @@ NONFICTION_GENRES = {
     "travel",
     "art & music",
     "food & cooking",
-    "plays & drama",
     "religion & spirituality",
 }
 

--- a/core/dna_constants.py
+++ b/core/dna_constants.py
@@ -1539,3 +1539,42 @@ for canonical, aliases in GENRE_ALIASES.items():
     CANONICAL_GENRE_MAP[canonical] = canonical
     for alias in aliases:
         CANONICAL_GENRE_MAP[alias] = canonical
+
+FICTION_GENRES = {
+    "fantasy",
+    "science fiction",
+    "thriller",
+    "horror",
+    "historical fiction",
+    "romance",
+    "humorous fiction",
+    "young adult",
+    "children's literature",
+    "classics",
+    "mythology & folklore",
+    "short stories",
+    "comics & graphic novels",
+    "holiday fiction",
+    "fairy tales & fables",
+}
+
+NONFICTION_GENRES = {
+    "non-fiction",
+    "biography",
+    "history",
+    "psychology",
+    "philosophy",
+    "social science",
+    "nature",
+    "self-help",
+    "science",
+    "travel",
+    "art & music",
+    "food & cooking",
+    "plays & drama",
+    "religion & spirituality",
+}
+
+_all_canonical = set(GENRE_ALIASES.keys())
+_classified = FICTION_GENRES | NONFICTION_GENRES
+assert _classified == _all_canonical, f"Unclassified genres: {_all_canonical - _classified}"

--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -18,8 +18,10 @@ from core.services.llm_service import generate_vibe_with_llm
 
 from ..dna_constants import (
     CANONICAL_GENRE_MAP,
+    FICTION_GENRES,
     GLOBAL_AVERAGES,
     NICHE_THRESHOLD,
+    NONFICTION_GENRES,
     READER_TYPE_DESCRIPTIONS,
     compute_contrariness,
 )
@@ -410,10 +412,18 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                     if progress_cb:
                         progress_cb(processed, total_books, "Syncing books")
 
+        fiction_count = 0
+        nonfiction_count = 0
+
         for book, genres, original_row in results:
             if book:
                 user_book_objects.append(book)
                 all_raw_genres.extend(genres)
+                canonical = {CANONICAL_GENRE_MAP.get(g, g) for g in genres}
+                if canonical & FICTION_GENRES:
+                    fiction_count += 1
+                elif canonical & NONFICTION_GENRES:
+                    nonfiction_count += 1
 
         # Sync currently-reading books to DB (Book/Author only, no UserBook, no global_read_count)
         if currently_reading_books:
@@ -594,6 +604,27 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
             }
             niche_books_count = sum(1 for b in user_book_objects if b.global_read_count <= NICHE_THRESHOLD)
 
+        longest_book = None
+        shortest_book = None
+        books_with_pages = [b for b in user_book_objects if b.page_count]
+        if len(books_with_pages) >= 2:
+            books_with_pages.sort(key=lambda b: (-b.page_count, b.normalized_title))
+            longest = books_with_pages[0]
+            longest_book = {
+                "title": longest.title,
+                "author": longest.author.name,
+                "page_count": longest.page_count,
+                "cover_url": _build_cover_url(longest.isbn13),
+            }
+            books_with_pages.sort(key=lambda b: (b.page_count, b.normalized_title))
+            shortest = books_with_pages[0]
+            shortest_book = {
+                "title": shortest.title,
+                "author": shortest.author.name,
+                "page_count": shortest.page_count,
+                "cover_url": _build_cover_url(shortest.isbn13),
+            }
+
         top_authors = list(read_df["Author"].value_counts().head(10).items())
         unique_authors_count = int(read_df["Author"].nunique())
         unique_genres_count = len(set(mapped_genres))
@@ -766,6 +797,13 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
             "currently_reading_books": currently_reading_books,
             "currently_reading_count": currently_reading_count,
             "custom_shelf_count": custom_shelf_count,
+            "fiction_nonfiction_split": (
+                {"fiction_count": fiction_count, "nonfiction_count": nonfiction_count}
+                if (fiction_count + nonfiction_count) > 0
+                else None
+            ),
+            "longest_book": longest_book,
+            "shortest_book": shortest_book,
         }
         logger.debug(f"DNA data generated")
 

--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -606,24 +606,26 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
 
         longest_book = None
         shortest_book = None
+        page_difference = None
         books_with_pages = [b for b in user_book_objects if b.page_count]
         if len(books_with_pages) >= 2:
             books_with_pages.sort(key=lambda b: (-b.page_count, b.normalized_title))
             longest = books_with_pages[0]
-            longest_book = {
-                "title": longest.title,
-                "author": longest.author.name,
-                "page_count": longest.page_count,
-                "cover_url": _build_cover_url(longest.isbn13),
-            }
-            books_with_pages.sort(key=lambda b: (b.page_count, b.normalized_title))
-            shortest = books_with_pages[0]
-            shortest_book = {
-                "title": shortest.title,
-                "author": shortest.author.name,
-                "page_count": shortest.page_count,
-                "cover_url": _build_cover_url(shortest.isbn13),
-            }
+            shortest = books_with_pages[-1]
+            if longest.page_count != shortest.page_count:
+                longest_book = {
+                    "title": longest.title,
+                    "author": longest.author.name,
+                    "page_count": longest.page_count,
+                    "cover_url": _build_cover_url(longest.isbn13),
+                }
+                shortest_book = {
+                    "title": shortest.title,
+                    "author": shortest.author.name,
+                    "page_count": shortest.page_count,
+                    "cover_url": _build_cover_url(shortest.isbn13),
+                }
+                page_difference = longest.page_count - shortest.page_count
 
         top_authors = list(read_df["Author"].value_counts().head(10).items())
         unique_authors_count = int(read_df["Author"].nunique())
@@ -804,6 +806,7 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
             ),
             "longest_book": longest_book,
             "shortest_book": shortest_book,
+            "page_difference": page_difference,
         }
         logger.debug(f"DNA data generated")
 

--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -419,6 +419,8 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
             if book:
                 user_book_objects.append(book)
                 all_raw_genres.extend(genres)
+                # Fiction-first: books with any fiction genre are counted as fiction,
+                # even if they also carry nonfiction genres (e.g. historical fiction).
                 canonical = {CANONICAL_GENRE_MAP.get(g, g) for g in genres}
                 if canonical & FICTION_GENRES:
                     fiction_count += 1

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -328,6 +328,7 @@
                                 entries.forEach((entry) => {
                                     if (entry.isIntersecting) {
                                         entry.target.classList.add("is-visible");
+                                        entry.target.querySelectorAll(".scroll-fade-left, .scroll-fade-up").forEach((el) => el.classList.add("is-visible"));
                                         observer.unobserve(entry.target);
                                     }
                                 });

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -185,7 +185,7 @@
                 {% include 'core/partials/dna/review_analysis_card.html' %}
 
                 {% if dna.fiction_nonfiction_split or dna.longest_book %}
-                    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+                    <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
                         {% if dna.fiction_nonfiction_split %}
                             {% include 'core/partials/dna/fiction_nonfiction_card.html' %}
                         {% endif %}

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -23,7 +23,11 @@
 {% block content %}
     <div class="mx-auto h-full max-w-4xl space-y-6 p-2">
         {% if is_processing %}
-            <div id="processing-container" class="flex flex-col items-center p-4 py-12 md:py-24" x-data="{ status: 'PENDING' }">
+            <div
+                id="processing-container"
+                class="flex flex-col items-center p-4 py-12 md:py-24"
+                x-data="{ status: 'PENDING' }"
+            >
                 <div class="w-full max-w-2xl text-center" x-show="status !== 'FAILURE'">
                     {% include 'core/partials/cycling_messages.html' %}
                     <p class="mb-8 text-lg text-gray-600">
@@ -149,30 +153,28 @@
             </script>
         {% elif dna %}
             <div x-data="shareModalData()" class="space-y-6">
-            {{ dna|json_script:"dna-data" }}
-            <h1 class="mb-4 text-center text-5xl font-bold tracking-widest uppercase md:mb-8">
-                <span class="relative z-10">
-                    {% if user.is_authenticated %}
-                        {% include 'core/partials/username_editor.html' %}
-                    {% else %}
-                        Your Bibliotype
-                    {% endif %}
-                </span>
-            </h1>
+                {{ dna|json_script:"dna-data" }}
+                <h1 class="mb-4 text-center text-5xl font-bold tracking-widest uppercase md:mb-8">
+                    <span class="relative z-10">
+                        {% if user.is_authenticated %}
+                            {% include 'core/partials/username_editor.html' %}
+                        {% else %}
+                            Your Bibliotype
+                        {% endif %}
+                    </span>
+                </h1>
 
-            {% include 'core/partials/dna/vibe_display.html' %}
-            {% include 'core/partials/dna/reader_type_card.html' %}
-
-            {% include 'core/partials/share/share_button.html' %}
-            {% if user.is_authenticated %}
-                {% include 'core/partials/share/share_modal.html' with share_url="bibliotype.app/u/"|add:user.username %}
-            {% else %}
-                {% include 'core/partials/share/share_modal.html' with share_url="bibliotype.app" %}
-            {% endif %}
-
-            {% include 'core/partials/dna/top_traits_list.html' %}
-            {% include 'core/partials/dna/key_stats_row.html' %}
-            {% include 'core/partials/dna/comparative_analytics_card.html' %}
+                {% include 'core/partials/dna/vibe_display.html' %}
+                {% include 'core/partials/dna/reader_type_card.html' %}
+                {% include 'core/partials/share/share_button.html' %}
+                {% if user.is_authenticated %}
+                    {% include 'core/partials/share/share_modal.html' with share_url="bibliotype.app/u/"|add:user.username %}
+                {% else %}
+                    {% include 'core/partials/share/share_modal.html' with share_url="bibliotype.app" %}
+                {% endif %}
+                {% include 'core/partials/dna/top_traits_list.html' %}
+                {% include 'core/partials/dna/key_stats_row.html' %}
+                {% include 'core/partials/dna/comparative_analytics_card.html' %}
 
                 <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
                     {% include 'core/partials/dna/niche_read_card.html' %}
@@ -181,6 +183,17 @@
 
                 {% include 'core/partials/dna/top_genres_authors_row.html' with use_rainbow=True %}
                 {% include 'core/partials/dna/review_analysis_card.html' %}
+
+                {% if dna.fiction_nonfiction_split or dna.longest_book %}
+                    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+                        {% if dna.fiction_nonfiction_split %}
+                            {% include 'core/partials/dna/fiction_nonfiction_card.html' %}
+                        {% endif %}
+                        {% if dna.longest_book %}
+                            {% include 'core/partials/dna/book_extremes_card.html' %}
+                        {% endif %}
+                    </div>
+                {% endif %}
                 {% include 'core/partials/dna/controversial_ratings_card.html' %}
                 {% include 'core/partials/dna/currently_reading_card.html' %}
 
@@ -209,10 +222,14 @@
                         }"
                         x-init="init()"
                     >
-                    {# djlint:on #}
+                        {# djlint:on #}
                         <h2 class="mb-4 text-2xl font-bold uppercase">Recommended for You</h2>
                         <p class="text-lg opacity-70">
-                            Generating your recommendations<span x-data="{ dots: '' }" x-init="setInterval(() => dots = dots.length >= 3 ? '' : dots + '.', 500)" x-text="dots"></span>
+                            Generating your recommendations<span
+                                x-data="{ dots: '' }"
+                                x-init="setInterval(() => dots = dots.length >= 3 ? '' : dots + '.', 500)"
+                                x-text="dots"
+                            ></span>
                         </p>
                     </div>
                 {% else %}
@@ -287,51 +304,51 @@
                         </p>
                     </div>
                 {% endif %}
-            {% include 'core/partials/dna/charts_scripts.html' %}
-            <style>
-                .fade-in-section {
-                    opacity: 0;
-                    transform: translateY(6px);
-                    transition: opacity 0.45s ease-out, transform 0.45s ease-out;
-                }
-                .fade-in-section.is-visible {
-                    opacity: 1;
-                    transform: translateY(0);
-                }
-            </style>
-            <script>
-                document.addEventListener("DOMContentLoaded", function () {
-                    const container = document.querySelector('[x-data="shareModalData()"]');
-                    if (!container) return;
-                    const sections = container.querySelectorAll(":scope > *");
-                    const observer = new IntersectionObserver(
-                        (entries) => {
-                            entries.forEach((entry) => {
-                                if (entry.isIntersecting) {
-                                    entry.target.classList.add("is-visible");
-                                    observer.unobserve(entry.target);
-                                }
-                            });
-                        },
-                        { threshold: 0.05 }
-                    );
-                    sections.forEach((s) => {
-                        if (s.tagName === "SCRIPT" || s.tagName === "STYLE") return;
-                        const rect = s.getBoundingClientRect();
-                        if (rect.top < window.innerHeight) return;
-                        s.classList.add("fade-in-section");
-                        observer.observe(s);
+                {% include 'core/partials/dna/charts_scripts.html' %}
+                <style>
+                    .fade-in-section {
+                        opacity: 0;
+                        transform: translateY(6px);
+                        transition:
+                            opacity 0.45s ease-out,
+                            transform 0.45s ease-out;
+                    }
+                    .fade-in-section.is-visible {
+                        opacity: 1;
+                        transform: translateY(0);
+                    }
+                </style>
+                <script>
+                    document.addEventListener("DOMContentLoaded", function () {
+                        const container = document.querySelector('[x-data="shareModalData()"]');
+                        if (!container) return;
+                        const sections = container.querySelectorAll(":scope > *");
+                        const observer = new IntersectionObserver(
+                            (entries) => {
+                                entries.forEach((entry) => {
+                                    if (entry.isIntersecting) {
+                                        entry.target.classList.add("is-visible");
+                                        observer.unobserve(entry.target);
+                                    }
+                                });
+                            },
+                            { threshold: 0.05 },
+                        );
+                        sections.forEach((s) => {
+                            if (s.tagName === "SCRIPT" || s.tagName === "STYLE") return;
+                            const rect = s.getBoundingClientRect();
+                            if (rect.top < window.innerHeight) return;
+                            s.classList.add("fade-in-section");
+                            observer.observe(s);
+                        });
                     });
-                });
-            </script>
+                </script>
             </div>
         {% else %}
             <div class="flex h-full flex-col p-4">
                 <div class="w-full">
                     <h1 class="mb-4 text-center text-5xl font-bold tracking-widest uppercase md:mb-8">
-                        <span class="relative z-10">
-                            {% include 'core/partials/username_editor.html' %}
-                        </span>
+                        <span class="relative z-10"> {% include 'core/partials/username_editor.html' %} </span>
                     </h1>
                 </div>
                 <div class="flex flex-grow items-center justify-center">

--- a/core/templates/core/partials/dna/book_extremes_card.html
+++ b/core/templates/core/partials/dna/book_extremes_card.html
@@ -1,0 +1,88 @@
+<div class="border-brand-text shadow-neo border-2 bg-white p-6">
+    <h2 class="mb-4 text-center text-2xl font-bold uppercase">Book Extremes</h2>
+    <div class="flex flex-col gap-6">
+        {% if dna.longest_book %}
+            <div class="flex items-center gap-4">
+                <div class="shrink-0" x-data="{ imgFailed: false }">
+                    {% if dna.longest_book.cover_url %}
+                        <div x-show="!imgFailed" class="border-brand-text h-40 w-[6.75rem] overflow-hidden border-2">
+                            <img
+                                src="{{ dna.longest_book.cover_url }}"
+                                alt="Cover of {{ dna.longest_book.title }}"
+                                class="h-full w-full object-cover"
+                                loading="lazy"
+                                x-on:error="imgFailed = true"
+                                x-on:load="if ($el.naturalWidth < 10) imgFailed = true"
+                            />
+                        </div>
+                        <div
+                            x-show="imgFailed"
+                            x-cloak
+                            class="bg-brand-orange border-brand-text flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
+                        >
+                            {{ dna.longest_book.title|first|upper }}
+                        </div>
+                    {% else %}
+                        <div
+                            class="bg-brand-orange border-brand-text flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
+                        >
+                            {{ dna.longest_book.title|first|upper }}
+                        </div>
+                    {% endif %}
+                </div>
+                <div class="min-w-0 flex-1">
+                    <span
+                        class="bg-brand-orange border-brand-text mb-2 inline-block border-2 px-2 py-0.5 text-sm font-bold uppercase"
+                    >
+                        Longest
+                    </span>
+                    <p class="truncate text-xl font-bold">{{ dna.longest_book.title }}</p>
+                    <p class="truncate text-lg text-gray-600">by {{ dna.longest_book.author }}</p>
+                    <p class="text-lg font-bold">{{ dna.longest_book.page_count }} pages</p>
+                </div>
+            </div>
+        {% endif %}
+
+        {% if dna.shortest_book %}
+            <div class="flex items-center gap-4">
+                <div class="shrink-0" x-data="{ imgFailed: false }">
+                    {% if dna.shortest_book.cover_url %}
+                        <div x-show="!imgFailed" class="border-brand-text h-40 w-[6.75rem] overflow-hidden border-2">
+                            <img
+                                src="{{ dna.shortest_book.cover_url }}"
+                                alt="Cover of {{ dna.shortest_book.title }}"
+                                class="h-full w-full object-cover"
+                                loading="lazy"
+                                x-on:error="imgFailed = true"
+                                x-on:load="if ($el.naturalWidth < 10) imgFailed = true"
+                            />
+                        </div>
+                        <div
+                            x-show="imgFailed"
+                            x-cloak
+                            class="bg-brand-green border-brand-text flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
+                        >
+                            {{ dna.shortest_book.title|first|upper }}
+                        </div>
+                    {% else %}
+                        <div
+                            class="bg-brand-green border-brand-text flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
+                        >
+                            {{ dna.shortest_book.title|first|upper }}
+                        </div>
+                    {% endif %}
+                </div>
+                <div class="min-w-0 flex-1">
+                    <span
+                        class="bg-brand-green border-brand-text mb-2 inline-block border-2 px-2 py-0.5 text-sm font-bold uppercase"
+                    >
+                        Shortest
+                    </span>
+                    <p class="truncate text-xl font-bold">{{ dna.shortest_book.title }}</p>
+                    <p class="truncate text-lg text-gray-600">by {{ dna.shortest_book.author }}</p>
+                    <p class="text-lg font-bold">{{ dna.shortest_book.page_count }} pages</p>
+                </div>
+            </div>
+        {% endif %}
+    </div>
+</div>

--- a/core/templates/core/partials/dna/book_extremes_card.html
+++ b/core/templates/core/partials/dna/book_extremes_card.html
@@ -1,14 +1,14 @@
 <div class="border-brand-text shadow-neo border-2 bg-white p-6">
     <h2 class="mb-1 text-center text-2xl font-bold uppercase">Book Extremes</h2>
     <p class="mb-4 text-center text-base text-gray-500 italic">
-        A {{ dna.page_difference }}-page difference between your longest and shortest reads
-    </p>
+        A {{ dna.page_difference }}-page difference between {{ pronoun_pos|default:"your" }} longest and shortest reads
+    </p></invoke>
     <div class="flex flex-col gap-6">
         {% if dna.longest_book %}
             <div class="flex items-start gap-4">
                 <div class="shrink-0" x-data="{ imgFailed: false }">
                     {% if dna.longest_book.cover_url %}
-                        <div x-show="!imgFailed" class="border-brand-text h-40 w-[6.75rem] overflow-hidden border-2">
+                        <div x-show="!imgFailed" class="border-brand-text shadow-neo-sm h-40 w-[6.75rem] overflow-hidden border-2">
                             <img
                                 src="{{ dna.longest_book.cover_url }}"
                                 alt="Cover of {{ dna.longest_book.title }}"
@@ -21,13 +21,13 @@
                         <div
                             x-show="imgFailed"
                             x-cloak
-                            class="bg-brand-orange border-brand-text flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
+                            class="bg-brand-orange border-brand-text shadow-neo-sm flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
                         >
                             {{ dna.longest_book.title|first|upper }}
                         </div>
                     {% else %}
                         <div
-                            class="bg-brand-orange border-brand-text flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
+                            class="bg-brand-orange border-brand-text shadow-neo-sm flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
                         >
                             {{ dna.longest_book.title|first|upper }}
                         </div>
@@ -50,7 +50,7 @@
             <div class="flex items-start gap-4">
                 <div class="shrink-0" x-data="{ imgFailed: false }">
                     {% if dna.shortest_book.cover_url %}
-                        <div x-show="!imgFailed" class="border-brand-text h-40 w-[6.75rem] overflow-hidden border-2">
+                        <div x-show="!imgFailed" class="border-brand-text shadow-neo-sm h-40 w-[6.75rem] overflow-hidden border-2">
                             <img
                                 src="{{ dna.shortest_book.cover_url }}"
                                 alt="Cover of {{ dna.shortest_book.title }}"
@@ -63,13 +63,13 @@
                         <div
                             x-show="imgFailed"
                             x-cloak
-                            class="bg-brand-green border-brand-text flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
+                            class="bg-brand-green border-brand-text shadow-neo-sm flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
                         >
                             {{ dna.shortest_book.title|first|upper }}
                         </div>
                     {% else %}
                         <div
-                            class="bg-brand-green border-brand-text flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
+                            class="bg-brand-green border-brand-text shadow-neo-sm flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
                         >
                             {{ dna.shortest_book.title|first|upper }}
                         </div>

--- a/core/templates/core/partials/dna/book_extremes_card.html
+++ b/core/templates/core/partials/dna/book_extremes_card.html
@@ -6,7 +6,7 @@
     <div class="flex flex-col gap-6">
         {% if dna.longest_book %}
             <div class="flex items-start gap-4">
-                <div class="shrink-0" x-data="{ imgFailed: false }">
+                <div class="scroll-fade-left shrink-0" x-data="{ imgFailed: false }">
                     {% if dna.longest_book.cover_url %}
                         <div x-show="!imgFailed" class="border-brand-text shadow-neo-sm h-40 w-[6.75rem] overflow-hidden border-2">
                             <img
@@ -48,7 +48,7 @@
 
         {% if dna.shortest_book %}
             <div class="flex items-start gap-4">
-                <div class="shrink-0" x-data="{ imgFailed: false }">
+                <div class="scroll-fade-left shrink-0" x-data="{ imgFailed: false }">
                     {% if dna.shortest_book.cover_url %}
                         <div x-show="!imgFailed" class="border-brand-text shadow-neo-sm h-40 w-[6.75rem] overflow-hidden border-2">
                             <img

--- a/core/templates/core/partials/dna/book_extremes_card.html
+++ b/core/templates/core/partials/dna/book_extremes_card.html
@@ -1,8 +1,11 @@
 <div class="border-brand-text shadow-neo border-2 bg-white p-6">
-    <h2 class="mb-4 text-center text-2xl font-bold uppercase">Book Extremes</h2>
+    <h2 class="mb-1 text-center text-2xl font-bold uppercase">Book Extremes</h2>
+    <p class="mb-4 text-center text-base text-gray-500 italic">
+        A {{ dna.page_difference }}-page difference between your longest and shortest reads
+    </p>
     <div class="flex flex-col gap-6">
         {% if dna.longest_book %}
-            <div class="flex items-center gap-4">
+            <div class="flex items-start gap-4">
                 <div class="shrink-0" x-data="{ imgFailed: false }">
                     {% if dna.longest_book.cover_url %}
                         <div x-show="!imgFailed" class="border-brand-text h-40 w-[6.75rem] overflow-hidden border-2">
@@ -36,7 +39,7 @@
                     >
                         Longest
                     </span>
-                    <p class="truncate text-xl font-bold">{{ dna.longest_book.title }}</p>
+                    <p class="line-clamp-2 text-xl font-bold">{{ dna.longest_book.title }}</p>
                     <p class="truncate text-lg text-gray-600">by {{ dna.longest_book.author }}</p>
                     <p class="text-lg font-bold">{{ dna.longest_book.page_count }} pages</p>
                 </div>
@@ -44,7 +47,7 @@
         {% endif %}
 
         {% if dna.shortest_book %}
-            <div class="flex items-center gap-4">
+            <div class="flex items-start gap-4">
                 <div class="shrink-0" x-data="{ imgFailed: false }">
                     {% if dna.shortest_book.cover_url %}
                         <div x-show="!imgFailed" class="border-brand-text h-40 w-[6.75rem] overflow-hidden border-2">
@@ -78,7 +81,7 @@
                     >
                         Shortest
                     </span>
-                    <p class="truncate text-xl font-bold">{{ dna.shortest_book.title }}</p>
+                    <p class="line-clamp-2 text-xl font-bold">{{ dna.shortest_book.title }}</p>
                     <p class="truncate text-lg text-gray-600">by {{ dna.shortest_book.author }}</p>
                     <p class="text-lg font-bold">{{ dna.shortest_book.page_count }} pages</p>
                 </div>

--- a/core/templates/core/partials/dna/book_extremes_card.html
+++ b/core/templates/core/partials/dna/book_extremes_card.html
@@ -13,7 +13,7 @@
                                 src="{{ dna.longest_book.cover_url }}"
                                 alt="Cover of {{ dna.longest_book.title }}"
                                 class="h-full w-full object-cover"
-                                loading="lazy"
+
                                 x-on:error="imgFailed = true"
                                 x-on:load="if ($el.naturalWidth < 10) imgFailed = true"
                             />
@@ -55,7 +55,7 @@
                                 src="{{ dna.shortest_book.cover_url }}"
                                 alt="Cover of {{ dna.shortest_book.title }}"
                                 class="h-full w-full object-cover"
-                                loading="lazy"
+
                                 x-on:error="imgFailed = true"
                                 x-on:load="if ($el.naturalWidth < 10) imgFailed = true"
                             />

--- a/core/templates/core/partials/dna/charts_scripts.html
+++ b/core/templates/core/partials/dna/charts_scripts.html
@@ -166,13 +166,18 @@
                             data: [split.fiction_count, split.nonfiction_count],
                             backgroundColor: ["#ffb4dd", "#8bbfff"],
                             borderColor: "#1f2937",
-                            borderWidth: 2,
+                            borderWidth: 3,
                         },
                     ],
                 },
                 options: {
                     responsive: true,
                     maintainAspectRatio: false,
+                    animation: {
+                        animateRotate: true,
+                        duration: 1200,
+                        easing: "easeOutQuart",
+                    },
                     plugins: {
                         legend: { display: false },
                         tooltip: {

--- a/core/templates/core/partials/dna/charts_scripts.html
+++ b/core/templates/core/partials/dna/charts_scripts.html
@@ -67,130 +67,194 @@
             return { labels: [], values: [] };
         }
 
-        // --- Top Genres Chart ---
-        const topGenresCtx = document.getElementById("topGenresChart")?.getContext("2d");
-        if (topGenresCtx && dnaData.top_genres) {
-            const { labels: genreLabels, values: genreValues } = parseChartData(dnaData.top_genres);
+        // --- Helper: create chart on scroll into view ---
+        function createChartOnScroll(canvasId, createFn) {
+            const canvas = document.getElementById(canvasId);
+            if (!canvas) return;
+            const wrapper = canvas.closest(".chart-await");
+            const observer = new IntersectionObserver((entries) => {
+                if (entries[0].isIntersecting) {
+                    observer.unobserve(canvas);
+                    if (wrapper) {
+                        wrapper.classList.remove("chart-await");
+                        wrapper.classList.add("chart-visible");
+                    }
+                    createFn(canvas.getContext("2d"));
+                }
+            }, { threshold: 0.3 });
+            observer.observe(canvas);
+        }
 
-            new Chart(topGenresCtx, {
-                type: "doughnut",
-                data: {
-                    labels: genreLabels,
-                    datasets: [
-                        {
-                            label: "Genres",
-                            data: genreValues,
-                            backgroundColor: chartColors,
-                            borderColor: "#1f2937",
-                            borderWidth: 2,
+        // --- Top Genres Chart ---
+        if (dnaData.top_genres) {
+            const { labels: genreLabels, values: genreValues } = parseChartData(dnaData.top_genres);
+            createChartOnScroll("topGenresChart", (ctx) => {
+                new Chart(ctx, {
+                    type: "doughnut",
+                    data: {
+                        labels: genreLabels,
+                        datasets: [
+                            {
+                                label: "Genres",
+                                data: genreValues,
+                                backgroundColor: chartColors,
+                                borderColor: "#1f2937",
+                                borderWidth: 4,
+                            },
+                        ],
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: {
+                            animateRotate: true,
+                            animateScale: true,
+                            duration: 1400,
+                            easing: "easeOutQuart",
                         },
-                    ],
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                        legend: { display: false },
-                        tooltip: {
-                            callbacks: {
-                                label: function (context) {
-                                    let label = context.label || "";
-                                    if (label) {
-                                        label += ": ";
-                                    }
-                                    if (context.parsed !== null) {
-                                        label += context.parsed;
-                                    }
-                                    return label;
+                        plugins: {
+                            legend: { display: false },
+                            tooltip: {
+                                callbacks: {
+                                    label: function (context) {
+                                        let label = context.label || "";
+                                        if (label) label += ": ";
+                                        if (context.parsed !== null) label += context.parsed;
+                                        return label;
+                                    },
                                 },
                             },
                         },
                     },
-                },
+                });
             });
         }
 
         // --- Top Authors Chart ---
-        const topAuthorsCtx = document.getElementById("topAuthorsChart")?.getContext("2d");
-        if (topAuthorsCtx && dnaData.top_authors) {
+        if (dnaData.top_authors) {
             const { labels: authorLabels, values: authorValues } = parseChartData(dnaData.top_authors);
-
-            new Chart(topAuthorsCtx, {
-                type: "doughnut",
-                data: {
-                    labels: authorLabels,
-                    datasets: [
-                        {
-                            label: "Authors",
-                            data: authorValues,
-                            backgroundColor: chartColors,
-                            borderColor: "#1f2937",
-                            borderWidth: 2,
+            createChartOnScroll("topAuthorsChart", (ctx) => {
+                new Chart(ctx, {
+                    type: "doughnut",
+                    data: {
+                        labels: authorLabels,
+                        datasets: [
+                            {
+                                label: "Authors",
+                                data: authorValues,
+                                backgroundColor: chartColors,
+                                borderColor: "#1f2937",
+                                borderWidth: 4,
+                            },
+                        ],
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: {
+                            animateRotate: true,
+                            animateScale: true,
+                            duration: 1400,
+                            easing: "easeOutQuart",
                         },
-                    ],
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                        legend: { display: false },
-                        tooltip: {
-                            callbacks: {
-                                label: function (context) {
-                                    let label = context.label || "";
-                                    if (label) {
-                                        label += ": ";
-                                    }
-                                    if (context.parsed !== null) {
-                                        label += context.parsed;
-                                    }
-                                    return label;
+                        plugins: {
+                            legend: { display: false },
+                            tooltip: {
+                                callbacks: {
+                                    label: function (context) {
+                                        let label = context.label || "";
+                                        if (label) label += ": ";
+                                        if (context.parsed !== null) label += context.parsed;
+                                        return label;
+                                    },
                                 },
                             },
                         },
                     },
-                },
+                });
             });
         }
 
         // --- Fiction vs Nonfiction Chart ---
-        const fictionCtx = document.getElementById("fictionNonfictionChart")?.getContext("2d");
-        if (fictionCtx && dnaData.fiction_nonfiction_split) {
-            const split = dnaData.fiction_nonfiction_split;
-            new Chart(fictionCtx, {
-                type: "pie",
-                data: {
-                    labels: ["Fiction", "Nonfiction"],
-                    datasets: [
-                        {
-                            data: [split.fiction_count, split.nonfiction_count],
-                            backgroundColor: ["#ffb4dd", "#8bbfff"],
-                            borderColor: "#1f2937",
-                            borderWidth: 3,
-                        },
-                    ],
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    animation: {
-                        animateRotate: true,
-                        duration: 1200,
-                        easing: "easeOutQuart",
+        if (dnaData.fiction_nonfiction_split) {
+            createChartOnScroll("fictionNonfictionChart", (ctx) => {
+                // Diagonal stripe pattern for fiction segment
+                const stripeSize = 24;
+                const stripeCanvas = document.createElement("canvas");
+                stripeCanvas.width = stripeSize;
+                stripeCanvas.height = stripeSize;
+                const sCtx = stripeCanvas.getContext("2d");
+                sCtx.fillStyle = "#ffb4dd";
+                sCtx.fillRect(0, 0, stripeSize, stripeSize);
+                sCtx.strokeStyle = "#ffcce8";
+                sCtx.lineWidth = 10;
+                sCtx.beginPath();
+                sCtx.moveTo(0, stripeSize);
+                sCtx.lineTo(stripeSize, 0);
+                sCtx.moveTo(-stripeSize / 2, stripeSize / 2);
+                sCtx.lineTo(stripeSize / 2, -stripeSize / 2);
+                sCtx.moveTo(stripeSize / 2, stripeSize * 1.5);
+                sCtx.lineTo(stripeSize * 1.5, stripeSize / 2);
+                sCtx.stroke();
+                const fictionPattern = ctx.createPattern(stripeCanvas, "repeat");
+
+                // Stripe pattern for nonfiction segment (same orientation as fiction)
+                const nfStripeCanvas = document.createElement("canvas");
+                nfStripeCanvas.width = stripeSize;
+                nfStripeCanvas.height = stripeSize;
+                const nfCtx = nfStripeCanvas.getContext("2d");
+                nfCtx.fillStyle = "#8bbfff";
+                nfCtx.fillRect(0, 0, stripeSize, stripeSize);
+                nfCtx.strokeStyle = "#b0d4ff";
+                nfCtx.lineWidth = 10;
+                nfCtx.beginPath();
+                nfCtx.moveTo(0, stripeSize);
+                nfCtx.lineTo(stripeSize, 0);
+                nfCtx.moveTo(-stripeSize / 2, stripeSize / 2);
+                nfCtx.lineTo(stripeSize / 2, -stripeSize / 2);
+                nfCtx.moveTo(stripeSize / 2, stripeSize * 1.5);
+                nfCtx.lineTo(stripeSize * 1.5, stripeSize / 2);
+                nfCtx.stroke();
+                const nonfictionPattern = ctx.createPattern(nfStripeCanvas, "repeat");
+
+                const split = dnaData.fiction_nonfiction_split;
+                new Chart(ctx, {
+                    type: "pie",
+                    data: {
+                        labels: ["Fiction", "Nonfiction"],
+                        datasets: [
+                            {
+                                data: [split.fiction_count, split.nonfiction_count],
+                                backgroundColor: [fictionPattern, nonfictionPattern],
+                                borderColor: "#1f2937",
+                                borderWidth: 5,
+                            },
+                        ],
                     },
-                    plugins: {
-                        legend: { display: false },
-                        tooltip: {
-                            callbacks: {
-                                label: function (context) {
-                                    const total = split.fiction_count + split.nonfiction_count;
-                                    const pct = Math.round((context.parsed / total) * 100);
-                                    return context.label + ": " + pct + "%";
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: {
+                            animateRotate: true,
+                            animateScale: true,
+                            duration: 1400,
+                            easing: "easeOutQuart",
+                        },
+                        animations: { colors: false },
+                        plugins: {
+                            legend: { display: false },
+                            tooltip: {
+                                callbacks: {
+                                    label: function (context) {
+                                        const total = split.fiction_count + split.nonfiction_count;
+                                        const pct = Math.round((context.parsed / total) * 100);
+                                        return context.label + ": " + pct + "%";
+                                    },
                                 },
                             },
                         },
                     },
-                },
+                });
             });
         }
     });

--- a/core/templates/core/partials/dna/charts_scripts.html
+++ b/core/templates/core/partials/dna/charts_scripts.html
@@ -260,4 +260,19 @@
     });
 
     window.addEventListener("resize", updateVibeSeparators);
+
+    // --- Scroll-triggered fade-in animations ---
+    document.addEventListener("DOMContentLoaded", function () {
+        const scrollEls = document.querySelectorAll(".scroll-fade-left, .scroll-fade-up");
+        if (!scrollEls.length) return;
+        const obs = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add("is-visible");
+                    obs.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.2 });
+        scrollEls.forEach((el) => obs.observe(el));
+    });
 </script>

--- a/core/templates/core/partials/dna/charts_scripts.html
+++ b/core/templates/core/partials/dna/charts_scripts.html
@@ -28,29 +28,40 @@
 
     document.addEventListener("DOMContentLoaded", function () {
         updateVibeSeparators();
-        
+
         const dnaDataScript = document.getElementById("dna-data");
         if (!dnaDataScript) return;
-        
+
         const dnaData = JSON.parse(dnaDataScript.textContent);
 
         Chart.defaults.font.family = "VT323";
         Chart.defaults.font.size = 16;
         Chart.defaults.color = "#1f2937";
 
-        const chartColors = ['#ffb4dd', '#40e7aa', '#ffa75e', '#8bbfff', '#FFE9CE', '#ff647c', '#ffe56c', '#A1CDF1', '#9af6d4', '#fe9393'];
+        const chartColors = [
+            "#ffb4dd",
+            "#40e7aa",
+            "#ffa75e",
+            "#8bbfff",
+            "#FFE9CE",
+            "#ff647c",
+            "#ffe56c",
+            "#A1CDF1",
+            "#9af6d4",
+            "#fe9393",
+        ];
 
         // --- Helper to parse data (Array of tuples vs Object) ---
         function parseChartData(data) {
             if (Array.isArray(data)) {
                 return {
-                    labels: data.map(item => item[0]),
-                    values: data.map(item => item[1])
+                    labels: data.map((item) => item[0]),
+                    values: data.map((item) => item[1]),
                 };
-            } else if (typeof data === 'object' && data !== null) {
+            } else if (typeof data === "object" && data !== null) {
                 return {
                     labels: Object.keys(data),
-                    values: Object.values(data)
+                    values: Object.values(data),
                 };
             }
             return { labels: [], values: [] };
@@ -60,7 +71,7 @@
         const topGenresCtx = document.getElementById("topGenresChart")?.getContext("2d");
         if (topGenresCtx && dnaData.top_genres) {
             const { labels: genreLabels, values: genreValues } = parseChartData(dnaData.top_genres);
-            
+
             new Chart(topGenresCtx, {
                 type: "doughnut",
                 data: {
@@ -70,7 +81,7 @@
                             label: "Genres",
                             data: genreValues,
                             backgroundColor: chartColors,
-                            borderColor: '#1f2937', 
+                            borderColor: "#1f2937",
                             borderWidth: 2,
                         },
                     ],
@@ -113,7 +124,7 @@
                             label: "Authors",
                             data: authorValues,
                             backgroundColor: chartColors,
-                            borderColor: '#1f2937',
+                            borderColor: "#1f2937",
                             borderWidth: 2,
                         },
                     ],
@@ -141,8 +152,43 @@
                 },
             });
         }
+
+        // --- Fiction vs Nonfiction Chart ---
+        const fictionCtx = document.getElementById("fictionNonfictionChart")?.getContext("2d");
+        if (fictionCtx && dnaData.fiction_nonfiction_split) {
+            const split = dnaData.fiction_nonfiction_split;
+            new Chart(fictionCtx, {
+                type: "pie",
+                data: {
+                    labels: ["Fiction", "Nonfiction"],
+                    datasets: [
+                        {
+                            data: [split.fiction_count, split.nonfiction_count],
+                            backgroundColor: ["#ffb4dd", "#8bbfff"],
+                            borderColor: "#1f2937",
+                            borderWidth: 2,
+                        },
+                    ],
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: function (context) {
+                                    const total = split.fiction_count + split.nonfiction_count;
+                                    const pct = Math.round((context.parsed / total) * 100);
+                                    return context.label + ": " + pct + "%";
+                                },
+                            },
+                        },
+                    },
+                },
+            });
+        }
     });
 
     window.addEventListener("resize", updateVibeSeparators);
 </script>
-

--- a/core/templates/core/partials/dna/charts_scripts.html
+++ b/core/templates/core/partials/dna/charts_scripts.html
@@ -175,47 +175,33 @@
             });
         }
 
+        // --- Helper: create diagonal stripe pattern ---
+        function createStripePattern(ctx, fillColor, strokeColor) {
+            const size = 24;
+            const c = document.createElement("canvas");
+            c.width = size;
+            c.height = size;
+            const s = c.getContext("2d");
+            s.fillStyle = fillColor;
+            s.fillRect(0, 0, size, size);
+            s.strokeStyle = strokeColor;
+            s.lineWidth = 10;
+            s.beginPath();
+            s.moveTo(0, size);
+            s.lineTo(size, 0);
+            s.moveTo(-size / 2, size / 2);
+            s.lineTo(size / 2, -size / 2);
+            s.moveTo(size / 2, size * 1.5);
+            s.lineTo(size * 1.5, size / 2);
+            s.stroke();
+            return ctx.createPattern(c, "repeat");
+        }
+
         // --- Fiction vs Nonfiction Chart ---
         if (dnaData.fiction_nonfiction_split) {
             createChartOnScroll("fictionNonfictionChart", (ctx) => {
-                // Diagonal stripe pattern for fiction segment
-                const stripeSize = 24;
-                const stripeCanvas = document.createElement("canvas");
-                stripeCanvas.width = stripeSize;
-                stripeCanvas.height = stripeSize;
-                const sCtx = stripeCanvas.getContext("2d");
-                sCtx.fillStyle = "#ffb4dd";
-                sCtx.fillRect(0, 0, stripeSize, stripeSize);
-                sCtx.strokeStyle = "#ffcce8";
-                sCtx.lineWidth = 10;
-                sCtx.beginPath();
-                sCtx.moveTo(0, stripeSize);
-                sCtx.lineTo(stripeSize, 0);
-                sCtx.moveTo(-stripeSize / 2, stripeSize / 2);
-                sCtx.lineTo(stripeSize / 2, -stripeSize / 2);
-                sCtx.moveTo(stripeSize / 2, stripeSize * 1.5);
-                sCtx.lineTo(stripeSize * 1.5, stripeSize / 2);
-                sCtx.stroke();
-                const fictionPattern = ctx.createPattern(stripeCanvas, "repeat");
-
-                // Stripe pattern for nonfiction segment (same orientation as fiction)
-                const nfStripeCanvas = document.createElement("canvas");
-                nfStripeCanvas.width = stripeSize;
-                nfStripeCanvas.height = stripeSize;
-                const nfCtx = nfStripeCanvas.getContext("2d");
-                nfCtx.fillStyle = "#8bbfff";
-                nfCtx.fillRect(0, 0, stripeSize, stripeSize);
-                nfCtx.strokeStyle = "#b0d4ff";
-                nfCtx.lineWidth = 10;
-                nfCtx.beginPath();
-                nfCtx.moveTo(0, stripeSize);
-                nfCtx.lineTo(stripeSize, 0);
-                nfCtx.moveTo(-stripeSize / 2, stripeSize / 2);
-                nfCtx.lineTo(stripeSize / 2, -stripeSize / 2);
-                nfCtx.moveTo(stripeSize / 2, stripeSize * 1.5);
-                nfCtx.lineTo(stripeSize * 1.5, stripeSize / 2);
-                nfCtx.stroke();
-                const nonfictionPattern = ctx.createPattern(nfStripeCanvas, "repeat");
+                const fictionPattern = createStripePattern(ctx, "#ffb4dd", "#ffcce8");
+                const nonfictionPattern = createStripePattern(ctx, "#8bbfff", "#b0d4ff");
 
                 const split = dnaData.fiction_nonfiction_split;
                 new Chart(ctx, {

--- a/core/templates/core/partials/dna/currently_reading_card.html
+++ b/core/templates/core/partials/dna/currently_reading_card.html
@@ -9,7 +9,7 @@
                 class="flex gap-6 overflow-x-auto pb-2 md:grid {% if dna.currently_reading_books|length == 1 %}md:max-w-[10rem] md:mx-auto md:grid-cols-1{% elif dna.currently_reading_books|length == 2 %}md:max-w-sm md:mx-auto md:grid-cols-2{% else %}md:grid-cols-3{% endif %} md:overflow-x-visible md:pb-0"
             >
                 {% for book in dna.currently_reading_books %}
-                    <div class="flex w-32 shrink-0 flex-col items-center text-center md:w-auto md:shrink" x-data="{ imgFailed: false }">
+                    <div class="scroll-fade-up flex w-32 shrink-0 flex-col items-center text-center md:w-auto md:shrink" style="transition-delay: {{ forloop.counter0 }}50ms" x-data="{ imgFailed: false }">
                         {% if book.cover_url %}
                             <div
                                 x-show="!imgFailed"

--- a/core/templates/core/partials/dna/currently_reading_card.html
+++ b/core/templates/core/partials/dna/currently_reading_card.html
@@ -13,7 +13,7 @@
                         {% if book.cover_url %}
                             <div
                                 x-show="!imgFailed"
-                                class="border-brand-text h-44 w-32 shrink-0 overflow-hidden border-2 md:mx-auto md:h-64 md:w-[10rem]"
+                                class="border-brand-text shadow-neo-sm h-44 w-32 shrink-0 overflow-hidden border-2 md:mx-auto md:h-64 md:w-[10rem]"
                             >
                                 <img
                                     src="{{ book.cover_url }}"
@@ -27,7 +27,7 @@
                         {% endif %}
                         <div
                             {% if book.cover_url %}x-show="imgFailed" x-cloak{% endif %}
-                            class="{% if forloop.counter0 == 0 %}bg-brand-pink{% elif forloop.counter0 == 1 %}bg-brand-cyan{% else %}bg-brand-green{% endif %} border-brand-text flex h-44 w-32 shrink-0 items-center justify-center border-2 text-4xl font-bold md:mx-auto md:h-64 md:w-[10rem]"
+                            class="{% if forloop.counter0 == 0 %}bg-brand-pink{% elif forloop.counter0 == 1 %}bg-brand-cyan{% else %}bg-brand-green{% endif %} border-brand-text shadow-neo-sm flex h-44 w-32 shrink-0 items-center justify-center border-2 text-4xl font-bold md:mx-auto md:h-64 md:w-[10rem]"
                         >
                             {{ book.title|first|upper }}
                         </div>

--- a/core/templates/core/partials/dna/currently_reading_card.html
+++ b/core/templates/core/partials/dna/currently_reading_card.html
@@ -19,7 +19,7 @@
                                     src="{{ book.cover_url }}"
                                     alt="Cover of {{ book.title }}"
                                     class="h-full w-full object-cover"
-                                    loading="lazy"
+
                                     x-on:error="imgFailed = true"
                                     x-on:load="if ($el.naturalWidth < 10) imgFailed = true"
                                 />

--- a/core/templates/core/partials/dna/currently_reading_card.html
+++ b/core/templates/core/partials/dna/currently_reading_card.html
@@ -1,5 +1,5 @@
 {% if dna.currently_reading_count %}
-    <div class="border-brand-text shadow-neo border-2 bg-white p-6">
+    <div class="border-brand-text shadow-neo overflow-y-clip border-2 bg-white p-6">
         <h2 class="mb-1 text-2xl font-bold uppercase">Currently Reading</h2>
         <p class="mb-4 text-base text-gray-500 italic">
             We found {{ dna.currently_reading_count }} book{{ dna.currently_reading_count|pluralize }} on {{ pronoun_pos|default:"your" }} currently-reading shelf — here are the most recent

--- a/core/templates/core/partials/dna/fiction_nonfiction_card.html
+++ b/core/templates/core/partials/dna/fiction_nonfiction_card.html
@@ -1,22 +1,24 @@
-<div class="border-brand-text shadow-neo flex flex-col justify-center border-2 bg-white p-6">
+<div class="border-brand-text shadow-neo flex flex-col border-2 bg-white p-6">
     <h2 class="mb-1 text-center text-2xl font-bold uppercase">Fiction vs Nonfiction</h2>
     <p class="mb-4 text-center text-base text-gray-500 italic">
         How your library splits between fiction and nonfiction
     </p>
-    <div class="mx-auto" style="height: 180px; max-width: 180px">
-        <canvas id="fictionNonfictionChart"></canvas>
-    </div>
-    {% with split=dna.fiction_nonfiction_split %}
-        {% widthratio split.fiction_count split.fiction_count|add:split.nonfiction_count 100 as fiction_pct %}
-        <div class="mt-4 flex items-center justify-center gap-6 text-lg">
-            <div class="flex items-center gap-2">
-                <span class="inline-block h-4 w-4 border-2 border-gray-800" style="background-color: #ffb4dd"></span>
-                Fiction {{ fiction_pct }}%
-            </div>
-            <div class="flex items-center gap-2">
-                <span class="inline-block h-4 w-4 border-2 border-gray-800" style="background-color: #8bbfff"></span>
-                Nonfiction {% widthratio split.nonfiction_count split.fiction_count|add:split.nonfiction_count 100 %}%
-            </div>
+    <div class="flex flex-1 flex-col items-center justify-center">
+        <div class="mx-auto" style="height: 180px; max-width: 180px">
+            <canvas id="fictionNonfictionChart"></canvas>
         </div>
-    {% endwith %}
+        {% with split=dna.fiction_nonfiction_split %}
+            {% widthratio split.fiction_count split.fiction_count|add:split.nonfiction_count 100 as fiction_pct %}
+            <div class="mt-4 flex items-center justify-center gap-6 text-lg">
+                <div class="flex items-center gap-2">
+                    <span class="inline-block h-4 w-4 border-2 border-gray-800" style="background-color: #ffb4dd"></span>
+                    Fiction {{ fiction_pct }}%
+                </div>
+                <div class="flex items-center gap-2">
+                    <span class="inline-block h-4 w-4 border-2 border-gray-800" style="background-color: #8bbfff"></span>
+                    Nonfiction {% widthratio split.nonfiction_count split.fiction_count|add:split.nonfiction_count 100 %}%
+                </div>
+            </div>
+        {% endwith %}
+    </div>
 </div>

--- a/core/templates/core/partials/dna/fiction_nonfiction_card.html
+++ b/core/templates/core/partials/dna/fiction_nonfiction_card.html
@@ -1,31 +1,31 @@
 <div class="border-brand-text shadow-neo flex flex-col border-2 bg-white p-6">
     <h2 class="mb-1 text-center text-2xl font-bold uppercase">Fiction vs Nonfiction</h2>
-    <p class="mb-4 text-center text-base text-gray-500 italic">
+    <p class="text-center text-base text-gray-500 italic">
         How your library splits between fiction and nonfiction
     </p>
-    <div class="flex flex-1 flex-col items-center justify-center">
-        <div class="border-brand-text mx-auto -rotate-2 border-4 bg-white p-2" style="height: 240px; width: 240px">
-            <canvas id="fictionNonfictionChart" class="pie-chart-intro"></canvas>
+    <div class="flex flex-1 flex-col items-center justify-center py-4">
+        <div class="chart-await mx-auto" style="height: 220px; width: 220px">
+            <canvas id="fictionNonfictionChart"></canvas>
         </div>
-        {% with split=dna.fiction_nonfiction_split %}
-            {% widthratio split.fiction_count split.fiction_count|add:split.nonfiction_count 100 as fiction_pct %}
-            <div class="mt-4 flex items-center justify-center gap-6 text-lg">
-                <div class="flex items-center gap-2">
-                    <span
-                        class="inline-block h-4 w-4 border-2 border-gray-800"
-                        style="background-color: #ffb4dd"
-                    ></span>
-                    Fiction {{ fiction_pct }}%
-                </div>
-                <div class="flex items-center gap-2">
-                    <span
-                        class="inline-block h-4 w-4 border-2 border-gray-800"
-                        style="background-color: #8bbfff"
-                    ></span>
-                    Nonfiction
-                    {% widthratio split.nonfiction_count split.fiction_count|add:split.nonfiction_count 100 %}%
-                </div>
-            </div>
-        {% endwith %}
     </div>
+    {% with split=dna.fiction_nonfiction_split %}
+        {% widthratio split.fiction_count split.fiction_count|add:split.nonfiction_count 100 as fiction_pct %}
+        <div class="flex items-center justify-center gap-6 text-lg">
+            <div class="flex items-center gap-2">
+                <span
+                    class="inline-block h-4 w-4 border-2 border-gray-800"
+                    style="background-color: #ffb4dd"
+                ></span>
+                Fiction {{ fiction_pct }}%
+            </div>
+            <div class="flex items-center gap-2">
+                <span
+                    class="inline-block h-4 w-4 border-2 border-gray-800"
+                    style="background-color: #8bbfff"
+                ></span>
+                Nonfiction
+                {% widthratio split.nonfiction_count split.fiction_count|add:split.nonfiction_count 100 %}%
+            </div>
+        </div>
+    {% endwith %}
 </div>

--- a/core/templates/core/partials/dna/fiction_nonfiction_card.html
+++ b/core/templates/core/partials/dna/fiction_nonfiction_card.html
@@ -1,4 +1,4 @@
-<div class="border-brand-text shadow-neo border-2 bg-white p-6">
+<div class="border-brand-text shadow-neo flex flex-col justify-center border-2 bg-white p-6">
     <h2 class="mb-1 text-center text-2xl font-bold uppercase">Fiction vs Nonfiction</h2>
     <p class="mb-4 text-center text-base text-gray-500 italic">
         How your library splits between fiction and nonfiction

--- a/core/templates/core/partials/dna/fiction_nonfiction_card.html
+++ b/core/templates/core/partials/dna/fiction_nonfiction_card.html
@@ -4,19 +4,26 @@
         How your library splits between fiction and nonfiction
     </p>
     <div class="flex flex-1 flex-col items-center justify-center">
-        <div class="mx-auto" style="height: 180px; max-width: 180px">
-            <canvas id="fictionNonfictionChart"></canvas>
+        <div class="border-brand-text mx-auto -rotate-2 border-4 bg-white p-2" style="height: 240px; width: 240px">
+            <canvas id="fictionNonfictionChart" class="pie-chart-intro"></canvas>
         </div>
         {% with split=dna.fiction_nonfiction_split %}
             {% widthratio split.fiction_count split.fiction_count|add:split.nonfiction_count 100 as fiction_pct %}
             <div class="mt-4 flex items-center justify-center gap-6 text-lg">
                 <div class="flex items-center gap-2">
-                    <span class="inline-block h-4 w-4 border-2 border-gray-800" style="background-color: #ffb4dd"></span>
+                    <span
+                        class="inline-block h-4 w-4 border-2 border-gray-800"
+                        style="background-color: #ffb4dd"
+                    ></span>
                     Fiction {{ fiction_pct }}%
                 </div>
                 <div class="flex items-center gap-2">
-                    <span class="inline-block h-4 w-4 border-2 border-gray-800" style="background-color: #8bbfff"></span>
-                    Nonfiction {% widthratio split.nonfiction_count split.fiction_count|add:split.nonfiction_count 100 %}%
+                    <span
+                        class="inline-block h-4 w-4 border-2 border-gray-800"
+                        style="background-color: #8bbfff"
+                    ></span>
+                    Nonfiction
+                    {% widthratio split.nonfiction_count split.fiction_count|add:split.nonfiction_count 100 %}%
                 </div>
             </div>
         {% endwith %}

--- a/core/templates/core/partials/dna/fiction_nonfiction_card.html
+++ b/core/templates/core/partials/dna/fiction_nonfiction_card.html
@@ -1,0 +1,19 @@
+<div class="border-brand-text shadow-neo border-2 bg-white p-6">
+    <h2 class="mb-4 text-center text-2xl font-bold uppercase">Fiction vs Nonfiction</h2>
+    <div class="mx-auto" style="height: 180px; max-width: 180px">
+        <canvas id="fictionNonfictionChart"></canvas>
+    </div>
+    {% with split=dna.fiction_nonfiction_split %}
+        {% widthratio split.fiction_count split.fiction_count|add:split.nonfiction_count 100 as fiction_pct %}
+        <div class="mt-4 flex items-center justify-center gap-6 text-lg">
+            <div class="flex items-center gap-2">
+                <span class="inline-block h-4 w-4 border-2 border-gray-800" style="background-color: #ffb4dd"></span>
+                Fiction {{ fiction_pct }}%
+            </div>
+            <div class="flex items-center gap-2">
+                <span class="inline-block h-4 w-4 border-2 border-gray-800" style="background-color: #8bbfff"></span>
+                Nonfiction {% widthratio split.nonfiction_count split.fiction_count|add:split.nonfiction_count 100 %}%
+            </div>
+        </div>
+    {% endwith %}
+</div>

--- a/core/templates/core/partials/dna/fiction_nonfiction_card.html
+++ b/core/templates/core/partials/dna/fiction_nonfiction_card.html
@@ -1,7 +1,7 @@
 <div class="border-brand-text shadow-neo flex flex-col border-2 bg-white p-6">
     <h2 class="mb-1 text-center text-2xl font-bold uppercase">Fiction vs Nonfiction</h2>
     <p class="text-center text-base text-gray-500 italic">
-        How your library splits between fiction and nonfiction
+        How {{ pronoun_pos|default:"your" }} library splits between fiction and nonfiction
     </p>
     <div class="flex flex-1 flex-col items-center justify-center py-4">
         <div class="chart-await mx-auto" style="height: 220px; width: 220px">

--- a/core/templates/core/partials/dna/fiction_nonfiction_card.html
+++ b/core/templates/core/partials/dna/fiction_nonfiction_card.html
@@ -1,5 +1,8 @@
 <div class="border-brand-text shadow-neo border-2 bg-white p-6">
-    <h2 class="mb-4 text-center text-2xl font-bold uppercase">Fiction vs Nonfiction</h2>
+    <h2 class="mb-1 text-center text-2xl font-bold uppercase">Fiction vs Nonfiction</h2>
+    <p class="mb-4 text-center text-base text-gray-500 italic">
+        How your library splits between fiction and nonfiction
+    </p>
     <div class="mx-auto" style="height: 180px; max-width: 180px">
         <canvas id="fictionNonfictionChart"></canvas>
     </div>

--- a/core/templates/core/partials/dna/mainstream_gauge_card.html
+++ b/core/templates/core/partials/dna/mainstream_gauge_card.html
@@ -51,7 +51,7 @@
             observer.observe(this.$el);
         }
     }" x-init="init()">
-        <div class="relative mx-auto h-32 w-64" style="filter: drop-shadow(4px 4px 0px #1f2937)">
+        <div class="scroll-fade-up relative mx-auto h-32 w-64" style="filter: drop-shadow(4px 4px 0px #1f2937)">
 
             <!-- Layer 1: The Semicircle Container (with the necessary clipping) -->
             <div class="absolute top-0 left-0 h-full w-full overflow-hidden">

--- a/core/templates/core/partials/dna/mainstream_gauge_card.html
+++ b/core/templates/core/partials/dna/mainstream_gauge_card.html
@@ -51,7 +51,7 @@
             observer.observe(this.$el);
         }
     }" x-init="init()">
-        <div class="relative mx-auto h-32 w-64">
+        <div class="relative mx-auto h-32 w-64" style="filter: drop-shadow(4px 4px 0px #1f2937)">
 
             <!-- Layer 1: The Semicircle Container (with the necessary clipping) -->
             <div class="absolute top-0 left-0 h-full w-full overflow-hidden">
@@ -95,6 +95,7 @@
             <div class="absolute -bottom-4 border-brand-text border-4 left-0 w-full h-4 z-[15]"
                  style="background: repeating-linear-gradient(45deg, #6b7280 0px, #6b7280 4px, #4b5563 4px, #4b5563 7px);"></div>
 
+
             <!-- Note: Increased width to w-3 to make the taper more visible -->
             <div class="absolute bottom-0 left-1/2 h-24 w-3 origin-bottom z-20"
                  :style="`transform: translateX(-50%) rotate(${rotation}deg);`">
@@ -118,6 +119,7 @@
 
 
         </div>
+
 
         <!-- The descriptive text below the meter -->
         <p class="mt-6 text-center text-lg">

--- a/core/templates/core/partials/dna/niche_read_card.html
+++ b/core/templates/core/partials/dna/niche_read_card.html
@@ -6,7 +6,7 @@
         <p class="mb-4 text-center text-base italic text-gray-500">{{ pronoun_pos|default:"Your"|capfirst }} rarest find on Bibliotype — read by only {{ dna.most_niche_book.read_count }} people</p>
     {% endif %}
     {% if dna.most_niche_book %}
-        <div class="flex flex-1 flex-col items-center justify-center" x-data="{ imgFailed: false }">
+        <div class="scroll-fade-up flex flex-1 flex-col items-center justify-center" x-data="{ imgFailed: false }">
             {% if dna.most_niche_book.cover_url %}
                 <div
                     x-show="!imgFailed"
@@ -16,7 +16,7 @@
                         src="{{ dna.most_niche_book.cover_url }}"
                         alt="Cover of {{ dna.most_niche_book.title }}"
                         class="h-full w-full object-cover"
-                        loading="lazy"
+                        fetchpriority="low"
                         x-on:error="imgFailed = true"
                         x-on:load="if ($el.naturalWidth < 10) imgFailed = true"
                     />

--- a/core/templates/core/partials/dna/niche_read_card.html
+++ b/core/templates/core/partials/dna/niche_read_card.html
@@ -10,7 +10,7 @@
             {% if dna.most_niche_book.cover_url %}
                 <div
                     x-show="!imgFailed"
-                    class="border-brand-text h-40 w-[6.75rem] overflow-hidden border-2"
+                    class="border-brand-text shadow-neo-sm h-40 w-[6.75rem] overflow-hidden border-2"
                 >
                     <img
                         src="{{ dna.most_niche_book.cover_url }}"
@@ -24,13 +24,13 @@
                 <div
                     x-show="imgFailed"
                     x-cloak
-                    class="bg-brand-purple border-brand-text flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
+                    class="bg-brand-purple border-brand-text shadow-neo-sm flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
                 >
                     {{ dna.most_niche_book.title|first|upper }}
                 </div>
             {% else %}
                 <div
-                    class="bg-brand-purple border-brand-text flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
+                    class="bg-brand-purple border-brand-text shadow-neo-sm flex h-40 w-[6.75rem] items-center justify-center border-2 text-5xl font-bold"
                 >
                     {{ dna.most_niche_book.title|first|upper }}
                 </div>

--- a/core/templates/core/partials/dna/top_genres_authors_row.html
+++ b/core/templates/core/partials/dna/top_genres_authors_row.html
@@ -32,7 +32,7 @@
                 {% if dna.unique_genres_count %}
                     <p class="mb-2 text-base italic text-gray-500 md:mb-6 md:pr-36">We found {{ dna.unique_genres_count }} unique genre{{ dna.unique_genres_count|pluralize }} in {{ pronoun_pos|default:"your" }} library</p>
                 {% endif %}
-                <div class="h-28 w-28 flex-shrink-0 md:!absolute md:!top-2 md:!right-2 md:!h-32 md:!w-32" style="position: relative; top: -2.5rem; right: -0.6rem;">
+                <div class="chart-drop-shadow chart-await h-28 w-28 flex-shrink-0 md:!absolute md:!top-2 md:!right-2 md:!h-32 md:!w-32" style="position: relative; top: -2.5rem; right: -0.6rem;">
                     <canvas id="topGenresChart"></canvas>
                 </div>
             </div>
@@ -83,7 +83,7 @@
                 {% if dna.unique_authors_count %}
                     <p class="mb-2 text-base italic text-gray-500 md:mb-6 md:pr-36">We found {{ dna.unique_authors_count }} unique author{{ dna.unique_authors_count|pluralize }} in {{ pronoun_pos|default:"your" }} library</p>
                 {% endif %}
-                <div class="h-28 w-28 flex-shrink-0 md:!absolute md:!top-2 md:!right-2 md:!h-32 md:!w-32" style="position: relative; top: -2.5rem; right: -0.6rem;">
+                <div class="chart-drop-shadow chart-await h-28 w-28 flex-shrink-0 md:!absolute md:!top-2 md:!right-2 md:!h-32 md:!w-32" style="position: relative; top: -2.5rem; right: -0.6rem;">
                     <canvas id="topAuthorsChart"></canvas>
                 </div>
             </div>

--- a/core/templates/core/public_profile.html
+++ b/core/templates/core/public_profile.html
@@ -97,12 +97,12 @@
                 {% include 'core/partials/dna/review_analysis_card.html' %}
 
                 {% if dna.fiction_nonfiction_split or dna.longest_book %}
-                    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+                    <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
                         {% if dna.fiction_nonfiction_split %}
-                            {% include 'core/partials/dna/fiction_nonfiction_card.html' %}
+                            {% include 'core/partials/dna/fiction_nonfiction_card.html' with pronoun_pos="their" %}
                         {% endif %}
                         {% if dna.longest_book %}
-                            {% include 'core/partials/dna/book_extremes_card.html' %}
+                            {% include 'core/partials/dna/book_extremes_card.html' with pronoun_pos="their" %}
                         {% endif %}
                     </div>
                 {% endif %}

--- a/core/templates/core/public_profile.html
+++ b/core/templates/core/public_profile.html
@@ -3,37 +3,17 @@
 
 {% block seo_title %}Bibliotype – {{ heading_name }} Reading DNA{% endblock %}
 
-{% block seo_description %}{% if dna %}
-    View {{ title }} and literary personality. Discover their favourite genres, reading statistics, and book
-    preferences.
-{% else %}
-    {{ title }}
-    profile.
-{% endif %}{% endblock %}
+{% block seo_description %}{% if dna %}View {{ title }} and literary personality. Discover their favourite genres, reading statistics, and book preferences.{% else %}{{ title }} profile.{% endif %}{% endblock %}
 
-{% block seo_keywords %}
-    {{ heading_name }}
-    reading DNA, {{ heading_name }} literary personality, reading profile, book analysis, reader type, reading
-    statistics
-{% endblock %}
+{% block seo_keywords %}{{ heading_name }} reading DNA, {{ heading_name }} literary personality, reading profile, book analysis, reader type, reading statistics{% endblock %}
 
 {% block og_title %}{{ title }}{% endblock %}
 
-{% block og_description %}{% if dna %}
-    Discover {{ title }} and their unique reading DNA, literary personality, favourite genres, and reading insights.
-{% else %}
-    {{ title }}
-    profile.
-{% endif %}{% endblock %}
+{% block og_description %}{% if dna %}Discover {{ title }} and their unique reading DNA, literary personality, favourite genres, and reading insights.{% else %}{{ title }} profile.{% endif %}{% endblock %}
 
 {% block twitter_title %}{{ title }}{% endblock %}
 
-{% block twitter_description %}{% if dna %}
-    View {{ title }} and discover their literary personality.
-{% else %}
-    {{ title }}
-    profile.
-{% endif %}{% endblock %}
+{% block twitter_description %}{% if dna %}View {{ title }} and discover their literary personality.{% else %}{{ title }} profile.{% endif %}{% endblock %}
 
 {% block extra_head_js %}
     <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/core/templates/core/public_profile.html
+++ b/core/templates/core/public_profile.html
@@ -7,12 +7,14 @@
     View {{ title }} and literary personality. Discover their favourite genres, reading statistics, and book
     preferences.
 {% else %}
-    {{ title }} profile.
+    {{ title }}
+    profile.
 {% endif %}{% endblock %}
 
 {% block seo_keywords %}
-    {{ heading_name }} reading DNA, {{ heading_name }} literary personality, reading profile, book analysis, reader
-    type, reading statistics
+    {{ heading_name }}
+    reading DNA, {{ heading_name }} literary personality, reading profile, book analysis, reader type, reading
+    statistics
 {% endblock %}
 
 {% block og_title %}{{ title }}{% endblock %}
@@ -20,7 +22,8 @@
 {% block og_description %}{% if dna %}
     Discover {{ title }} and their unique reading DNA, literary personality, favourite genres, and reading insights.
 {% else %}
-    {{ title }} profile.
+    {{ title }}
+    profile.
 {% endif %}{% endblock %}
 
 {% block twitter_title %}{{ title }}{% endblock %}
@@ -28,7 +31,8 @@
 {% block twitter_description %}{% if dna %}
     View {{ title }} and discover their literary personality.
 {% else %}
-    {{ title }} profile.
+    {{ title }}
+    profile.
 {% endif %}{% endblock %}
 
 {% block extra_head_js %}
@@ -77,15 +81,15 @@
         {# Check if DNA data exists for this user #}
         {% if dna %}
             <div x-data="shareModalData()" class="space-y-6">
-            {# This script tag is still needed for the charts to work #}
-            {{ dna|json_script:"dna-data" }}
-            <!-- The main header, personalised with the profile owner's name -->
-            <h1
-                class="mb-4 flex flex-col items-center justify-center gap-x-4 text-center text-4xl font-bold tracking-widest uppercase sm:text-5xl md:mb-8 md:flex-row"
-            >
-                <span>{{ heading_name }}</span>
-                <span class="whitespace-nowrap">Bibliotype</span>
-            </h1>
+                {# This script tag is still needed for the charts to work #}
+                {{ dna|json_script:"dna-data" }}
+                <!-- The main header, personalised with the profile owner's name -->
+                <h1
+                    class="mb-4 flex flex-col items-center justify-center gap-x-4 text-center text-4xl font-bold tracking-widest uppercase sm:text-5xl md:mb-8 md:flex-row"
+                >
+                    <span>{{ heading_name }}</span>
+                    <span class="whitespace-nowrap">Bibliotype</span>
+                </h1>
 
                 {% include 'core/partials/dna/vibe_display.html' %}
 
@@ -111,6 +115,17 @@
 
                 {% include 'core/partials/dna/top_genres_authors_row.html' with use_rainbow=True pronoun_pos="their" %}
                 {% include 'core/partials/dna/review_analysis_card.html' %}
+
+                {% if dna.fiction_nonfiction_split or dna.longest_book %}
+                    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+                        {% if dna.fiction_nonfiction_split %}
+                            {% include 'core/partials/dna/fiction_nonfiction_card.html' %}
+                        {% endif %}
+                        {% if dna.longest_book %}
+                            {% include 'core/partials/dna/book_extremes_card.html' %}
+                        {% endif %}
+                    </div>
+                {% endif %}
                 {% include 'core/partials/dna/controversial_ratings_card.html' with controversial_title='Most Controversial Ratings' pronoun_pos="their" pronoun_sub="them" %}
                 {% include 'core/partials/dna/currently_reading_card.html' with pronoun_sub="they're" %}
 

--- a/core/tests/test_fiction_book_extremes.py
+++ b/core/tests/test_fiction_book_extremes.py
@@ -1,0 +1,118 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from core.dna_constants import (
+    CANONICAL_GENRE_MAP,
+    FICTION_GENRES,
+    GENRE_ALIASES,
+    NONFICTION_GENRES,
+)
+
+
+class FictionNonfictionConstantsTests(TestCase):
+    """Verify FICTION_GENRES and NONFICTION_GENRES cover all canonical genres."""
+
+    def test_sets_cover_all_canonical_genres(self):
+        all_canonical = set(GENRE_ALIASES.keys())
+        classified = FICTION_GENRES | NONFICTION_GENRES
+        self.assertEqual(classified, all_canonical)
+
+    def test_no_overlap_between_fiction_and_nonfiction(self):
+        overlap = FICTION_GENRES & NONFICTION_GENRES
+        self.assertEqual(overlap, set(), f"Overlapping genres: {overlap}")
+
+
+class FictionNonfictionClassificationTests(TestCase):
+    """Test the fiction-first classification logic used in dna_analyser."""
+
+    def _classify(self, genre_names):
+        """Reproduce the classification logic from dna_analyser."""
+        canonical = {CANONICAL_GENRE_MAP.get(g, g) for g in genre_names}
+        if canonical & FICTION_GENRES:
+            return "fiction"
+        elif canonical & NONFICTION_GENRES:
+            return "nonfiction"
+        return "unclassified"
+
+    def test_pure_fiction(self):
+        self.assertEqual(self._classify(["fantasy fiction", "epic fantasy"]), "fiction")
+
+    def test_pure_nonfiction(self):
+        self.assertEqual(self._classify(["history", "military history"]), "nonfiction")
+
+    def test_mixed_genres_fiction_wins(self):
+        """A book with both fiction and nonfiction genres should classify as fiction."""
+        self.assertEqual(self._classify(["fantasy", "history"]), "fiction")
+
+    def test_no_matching_genres(self):
+        self.assertEqual(self._classify(["unknown genre xyz"]), "unclassified")
+
+    def test_empty_genres(self):
+        self.assertEqual(self._classify([]), "unclassified")
+
+    def test_alias_maps_to_fiction(self):
+        self.assertEqual(self._classify(["ghost stories"]), "fiction")
+
+    def test_alias_maps_to_nonfiction(self):
+        self.assertEqual(self._classify(["autobiography"]), "nonfiction")
+
+
+class BookExtremesTests(TestCase):
+    """Test longest/shortest book selection logic."""
+
+    def _make_book(self, title, author_name, page_count, isbn13=None):
+        book = MagicMock()
+        book.title = title
+        book.page_count = page_count
+        book.isbn13 = isbn13
+        book.normalized_title = title.lower()
+        book.author = MagicMock()
+        book.author.name = author_name
+        return book
+
+    def test_longest_and_shortest(self):
+        books = [
+            self._make_book("Medium", "Author A", 300),
+            self._make_book("Long", "Author B", 800),
+            self._make_book("Short", "Author C", 100),
+        ]
+        books_with_pages = [b for b in books if b.page_count]
+        books_with_pages.sort(key=lambda b: (-b.page_count, b.normalized_title))
+        longest = books_with_pages[0]
+        books_with_pages.sort(key=lambda b: (b.page_count, b.normalized_title))
+        shortest = books_with_pages[0]
+
+        self.assertEqual(longest.title, "Long")
+        self.assertEqual(longest.page_count, 800)
+        self.assertEqual(shortest.title, "Short")
+        self.assertEqual(shortest.page_count, 100)
+
+    def test_fewer_than_two_books_returns_none(self):
+        books = [self._make_book("Only", "Author A", 200)]
+        books_with_pages = [b for b in books if b.page_count]
+        self.assertLess(len(books_with_pages), 2)
+
+    def test_no_books_with_pages(self):
+        books = [
+            self._make_book("No Pages A", "Author A", None),
+            self._make_book("No Pages B", "Author B", 0),
+        ]
+        books_with_pages = [b for b in books if b.page_count]
+        self.assertEqual(len(books_with_pages), 0)
+
+    def test_tiebreaker_uses_normalized_title(self):
+        """When page counts are equal, normalized_title breaks the tie."""
+        books = [
+            self._make_book("Bravo", "Author A", 500),
+            self._make_book("Alpha", "Author B", 500),
+        ]
+        books_with_pages = [b for b in books if b.page_count]
+        books_with_pages.sort(key=lambda b: (-b.page_count, b.normalized_title))
+        longest = books_with_pages[0]
+        # "alpha" < "bravo" alphabetically, so Alpha wins the tiebreak
+        self.assertEqual(longest.title, "Alpha")
+
+        books_with_pages.sort(key=lambda b: (b.page_count, b.normalized_title))
+        shortest = books_with_pages[0]
+        self.assertEqual(shortest.title, "Alpha")

--- a/core/tests/test_fiction_book_extremes.py
+++ b/core/tests/test_fiction_book_extremes.py
@@ -72,6 +72,7 @@ class BookExtremesTests(TestCase):
         return book
 
     def test_longest_and_shortest(self):
+        """Mirror production logic: single descending sort, [0] = longest, [-1] = shortest."""
         books = [
             self._make_book("Medium", "Author A", 300),
             self._make_book("Long", "Author B", 800),
@@ -80,8 +81,7 @@ class BookExtremesTests(TestCase):
         books_with_pages = [b for b in books if b.page_count]
         books_with_pages.sort(key=lambda b: (-b.page_count, b.normalized_title))
         longest = books_with_pages[0]
-        books_with_pages.sort(key=lambda b: (b.page_count, b.normalized_title))
-        shortest = books_with_pages[0]
+        shortest = books_with_pages[-1]
 
         self.assertEqual(longest.title, "Long")
         self.assertEqual(longest.page_count, 800)
@@ -102,7 +102,7 @@ class BookExtremesTests(TestCase):
         self.assertEqual(len(books_with_pages), 0)
 
     def test_tiebreaker_uses_normalized_title(self):
-        """When page counts are equal, normalized_title breaks the tie."""
+        """When page counts are equal, normalized_title breaks the tie (single sort, like production)."""
         books = [
             self._make_book("Bravo", "Author A", 500),
             self._make_book("Alpha", "Author B", 500),
@@ -110,9 +110,7 @@ class BookExtremesTests(TestCase):
         books_with_pages = [b for b in books if b.page_count]
         books_with_pages.sort(key=lambda b: (-b.page_count, b.normalized_title))
         longest = books_with_pages[0]
-        # "alpha" < "bravo" alphabetically, so Alpha wins the tiebreak
+        shortest = books_with_pages[-1]
+        # "alpha" < "bravo" alphabetically, so Alpha wins the tiebreak for both
         self.assertEqual(longest.title, "Alpha")
-
-        books_with_pages.sort(key=lambda b: (b.page_count, b.normalized_title))
-        shortest = books_with_pages[0]
-        self.assertEqual(shortest.title, "Alpha")
+        self.assertEqual(shortest.title, "Bravo")

--- a/core/views.py
+++ b/core/views.py
@@ -225,7 +225,7 @@ def _enrich_dna_for_display(dna_data):
         niche_book["cover_url"] = None
 
     # Backfill page_difference for old DNA data
-    if not dna_data.get("page_difference"):
+    if dna_data.get("page_difference") is None:
         longest = dna_data.get("longest_book")
         shortest = dna_data.get("shortest_book")
         if longest and shortest and longest.get("page_count") and shortest.get("page_count"):

--- a/core/views.py
+++ b/core/views.py
@@ -224,6 +224,13 @@ def _enrich_dna_for_display(dna_data):
     if niche_book and "cover_url" not in niche_book:
         niche_book["cover_url"] = None
 
+    # Backfill page_difference for old DNA data
+    if not dna_data.get("page_difference"):
+        longest = dna_data.get("longest_book")
+        shortest = dna_data.get("shortest_book")
+        if longest and shortest and longest.get("page_count") and shortest.get("page_count"):
+            dna_data["page_difference"] = longest["page_count"] - shortest["page_count"]
+
     # Recalculate percentiles from current aggregate data so they're never stale.
     # Cached for 10 minutes to avoid a DB hit on every page load while still staying fresh.
     bl = user_stats.get("avg_book_length", 0)

--- a/core/views.py
+++ b/core/views.py
@@ -224,8 +224,8 @@ def _enrich_dna_for_display(dna_data):
     if niche_book and "cover_url" not in niche_book:
         niche_book["cover_url"] = None
 
-    # Backfill page_difference for old DNA data
-    if dna_data.get("page_difference") is None:
+    # Backfill page_difference for old DNA data (key absent = old DNA, not same-page-count None)
+    if "page_difference" not in dna_data:
         longest = dna_data.get("longest_book")
         shortest = dna_data.get("shortest_book")
         if longest and shortest and longest.get("page_count") and shortest.get("page_count"):

--- a/static/src/input.css
+++ b/static/src/input.css
@@ -58,6 +58,25 @@ ol.list-decimal {
     filter: drop-shadow(4px 4px 0px #1f2937);
 }
 
+/* Scroll-triggered intro animations */
+.scroll-fade-left {
+    opacity: 0;
+    transform: translateX(-20px);
+    transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.scroll-fade-up {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.scroll-fade-left.is-visible,
+.scroll-fade-up.is-visible {
+    opacity: 1;
+    transform: translate(0);
+}
+
 /* Force a scrollbar to always be present to prevent layout shifts */
 html {
     overflow-y: scroll;

--- a/static/src/input.css
+++ b/static/src/input.css
@@ -43,6 +43,21 @@ ol.list-decimal {
     list-style-type: decimal;
 }
 
+/* Charts hidden until scroll-triggered */
+.chart-await {
+    opacity: 0;
+}
+
+.chart-visible {
+    opacity: 1;
+}
+
+/* Hard neobrutalist drop shadow on circular charts */
+.chart-visible canvas,
+.chart-drop-shadow canvas {
+    filter: drop-shadow(4px 4px 0px #1f2937);
+}
+
 /* Force a scrollbar to always be present to prevent layout shifts */
 html {
     overflow-y: scroll;


### PR DESCRIPTION
## Summary
- **Fiction vs Nonfiction card** — pie chart with diagonal stripe patterns, scroll-triggered segment expansion animation
- **Book Extremes card** — longest/shortest books with covers, page counts, badges
- Both cards appear on dashboard and public profile, hidden when data insufficient

## Changes

### Backend
- Added FICTION_GENRES/NONFICTION_GENRES sets with drift-guard assertion
- Fiction/nonfiction counting with fiction-first priority
- Longest/shortest book selection by page_count with tiebreaker
- Backfill page_difference in _enrich_dna_for_display() for old DNA data

### Frontend
- Diagonal stripe patterns on both fiction (pink) and nonfiction (blue) pie segments
- Scroll-triggered chart creation via IntersectionObserver for all pie/doughnut charts
- Removed CSS pie-intro animation that was masking Chart.js native segment expansion
- Vertically centered pie chart with proper legend spacing
- shadow-neo-sm on book covers across cards, drop-shadow on mainstream gauge

### Tests
- 13 unit tests: constants coverage, fiction/nonfiction classification, book extremes edge cases

## Test plan
- [ ] Upload CSV with mixed fiction/nonfiction → both cards render with striped pie chart
- [ ] Pie segments sweep in with expansion animation on scroll
- [ ] Book extremes subtitle shows correct page difference
- [ ] Public profile shows same cards
- [ ] All tests pass

Generated with [Claude Code](https://claude.com/claude-code)