### PR TITLE
Fix Alpine.js FOUC and share card badge cutoff

### DIFF
--- a/core/templates/core/partials/share/card_full.html
+++ b/core/templates/core/partials/share/card_full.html
@@ -1,28 +1,28 @@
 {% load humanize %}
-<div class="flex h-[568px] w-[320px] flex-col justify-between border-2 border-brand-text bg-brand-purple p-5">
-    <div>
+<div class="border-brand-text bg-brand-purple flex h-[568px] w-[320px] flex-col border-2 p-5">
+    <div class="min-h-0 flex-1 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
-        <div class="mt-3 border-2 border-brand-text bg-white p-2.5 text-center">
+        <div class="border-brand-text mt-3 border-2 bg-white p-2.5 text-center">
             <p class="text-xs uppercase">I am a</p>
             <p class="text-xl font-bold tracking-wider uppercase">{{ dna.reader_type }}</p>
         </div>
         {% if dna.reading_vibe %}
             <div class="mt-2.5 flex flex-wrap justify-center gap-1">
                 {% for phrase in dna.reading_vibe %}
-                    <span class="border border-brand-text bg-white px-1.5 py-0.5 text-xs font-bold">{{ phrase }}</span>
+                    <span class="border-brand-text border bg-white px-1.5 py-0.5 text-xs font-bold">{{ phrase }}</span>
                 {% endfor %}
             </div>
         {% endif %}
         <div class="mt-3 grid grid-cols-3 gap-1.5">
-            <div class="border-2 border-brand-text bg-white p-1.5 text-center">
+            <div class="border-brand-text border-2 bg-white p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_books_read }}</div>
                 <div class="text-[10px] uppercase">Books</div>
             </div>
-            <div class="border-2 border-brand-text bg-white p-1.5 text-center">
+            <div class="border-brand-text border-2 bg-white p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_pages_read|intcomma }}</div>
                 <div class="text-[10px] uppercase">Pages</div>
             </div>
-            <div class="border-2 border-brand-text bg-white p-1.5 text-center">
+            <div class="border-brand-text border-2 bg-white p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.average_rating_overall }}</div>
                 <div class="text-[10px] uppercase">Avg Rating</div>
             </div>
@@ -33,7 +33,9 @@
                     <p class="text-[10px] font-bold uppercase">Top Genres</p>
                     {% for genre, count in dna.top_genres|slice:":3" %}
                         <p class="mt-0.5 text-xs">
-                            <span class="inline-block border border-brand-text bg-white px-1 font-bold capitalize">{{ genre }}</span>
+                            <span class="border-brand-text inline-block border bg-white px-1 font-bold capitalize"
+                                >{{ genre }}</span
+                            >
                         </p>
                     {% endfor %}
                 </div>
@@ -43,28 +45,36 @@
                     <p class="text-[10px] font-bold uppercase">Top Authors</p>
                     {% for author, count in dna.top_authors|slice:":3" %}
                         <p class="mt-0.5 text-xs">
-                            <span class="inline-block border border-brand-text bg-white px-1 font-bold">{{ author|truncatewords:3 }}</span>
+                            <span class="border-brand-text inline-block border bg-white px-1 font-bold"
+                                >{{ author|truncatewords:3 }}</span
+                            >
                         </p>
                     {% endfor %}
                 </div>
             {% endif %}
         </div>
-        <div class="mt-2.5 flex items-center gap-2 border-2 border-brand-text bg-white p-2">
+        <div class="border-brand-text mt-2.5 flex items-center gap-2 border-2 bg-white p-2">
             <div class="text-2xl font-bold">{{ dna.mainstream_score_percent }}%</div>
             <div class="text-xs">
                 <p class="font-bold uppercase">Mainstream</p>
                 {% if dna.most_niche_book %}
-                    <p class="mt-0.5 leading-tight opacity-80">Nichest: {{ dna.most_niche_book.title|truncatewords:6 }}</p>
+                    <p class="mt-0.5 leading-tight opacity-80">
+                        Nichest: {{ dna.most_niche_book.title|truncatewords:6 }}
+                    </p>
                 {% endif %}
             </div>
         </div>
