### PR TITLE
Tighten share card layout to prevent content clipping

### DIFF
--- a/core/templates/core/partials/share/card_full.html
+++ b/core/templates/core/partials/share/card_full.html
@@ -2,18 +2,18 @@
 <div class="border-brand-text bg-brand-purple flex h-[568px] w-[320px] flex-col border-2 p-5">
     <div class="min-h-0 flex-1 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
-        <div class="border-brand-text mt-3 border-2 bg-white p-2.5 text-center">
+        <div class="border-brand-text mt-2 border-2 bg-white px-2.5 py-1.5 text-center">
             <p class="text-xs uppercase">I am a</p>
             <p class="text-xl font-bold tracking-wider uppercase">{{ dna.reader_type }}</p>
         </div>
         {% if dna.reading_vibe %}
-            <div class="mt-2.5 flex flex-wrap justify-center gap-1">
+            <div class="mt-2 flex flex-wrap justify-center gap-1">
                 {% for phrase in dna.reading_vibe %}
                     <span class="border-brand-text border bg-white px-1.5 py-0.5 text-xs font-bold">{{ phrase }}</span>
                 {% endfor %}
             </div>
         {% endif %}
-        <div class="mt-3 grid grid-cols-3 gap-1.5">
+        <div class="mt-2 grid grid-cols-3 gap-1.5">
             <div class="border-brand-text border-2 bg-white p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_books_read }}</div>
                 <div class="text-[10px] uppercase">Books</div>
@@ -27,7 +27,7 @@
                 <div class="text-[10px] uppercase">Avg Rating</div>
             </div>
         </div>
-        <div class="mt-2.5 grid grid-cols-2 gap-2">
+        <div class="mt-2 grid grid-cols-2 gap-2">
             {% if dna.top_genres %}
                 <div>
                     <p class="text-[10px] font-bold uppercase">Top Genres</p>
@@ -66,7 +66,7 @@
         </div>
     </div>
     {% if dna.top_reader_types %}
-        <div class="mt-2.5 flex shrink-0 flex-wrap gap-1">
+        <div class="mt-1.5 flex shrink-0 flex-wrap gap-1">
             {% for item in dna.top_reader_types %}
                 <span class="border-brand-text border bg-white px-1.5 py-0.5 text-[10px] font-bold"
                     >{{ item.type }}</span

--- a/core/templates/core/partials/share/card_full_miami.html
+++ b/core/templates/core/partials/share/card_full_miami.html
@@ -2,12 +2,12 @@
 <div class="border-brand-text bg-brand-purple flex h-[568px] w-[320px] flex-col border-2 p-5">
     <div class="min-h-0 flex-1 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
-        <div class="border-brand-text bg-brand-cyan shadow-neo-sm mt-3 border-2 p-2.5 text-center">
+        <div class="border-brand-text bg-brand-cyan shadow-neo-sm mt-2 border-2 px-2.5 py-1.5 text-center">
             <p class="text-xs uppercase">My Reader Type is...</p>
             <p class="text-xl font-bold tracking-wider uppercase">{{ dna.reader_type }}</p>
         </div>
         {% if dna.reading_vibe %}
-            <div class="mt-2.5">
+            <div class="mt-2">
                 <p class="mb-1 text-center text-[10px] font-bold uppercase opacity-70">Reading Vibes</p>
                 <div class="flex flex-wrap justify-center gap-1">
                     {% for phrase in dna.reading_vibe %}
@@ -19,7 +19,7 @@
                 </div>
             </div>
         {% endif %}
-        <div class="mt-3 grid grid-cols-3 gap-1.5">
+        <div class="mt-2 grid grid-cols-3 gap-1.5">
             <div class="border-brand-text bg-brand-pink border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_books_read }}</div>
                 <div class="text-[10px] uppercase">Books</div>
@@ -33,12 +33,12 @@
                 <div class="text-[10px] uppercase">Avg Rating</div>
             </div>
         </div>
-        <div class="mt-2.5 grid grid-cols-2 gap-2">
+        <div class="mt-2 grid grid-cols-2 gap-2">
             {% if dna.top_genres %}
                 <div>
                     <p class="text-[10px] font-bold uppercase">Top Genres</p>
                     {% for genre, count in dna.top_genres|slice:":3" %}
