### PR TITLE
Reduce mainstream box height on share cards

### DIFF
--- a/core/templates/core/partials/share/card_full.html
+++ b/core/templates/core/partials/share/card_full.html
@@ -53,8 +53,8 @@
                 </div>
             {% endif %}
         </div>
-        <div class="border-brand-text mt-2.5 flex items-center gap-2 border-2 bg-white p-2">
-            <div class="text-2xl font-bold">{{ dna.mainstream_score_percent }}%</div>
+        <div class="border-brand-text mt-2 flex items-center gap-2 border-2 bg-white px-2 py-1">
+            <div class="text-xl font-bold">{{ dna.mainstream_score_percent }}%</div>
             <div class="text-xs">
                 <p class="font-bold uppercase">Mainstream</p>
                 {% if dna.most_niche_book %}

--- a/core/templates/core/partials/share/card_full_miami.html
+++ b/core/templates/core/partials/share/card_full_miami.html
@@ -61,9 +61,9 @@
                 </div>
             {% endif %}
         </div>
-        <div class="border-brand-text bg-brand-orange shadow-neo-sm mt-2.5 border-2 p-2 text-center">
+        <div class="border-brand-text bg-brand-orange shadow-neo-sm mt-2 border-2 px-2 py-1 text-center">
             <p class="text-xs uppercase">
-                <span class="text-2xl font-bold">{{ dna.mainstream_score_percent }}%</span> of my books are mainstream
+                <span class="text-xl font-bold">{{ dna.mainstream_score_percent }}%</span> of my books are mainstream
             </p>
             {% if dna.most_niche_book %}
                 <p class="mt-0.5 text-[10px] leading-tight opacity-80">

--- a/core/templates/core/partials/share/card_full_neon_picnic.html
+++ b/core/templates/core/partials/share/card_full_neon_picnic.html
@@ -61,9 +61,9 @@
                 </div>
             {% endif %}
         </div>
-        <div class="border-brand-text bg-brand-pink shadow-neo-sm mt-2.5 border-2 p-2 text-center">
+        <div class="border-brand-text bg-brand-pink shadow-neo-sm mt-2 border-2 px-2 py-1 text-center">
             <p class="text-xs uppercase">
-                <span class="text-2xl font-bold">{{ dna.mainstream_score_percent }}%</span> of my books are mainstream
+                <span class="text-xl font-bold">{{ dna.mainstream_score_percent }}%</span> of my books are mainstream
             </p>
             {% if dna.most_niche_book %}
                 <p class="mt-0.5 text-[10px] leading-tight opacity-80">

--- a/core/templates/core/partials/share/card_full_sherbet.html
+++ b/core/templates/core/partials/share/card_full_sherbet.html
@@ -61,9 +61,9 @@
                 </div>
             {% endif %}
         </div>
-        <div class="border-brand-text bg-brand-cyan shadow-neo-sm mt-2.5 border-2 p-2 text-center">
+        <div class="border-brand-text bg-brand-cyan shadow-neo-sm mt-2 border-2 px-2 py-1 text-center">
             <p class="text-xs uppercase">
-                <span class="text-2xl font-bold">{{ dna.mainstream_score_percent }}%</span> of my books are mainstream
+                <span class="text-xl font-bold">{{ dna.mainstream_score_percent }}%</span> of my books are mainstream
             </p>
             {% if dna.most_niche_book %}
                 <p class="mt-0.5 text-[10px] leading-tight opacity-80">


### PR DESCRIPTION
## Summary
- Shrink vertical padding on the mainstream percentage box from `p-2` to `px-2 py-1` on all 4 share card variants
- Reduce percentage text from `text-2xl` to `text-xl`
- Prevents the mainstream section from getting clipped by the overflow-hidden content area

## Test plan
- [ ] All 4 share card themes show the full mainstream box without cutoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)