-        {% if dna.top_reader_types %}
-            <div class="mt-2.5 flex flex-wrap gap-1">
-                {% for item in dna.top_reader_types %}
-                    <span class="border border-brand-text bg-white px-1.5 py-0.5 text-[10px] font-bold">{{ item.type }}</span>
-                {% endfor %}
-            </div>
-        {% endif %}
     </div>
-    <p class="text-center text-xs font-bold tracking-wider uppercase opacity-60">{{ share_url|default:"bibliotype.app" }}</p>
+    {% if dna.top_reader_types %}
+        <div class="mt-2.5 flex shrink-0 flex-wrap gap-1">
+            {% for item in dna.top_reader_types %}
+                <span class="border-brand-text border bg-white px-1.5 py-0.5 text-[10px] font-bold"
+                    >{{ item.type }}</span
+                >
+            {% endfor %}
+        </div>
+    {% endif %}
+    <p class="mt-auto shrink-0 text-center text-xs font-bold tracking-wider uppercase opacity-60">
+        {{ share_url|default:"bibliotype.app" }}
+    </p>
 </div>

--- a/core/templates/core/partials/share/card_full_miami.html
+++ b/core/templates/core/partials/share/card_full_miami.html
@@ -1,8 +1,8 @@
 {% load humanize %}
-<div class="flex h-[568px] w-[320px] flex-col justify-between border-2 border-brand-text bg-brand-purple p-5">
-    <div class="min-h-0 overflow-hidden">
+<div class="border-brand-text bg-brand-purple flex h-[568px] w-[320px] flex-col border-2 p-5">
+    <div class="min-h-0 flex-1 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
-        <div class="mt-3 border-2 border-brand-text bg-brand-cyan p-2.5 text-center shadow-neo-sm">
+        <div class="border-brand-text bg-brand-cyan shadow-neo-sm mt-3 border-2 p-2.5 text-center">
             <p class="text-xs uppercase">My Reader Type is...</p>
             <p class="text-xl font-bold tracking-wider uppercase">{{ dna.reader_type }}</p>
         </div>
@@ -10,22 +10,25 @@
             <div class="mt-2.5">
                 <p class="mb-1 text-center text-[10px] font-bold uppercase opacity-70">Reading Vibes</p>
                 <div class="flex flex-wrap justify-center gap-1">
-                {% for phrase in dna.reading_vibe %}
-                    <span class="border border-brand-text {% cycle 'bg-brand-pink' 'bg-brand-orange' 'bg-brand-pink' 'bg-brand-orange' %} px-1.5 py-0.5 text-xs font-bold shadow-neo-sm">{{ phrase }}</span>
-                {% endfor %}
+                    {% for phrase in dna.reading_vibe %}
+                        <span
+                            class="border-brand-text {% cycle 'bg-brand-pink' 'bg-brand-orange' 'bg-brand-pink' 'bg-brand-orange' %} shadow-neo-sm border px-1.5 py-0.5 text-xs font-bold"
+                            >{{ phrase }}</span
+                        >
+                    {% endfor %}
                 </div>
             </div>
         {% endif %}
         <div class="mt-3 grid grid-cols-3 gap-1.5">
-            <div class="border-2 border-brand-text bg-brand-pink p-1.5 text-center">
+            <div class="border-brand-text bg-brand-pink border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_books_read }}</div>
                 <div class="text-[10px] uppercase">Books</div>
             </div>
-            <div class="border-2 border-brand-text bg-brand-pink p-1.5 text-center">
+            <div class="border-brand-text bg-brand-pink border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_pages_read|intcomma }}</div>
                 <div class="text-[10px] uppercase">Pages</div>
             </div>
-            <div class="border-2 border-brand-text bg-brand-pink p-1.5 text-center">
+            <div class="border-brand-text bg-brand-pink border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.average_rating_overall }}</div>
                 <div class="text-[10px] uppercase">Avg Rating</div>
             </div>
@@ -36,7 +39,10 @@
                     <p class="text-[10px] font-bold uppercase">Top Genres</p>
                     {% for genre, count in dna.top_genres|slice:":3" %}
                         <p class="mt-1.5 text-xs">