-                        <p class="mt-1.5 text-xs">
+                        <p class="mt-1 text-xs">
                             <span
                                 class="border-brand-text bg-brand-cyan shadow-neo-sm inline-block border px-1 font-bold capitalize"
                                 >{{ genre }}</span
@@ -51,7 +51,7 @@
                 <div>
                     <p class="text-[10px] font-bold uppercase">Top Authors</p>
                     {% for author, count in dna.top_authors|slice:":3" %}
-                        <p class="mt-1.5 text-xs">
+                        <p class="mt-1 text-xs">
                             <span
                                 class="border-brand-text bg-brand-orange shadow-neo-sm inline-block border px-1 font-bold"
                                 >{{ author|truncatewords:3 }}</span
@@ -73,7 +73,7 @@
         </div>
     </div>
     {% if dna.top_reader_types %}
-        <div class="mt-2.5 flex shrink-0 flex-wrap gap-1">
+        <div class="mt-1.5 flex shrink-0 flex-wrap gap-1">
             {% for item in dna.top_reader_types %}
                 <span
                     class="border-brand-text {% cycle 'bg-brand-pink' 'bg-brand-cyan' 'bg-brand-orange' %} shadow-neo-sm border px-1.5 py-0.5 text-[10px] font-bold"

--- a/core/templates/core/partials/share/card_full_neon_picnic.html
+++ b/core/templates/core/partials/share/card_full_neon_picnic.html
@@ -2,12 +2,12 @@
 <div class="border-brand-text bg-brand-purple flex h-[568px] w-[320px] flex-col border-2 p-5">
     <div class="min-h-0 flex-1 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
-        <div class="border-brand-text bg-brand-green shadow-neo-sm mt-3 border-2 p-2.5 text-center">
+        <div class="border-brand-text bg-brand-green shadow-neo-sm mt-2 border-2 px-2.5 py-1.5 text-center">
             <p class="text-xs uppercase">My Reader Type is...</p>
             <p class="text-xl font-bold tracking-wider uppercase">{{ dna.reader_type }}</p>
         </div>
         {% if dna.reading_vibe %}
-            <div class="mt-2.5">
+            <div class="mt-2">
                 <p class="mb-1 text-center text-[10px] font-bold uppercase opacity-70">Reading Vibes</p>
                 <div class="flex flex-wrap justify-center gap-1">
                     {% for phrase in dna.reading_vibe %}
@@ -19,7 +19,7 @@
                 </div>
             </div>
         {% endif %}
-        <div class="mt-3 grid grid-cols-3 gap-1.5">
+        <div class="mt-2 grid grid-cols-3 gap-1.5">
             <div class="border-brand-text bg-brand-cyan border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_books_read }}</div>
                 <div class="text-[10px] uppercase">Books</div>
@@ -33,12 +33,12 @@
                 <div class="text-[10px] uppercase">Avg Rating</div>
             </div>
         </div>
-        <div class="mt-2.5 grid grid-cols-2 gap-2">
+        <div class="mt-2 grid grid-cols-2 gap-2">
             {% if dna.top_genres %}
                 <div>
                     <p class="text-[10px] font-bold uppercase">Top Genres</p>
                     {% for genre, count in dna.top_genres|slice:":3" %}
-                        <p class="mt-1.5 text-xs">
+                        <p class="mt-1 text-xs">
                             <span
                                 class="border-brand-text bg-brand-orange shadow-neo-sm inline-block border px-1 font-bold capitalize"
                                 >{{ genre }}</span
@@ -51,7 +51,7 @@
                 <div>
                     <p class="text-[10px] font-bold uppercase">Top Authors</p>
                     {% for author, count in dna.top_authors|slice:":3" %}
-                        <p class="mt-1.5 text-xs">
+                        <p class="mt-1 text-xs">
                             <span
                                 class="border-brand-text bg-brand-yellow shadow-neo-sm inline-block border px-1 font-bold"
                                 >{{ author|truncatewords:3 }}</span
@@ -73,7 +73,7 @@
         </div>
     </div>
     {% if dna.top_reader_types %}
-        <div class="mt-2.5 flex shrink-0 flex-wrap gap-1">
+        <div class="mt-1.5 flex shrink-0 flex-wrap gap-1">
             {% for item in dna.top_reader_types %}
                 <span
                     class="border-brand-text {% cycle 'bg-brand-green' 'bg-brand-cyan' 'bg-brand-orange' %} shadow-neo-sm border px-1.5 py-0.5 text-[10px] font-bold"

