### PR TITLE
Add spacing between badges and URL on share cards

### DIFF
--- a/core/templates/core/partials/share/card_full.html
+++ b/core/templates/core/partials/share/card_full.html
@@ -74,7 +74,7 @@
             {% endfor %}
         </div>
     {% endif %}
-    <p class="mt-auto shrink-0 text-center text-xs font-bold tracking-wider uppercase opacity-60">
+    <p class="mt-auto shrink-0 pt-2 text-center text-xs font-bold tracking-wider uppercase opacity-60">
         {{ share_url|default:"bibliotype.app" }}
     </p>
 </div>

--- a/core/templates/core/partials/share/card_full_miami.html
+++ b/core/templates/core/partials/share/card_full_miami.html
@@ -82,7 +82,7 @@
             {% endfor %}
         </div>
     {% endif %}
-    <p class="mt-auto shrink-0 text-center text-xs font-bold tracking-wider uppercase opacity-60">
+    <p class="mt-auto shrink-0 pt-2 text-center text-xs font-bold tracking-wider uppercase opacity-60">
         {{ share_url|default:"bibliotype.app" }}
     </p>
 </div>

--- a/core/templates/core/partials/share/card_full_neon_picnic.html
+++ b/core/templates/core/partials/share/card_full_neon_picnic.html
@@ -82,7 +82,7 @@
             {% endfor %}
         </div>
     {% endif %}
-    <p class="mt-auto shrink-0 text-center text-xs font-bold tracking-wider uppercase opacity-60">
+    <p class="mt-auto shrink-0 pt-2 text-center text-xs font-bold tracking-wider uppercase opacity-60">
         {{ share_url|default:"bibliotype.app" }}
     </p>
 </div>

--- a/core/templates/core/partials/share/card_full_sherbet.html
+++ b/core/templates/core/partials/share/card_full_sherbet.html
@@ -82,7 +82,7 @@
             {% endfor %}
         </div>
     {% endif %}
-    <p class="mt-auto shrink-0 text-center text-xs font-bold tracking-wider uppercase opacity-60">
+    <p class="mt-auto shrink-0 pt-2 text-center text-xs font-bold tracking-wider uppercase opacity-60">
         {{ share_url|default:"bibliotype.app" }}
     </p>
 </div>


### PR DESCRIPTION
## Summary
- Add `pt-2` to the URL line on all 4 share card variants to separate it from the reader trait badges

## Test plan
- [ ] Check all share card themes — URL should have visible spacing from badges above

🤖 Generated with [Claude Code](https://claude.com/claude-code)