-                            <span class="inline-block border border-brand-text bg-brand-cyan px-1 font-bold capitalize shadow-neo-sm">{{ genre }}</span>
+                            <span
+                                class="border-brand-text bg-brand-cyan shadow-neo-sm inline-block border px-1 font-bold capitalize"
+                                >{{ genre }}</span
+                            >
                         </p>
                     {% endfor %}
                 </div>
@@ -46,27 +52,37 @@
                     <p class="text-[10px] font-bold uppercase">Top Authors</p>
                     {% for author, count in dna.top_authors|slice:":3" %}
                         <p class="mt-1.5 text-xs">
-                            <span class="inline-block border border-brand-text bg-brand-orange px-1 font-bold shadow-neo-sm">{{ author|truncatewords:3 }}</span>
+                            <span
+                                class="border-brand-text bg-brand-orange shadow-neo-sm inline-block border px-1 font-bold"
+                                >{{ author|truncatewords:3 }}</span
+                            >
                         </p>
                     {% endfor %}
                 </div>
             {% endif %}
         </div>
-        <div class="mt-2.5 border-2 border-brand-text bg-brand-orange p-2 text-center shadow-neo-sm">
+        <div class="border-brand-text bg-brand-orange shadow-neo-sm mt-2.5 border-2 p-2 text-center">
             <p class="text-xs uppercase">
                 <span class="text-2xl font-bold">{{ dna.mainstream_score_percent }}%</span> of my books are mainstream
             </p>
             {% if dna.most_niche_book %}
-                <p class="mt-0.5 text-[10px] leading-tight opacity-80">Nichest: {{ dna.most_niche_book.title|truncatewords:6 }}</p>
+                <p class="mt-0.5 text-[10px] leading-tight opacity-80">
+                    Nichest: {{ dna.most_niche_book.title|truncatewords:6 }}
+                </p>
             {% endif %}
         </div>
-        {% if dna.top_reader_types %}
-            <div class="mt-2.5 flex flex-wrap gap-1">
-                {% for item in dna.top_reader_types %}
-                    <span class="border border-brand-text {% cycle 'bg-brand-pink' 'bg-brand-cyan' 'bg-brand-orange' %} px-1.5 py-0.5 text-[10px] font-bold shadow-neo-sm">{{ item.type }}</span>
-                {% endfor %}
-            </div>
-        {% endif %}
     </div>
-    <p class="text-center text-xs font-bold tracking-wider uppercase opacity-60">{{ share_url|default:"bibliotype.app" }}</p>
+    {% if dna.top_reader_types %}
+        <div class="mt-2.5 flex shrink-0 flex-wrap gap-1">
+            {% for item in dna.top_reader_types %}
+                <span
+                    class="border-brand-text {% cycle 'bg-brand-pink' 'bg-brand-cyan' 'bg-brand-orange' %} shadow-neo-sm border px-1.5 py-0.5 text-[10px] font-bold"
+                    >{{ item.type }}</span
+                >
+            {% endfor %}
+        </div>
+    {% endif %}
+    <p class="mt-auto shrink-0 text-center text-xs font-bold tracking-wider uppercase opacity-60">
+        {{ share_url|default:"bibliotype.app" }}
+    </p>
 </div>

--- a/core/templates/core/partials/share/card_full_neon_picnic.html
+++ b/core/templates/core/partials/share/card_full_neon_picnic.html
@@ -1,8 +1,8 @@
 {% load humanize %}
-<div class="flex h-[568px] w-[320px] flex-col justify-between border-2 border-brand-text bg-brand-purple p-5">
-    <div class="min-h-0 overflow-hidden">
+<div class="border-brand-text bg-brand-purple flex h-[568px] w-[320px] flex-col border-2 p-5">
+    <div class="min-h-0 flex-1 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
-        <div class="mt-3 border-2 border-brand-text bg-brand-green p-2.5 text-center shadow-neo-sm">
+        <div class="border-brand-text bg-brand-green shadow-neo-sm mt-3 border-2 p-2.5 text-center">
             <p class="text-xs uppercase">My Reader Type is...</p>
             <p class="text-xl font-bold tracking-wider uppercase">{{ dna.reader_type }}</p>
         </div>
@@ -10,22 +10,25 @@
             <div class="mt-2.5">
                 <p class="mb-1 text-center text-[10px] font-bold uppercase opacity-70">Reading Vibes</p>
                 <div class="flex flex-wrap justify-center gap-1">