--- a/core/templates/core/partials/share/card_full_sherbet.html
+++ b/core/templates/core/partials/share/card_full_sherbet.html
@@ -2,12 +2,12 @@
 <div class="border-brand-text bg-brand-purple flex h-[568px] w-[320px] flex-col border-2 p-5">
     <div class="min-h-0 flex-1 overflow-hidden">
         <p class="text-center text-sm font-bold tracking-[0.3em] uppercase">Bibliotype</p>
-        <div class="border-brand-text bg-brand-pink shadow-neo-sm mt-3 border-2 p-2.5 text-center">
+        <div class="border-brand-text bg-brand-pink shadow-neo-sm mt-2 border-2 px-2.5 py-1.5 text-center">
             <p class="text-xs uppercase">My Reader Type is...</p>
             <p class="text-xl font-bold tracking-wider uppercase">{{ dna.reader_type }}</p>
         </div>
         {% if dna.reading_vibe %}
-            <div class="mt-2.5">
+            <div class="mt-2">
                 <p class="mb-1 text-center text-[10px] font-bold uppercase opacity-70">Reading Vibes</p>
                 <div class="flex flex-wrap justify-center gap-1">
                     {% for phrase in dna.reading_vibe %}
@@ -19,7 +19,7 @@
                 </div>
             </div>
         {% endif %}
-        <div class="mt-3 grid grid-cols-3 gap-1.5">
+        <div class="mt-2 grid grid-cols-3 gap-1.5">
             <div class="border-brand-text bg-brand-yellow border-2 p-1.5 text-center">
                 <div class="text-lg font-bold">{{ dna.user_stats.total_books_read }}</div>
                 <div class="text-[10px] uppercase">Books</div>
@@ -33,12 +33,12 @@
                 <div class="text-[10px] uppercase">Avg Rating</div>
             </div>
         </div>
-        <div class="mt-2.5 grid grid-cols-2 gap-2">
+        <div class="mt-2 grid grid-cols-2 gap-2">
             {% if dna.top_genres %}
                 <div>
                     <p class="text-[10px] font-bold uppercase">Top Genres</p>
                     {% for genre, count in dna.top_genres|slice:":3" %}
-                        <p class="mt-1.5 text-xs">
+                        <p class="mt-1 text-xs">
                             <span
                                 class="border-brand-text bg-brand-green shadow-neo-sm inline-block border px-1 font-bold capitalize"
                                 >{{ genre }}</span
@@ -51,7 +51,7 @@
                 <div>
                     <p class="text-[10px] font-bold uppercase">Top Authors</p>
                     {% for author, count in dna.top_authors|slice:":3" %}
-                        <p class="mt-1.5 text-xs">
+                        <p class="mt-1 text-xs">
                             <span
                                 class="border-brand-text bg-brand-orange shadow-neo-sm inline-block border px-1 font-bold"
                                 >{{ author|truncatewords:3 }}</span
@@ -73,7 +73,7 @@
         </div>
     </div>
     {% if dna.top_reader_types %}
-        <div class="mt-2.5 flex shrink-0 flex-wrap gap-1">
+        <div class="mt-1.5 flex shrink-0 flex-wrap gap-1">
             {% for item in dna.top_reader_types %}
                 <span
                     class="border-brand-text {% cycle 'bg-brand-pink' 'bg-brand-green' 'bg-brand-yellow' %} shadow-neo-sm border px-1.5 py-0.5 text-[10px] font-bold"


### PR DESCRIPTION
## Summary
- Reduce margins and padding across all sections on all 4 share card variants
- Reader type box: `mt-3 p-2.5` → `mt-2 px-2.5 py-1.5`
- Reading vibes: `mt-2.5` → `mt-2`
- Stats grid: `mt-3` → `mt-2`
- Genre/author grid: `mt-2.5` → `mt-2`, items `mt-1.5` → `mt-1`
- Reader trait badges: `mt-2.5` → `mt-1.5`
- Saves ~25-30px of vertical space so the mainstream box no longer gets clipped on iPhone 16 and similar devices

## Test plan
- [ ] All 4 share card themes show the full mainstream box + badges + URL without cutoff on mobile
- [ ] Cards still look well-spaced and not overly cramped

🤖 Generated with [Claude Code](https://claude.com/claude-code)