-                {% for phrase in dna.reading_vibe %}
-                    <span class="border border-brand-text {% cycle 'bg-brand-yellow' 'bg-brand-cyan' 'bg-brand-pink' 'bg-brand-orange' %} px-1.5 py-0.5 text-xs font-bold shadow-neo-sm">{{ phrase }}</span>
-                {% endfor %}
+                    {% for phrase in dna.reading_vibe %}
+                        <span
+                            class="border-brand-text {% cycle 'bg-brand-yellow' 'bg-brand-cyan' 'bg-brand-pink' 'bg-brand-orange' %} shadow-neo-sm border px-1.5 py-0.5 text-xs font-bold"
+                            >{{ phrase }}</span
+                        >
+                    {% endfor %}
                 </div>
             </div>
         {% endif %}
         <div class="mt-3 grid grid-cols-3 gap-1.5">
-            <div class="border-2 border-brand-text bg-brand-cyan p-1.5 text-center">
+            <div class="border-brand-text bg-brand-cyan border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_books_read }}</div>
                 <div class="text-[10px] uppercase">Books</div>
             </div>
-            <div class="border-2 border-brand-text bg-brand-cyan p-1.5 text-center">
+            <div class="border-brand-text bg-brand-cyan border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_pages_read|intcomma }}</div>
                 <div class="text-[10px] uppercase">Pages</div>
             </div>
-            <div class="border-2 border-brand-text bg-brand-cyan p-1.5 text-center">
+            <div class="border-brand-text bg-brand-cyan border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.average_rating_overall }}</div>
                 <div class="text-[10px] uppercase">Avg Rating</div>
             </div>
@@ -36,7 +39,10 @@
                     <p class="text-[10px] font-bold uppercase">Top Genres</p>
                     {% for genre, count in dna.top_genres|slice:":3" %}
                         <p class="mt-1.5 text-xs">
-                            <span class="inline-block border border-brand-text bg-brand-orange px-1 font-bold capitalize shadow-neo-sm">{{ genre }}</span>
+                            <span
+                                class="border-brand-text bg-brand-orange shadow-neo-sm inline-block border px-1 font-bold capitalize"
+                                >{{ genre }}</span
+                            >
                         </p>
                     {% endfor %}
                 </div>
@@ -46,27 +52,37 @@
                     <p class="text-[10px] font-bold uppercase">Top Authors</p>
                     {% for author, count in dna.top_authors|slice:":3" %}
                         <p class="mt-1.5 text-xs">
-                            <span class="inline-block border border-brand-text bg-brand-yellow px-1 font-bold shadow-neo-sm">{{ author|truncatewords:3 }}</span>
+                            <span
+                                class="border-brand-text bg-brand-yellow shadow-neo-sm inline-block border px-1 font-bold"
+                                >{{ author|truncatewords:3 }}</span
+                            >
                         </p>
                     {% endfor %}
                 </div>
             {% endif %}
         </div>
-        <div class="mt-2.5 border-2 border-brand-text bg-brand-pink p-2 text-center shadow-neo-sm">
+        <div class="border-brand-text bg-brand-pink shadow-neo-sm mt-2.5 border-2 p-2 text-center">
             <p class="text-xs uppercase">
                 <span class="text-2xl font-bold">{{ dna.mainstream_score_percent }}%</span> of my books are mainstream
             </p>
             {% if dna.most_niche_book %}
-                <p class="mt-0.5 text-[10px] leading-tight opacity-80">Nichest: {{ dna.most_niche_book.title|truncatewords:6 }}</p>
+                <p class="mt-0.5 text-[10px] leading-tight opacity-80">
+                    Nichest: {{ dna.most_niche_book.title|truncatewords:6 }}
+                </p>
             {% endif %}
         </div>
-        {% if dna.top_reader_types %}
-            <div class="mt-2.5 flex flex-wrap gap-1">
-                {% for item in dna.top_reader_types %}
-                    <span class="border border-brand-text {% cycle 'bg-brand-green' 'bg-brand-cyan' 'bg-brand-orange' %} px-1.5 py-0.5 text-[10px] font-bold shadow-neo-sm">{{ item.type }}</span>
-                {% endfor %}
-            </div>
-        {% endif %}
     </div>
-    <p class="text-center text-xs font-bold tracking-wider uppercase opacity-60">{{ share_url|default:"bibliotype.app" }}</p>
+    {% if dna.top_reader_types %}
+        <div class="mt-2.5 flex shrink-0 flex-wrap gap-1">
+            {% for item in dna.top_reader_types %}
+                <span
+                    class="border-brand-text {% cycle 'bg-brand-green' 'bg-brand-cyan' 'bg-brand-orange' %} shadow-neo-sm border px-1.5 py-0.5 text-[10px] font-bold"
+                    >{{ item.type }}</span
+                >
+            {% endfor %}
+        </div>
+    {% endif %}
+    <p class="mt-auto shrink-0 text-center text-xs font-bold tracking-wider uppercase opacity-60">
+        {{ share_url|default:"bibliotype.app" }}
+    </p>
 </div>

--- a/core/templates/core/partials/share/card_full_sherbet.html
+++ b/core/templates/core/partials/share/card_full_sherbet.html
@@ -1,8 +1,8 @@
 {% load humanize %}
-<div class="flex h-[568px] w-[320px] flex-col justify-between border-2 border-brand-text bg-brand-purple p-5">
-    <div class="min-h-0 overflow-hidden">
+<div class="border-brand-text bg-brand-purple flex h-[568px] w-[320px] flex-col border-2 p-5">
+    <div class="min-h-0 flex-1 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
-        <div class="mt-3 border-2 border-brand-text bg-brand-pink p-2.5 text-center shadow-neo-sm">
+        <div class="border-brand-text bg-brand-pink shadow-neo-sm mt-3 border-2 p-2.5 text-center">
             <p class="text-xs uppercase">My Reader Type is...</p>
             <p class="text-xl font-bold tracking-wider uppercase">{{ dna.reader_type }}</p>
         </div>
@@ -10,22 +10,25 @@
             <div class="mt-2.5">
                 <p class="mb-1 text-center text-[10px] font-bold uppercase opacity-70">Reading Vibes</p>
                 <div class="flex flex-wrap justify-center gap-1">
-                {% for phrase in dna.reading_vibe %}
-                    <span class="border border-brand-text {% cycle 'bg-brand-cyan' 'bg-brand-green' 'bg-brand-yellow' 'bg-brand-purple' %} px-1.5 py-0.5 text-xs font-bold shadow-neo-sm">{{ phrase }}</span>
-                {% endfor %}
+                    {% for phrase in dna.reading_vibe %}
+                        <span
+                            class="border-brand-text {% cycle 'bg-brand-cyan' 'bg-brand-green' 'bg-brand-yellow' 'bg-brand-purple' %} shadow-neo-sm border px-1.5 py-0.5 text-xs font-bold"
+                            >{{ phrase }}</span
+                        >
+                    {% endfor %}
                 </div>
             </div>
         {% endif %}
         <div class="mt-3 grid grid-cols-3 gap-1.5">
-            <div class="border-2 border-brand-text bg-brand-yellow p-1.5 text-center">
+            <div class="border-brand-text bg-brand-yellow border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_books_read }}</div>
                 <div class="text-[10px] uppercase">Books</div>
             </div>
-            <div class="border-2 border-brand-text bg-brand-yellow p-1.5 text-center">
+            <div class="border-brand-text bg-brand-yellow border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_pages_read|intcomma }}</div>
                 <div class="text-[10px] uppercase">Pages</div>
             </div>
-            <div class="border-2 border-brand-text bg-brand-yellow p-1.5 text-center">
+            <div class="border-brand-text bg-brand-yellow border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.average_rating_overall }}</div>
                 <div class="text-[10px] uppercase">Avg Rating</div>
             </div>
@@ -36,7 +39,10 @@
                     <p class="text-[10px] font-bold uppercase">Top Genres</p>
                     {% for genre, count in dna.top_genres|slice:":3" %}
                         <p class="mt-1.5 text-xs">
-                            <span class="inline-block border border-brand-text bg-brand-green px-1 font-bold capitalize shadow-neo-sm">{{ genre }}</span>
+                            <span
+                                class="border-brand-text bg-brand-green shadow-neo-sm inline-block border px-1 font-bold capitalize"
+                                >{{ genre }}</span
+                            >
                         </p>
                     {% endfor %}
                 </div>
@@ -46,27 +52,37 @@
                     <p class="text-[10px] font-bold uppercase">Top Authors</p>
                     {% for author, count in dna.top_authors|slice:":3" %}
                         <p class="mt-1.5 text-xs">
-                            <span class="inline-block border border-brand-text bg-brand-orange px-1 font-bold shadow-neo-sm">{{ author|truncatewords:3 }}</span>
+                            <span
+                                class="border-brand-text bg-brand-orange shadow-neo-sm inline-block border px-1 font-bold"
+                                >{{ author|truncatewords:3 }}</span
+                            >
                         </p>
                     {% endfor %}
                 </div>
             {% endif %}
         </div>
-        <div class="mt-2.5 border-2 border-brand-text bg-brand-cyan p-2 text-center shadow-neo-sm">
+        <div class="border-brand-text bg-brand-cyan shadow-neo-sm mt-2.5 border-2 p-2 text-center">
             <p class="text-xs uppercase">
                 <span class="text-2xl font-bold">{{ dna.mainstream_score_percent }}%</span> of my books are mainstream
             </p>
             {% if dna.most_niche_book %}
-                <p class="mt-0.5 text-[10px] leading-tight opacity-80">Nichest: {{ dna.most_niche_book.title|truncatewords:6 }}</p>
+                <p class="mt-0.5 text-[10px] leading-tight opacity-80">
+                    Nichest: {{ dna.most_niche_book.title|truncatewords:6 }}
+                </p>
             {% endif %}
         </div>
-        {% if dna.top_reader_types %}
-            <div class="mt-2.5 flex flex-wrap gap-1">
-                {% for item in dna.top_reader_types %}
-                    <span class="border border-brand-text {% cycle 'bg-brand-pink' 'bg-brand-green' 'bg-brand-yellow' %} px-1.5 py-0.5 text-[10px] font-bold shadow-neo-sm">{{ item.type }}</span>
-                {% endfor %}
-            </div>
-        {% endif %}
     </div>
-    <p class="text-center text-xs font-bold tracking-wider uppercase opacity-60">{{ share_url|default:"bibliotype.app" }}</p>
+    {% if dna.top_reader_types %}
+        <div class="mt-2.5 flex shrink-0 flex-wrap gap-1">
+            {% for item in dna.top_reader_types %}
+                <span
+                    class="border-brand-text {% cycle 'bg-brand-pink' 'bg-brand-green' 'bg-brand-yellow' %} shadow-neo-sm border px-1.5 py-0.5 text-[10px] font-bold"
+                    >{{ item.type }}</span
+                >
+            {% endfor %}
+        </div>
+    {% endif %}
+    <p class="mt-auto shrink-0 text-center text-xs font-bold tracking-wider uppercase opacity-60">
+        {{ share_url|default:"bibliotype.app" }}
+    </p>
 </div>

--- a/static/src/input.css
+++ b/static/src/input.css
@@ -43,6 +43,11 @@ ol.list-decimal {
     list-style-type: decimal;
 }
 
+/* Hide Alpine.js elements until the framework initialises */
+[x-cloak] {
+    display: none !important;
+}
+
 /* Force a scrollbar to always be present to prevent layout shifts */
 html {
     overflow-y: scroll;


### PR DESCRIPTION
## Summary
- Add missing `[x-cloak] { display: none !important }` CSS rule to `input.css` — fixes the instructions flash on the home page and display name editor flash on the dashboard
- Move reader trait badges outside the `overflow-hidden` content div on all 4 share card variants (`card_full`, `card_full_miami`, `card_full_sherbet`, `card_full_neon_picnic`) so they never get clipped
- Badges and URL are now `shrink-0` flex children; main content uses `flex-1` to fill remaining space

## Test plan
- [ ] Home page: instructions should NOT flash on page load
- [ ] Dashboard: display name editor should NOT flash on page load
- [ ] Share cards: all 4 themes should show all reader trait badges without cutoff on mobile
- [ ] Share card screenshot generation still works correctly
- [ ] All 230 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)