### PR TITLE
Rewrite CLAUDE.md and add path-scoped rules subdocs

### DIFF
--- a/.claude/rules/caching.md
+++ b/.claude/rules/caching.md
@@ -1,0 +1,65 @@
+---
+paths:
+  - "core/cache_utils.py"
+  - "core/services/**"
+  - "core/views.py"
+---
+
+# Caching Architecture
+
+## Safe Cache Wrappers (`core/cache_utils.py`)
+
+All Redis operations MUST go through these wrappers — never call `cache.get/set/delete` directly:
+
+- `safe_cache_get(key, default=None)` — returns default on any exception
+- `safe_cache_set(key, value, timeout=None)` — silently continues on failure
+- `safe_cache_delete(key)` — silently continues on failure
+
+All three catch bare `Exception`, log a warning, and track via `track_redis_cache_error()` (production only). The app continues without cache — queries just run slower.
+
+## Redis Configuration
+
+- **Cache:** Redis DB 1 (`redis://localhost:6379/1` via `REDIS_CACHE_URL`)
+- **Celery broker/backend:** Redis DB 0 (`redis://localhost:6379/0`)
+- **Dev fallback:** Set `REDIS_CACHE_URL=locmem://` for in-memory cache
+- **Tests:** Use `@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})`
+
+## Cache Key Registry
+
+| Key | TTL | Set By | Read By |
+|-----|-----|--------|---------|
+| `user_recommendations_{user_id}` | 15min | recommendation_service | recommendation_service |
+| `anon_recommendations_{session_key}` | 15min | recommendation_service | recommendation_service |
+| `similar_users_{user_id}` | 30min | user_similarity_service | user_similarity_service |
+| `anon_profiles_sample` | 1hr | recommendation_service | recommendation_service |
+| `public_users_for_recs_sample` | 30min | recommendation_service | recommendation_service |
+| `dna_result_{task_id}` | 1hr | tasks.py (anonymous only) | tasks.py, views.py |
+| `session_key_{task_id}` | 1hr | tasks.py (anonymous only) | tasks.py |
+| `community_means` | 10min | views.py | views.py |
+| `fresh_pct_{bl}_{br}_{bpy}_{py}` | 10min | views.py | views.py |
+
+## Invalidation Strategy
+
+**Explicit invalidation (on DNA regeneration in `_save_dna_to_profile`):**
+- Deletes `similar_users_{user_id}` and `user_recommendations_{user_id}`
+- Clears `profile.recommendations_data` (triggers async regeneration)
+
+**On recommendation task completion:**
+- Deletes `user_recommendations_{user_id}`
+
+**Everything else is timeout-based** — no event-driven invalidation.
+
+## Database-Level Caching
+
+These `UserProfile` JSONFields act as persistent caches:
+- `dna_data` — overwritten on re-upload
+- `reading_vibe` + `vibe_data_hash` — regenerated only when book fingerprint SHA256 changes
+- `recommendations_data` + `recommendations_generated_at` — cleared on DNA save, regenerated async
+
+## Gotchas
+
+- Cache failures are **silent** — callers must handle `None` returns and compute fresh data
+- Cache keys are manually composed strings — check for typos
+- `dna_result_{task_id}` expires after 1 hour — anonymous users who wait too long to claim lose their cached result (falls back to Celery result backend)
+- Percentile cache is keyed by exact user stats — any stat change generates a new cache entry
+- No retry logic on cache failures — fail-fast approach

--- a/.claude/rules/celery-tasks.md
+++ b/.claude/rules/celery-tasks.md
@@ -1,0 +1,98 @@
+---
+paths:
+  - "core/tasks.py"
+  - "bibliotype/celery.py"
+---
+
+# Celery Tasks
+
+## Configuration
+
+- **Broker:** Redis DB 0 (`CELERY_BROKER_URL`, default `redis://localhost:6379/0`)
+- **Result backend:** Redis DB 0 (`CELERY_RESULT_BACKEND`)
+- **Serializer:** JSON only
+- **Timezone:** UTC
+- **Broker retry on startup:** Disabled (prevents hanging)
+- **Connection timeout:** 5 seconds
+
+## Task Registry
+
+| Task | Bind | Max Retries | Rate Limit | Countdown |
+|------|------|-------------|------------|-----------|
+| `generate_reading_dna_task` | Yes | None | None | — |
+| `claim_anonymous_dna_task` | Yes | 5 | None | Fixed 10s |
+| `generate_recommendations_task` | Yes | 3 | None | `60 * 2^retries` |
+| `enrich_book_task` | Yes | 3 | 30/min | `60 * 2^retries` |
+| `check_author_mainstream_status_task` | No | None | None | — |
+| `research_publisher_mainstream_task` | No | None | None | 2s sleep between |
+| `anonymize_expired_sessions_task` | No | None | None | — |
+| `run_management_command_task` | No | None | None | — |
+
+## Celery Beat Schedule
+
+- `anonymize_expired_sessions_task`: Daily at 2:00 AM UTC
+- `research_publisher_mainstream_task`: Weekly on Sundays at 3:00 AM UTC
+
+## Task Chain: Upload → DNA → Recommendations
+
+```
+upload_view
+├─ Auth user: generate_reading_dna_task.delay(csv_content, user.id)
+└─ Anon user: generate_reading_dna_task.delay(csv_content, None, session_key)
+    ↓
+generate_reading_dna_task
+├─ Parses CSV (Goodreads/StoryGraph auto-detected)
+├─ For each book:
+│   ├─ Create/fetch Author → if new: check_author_mainstream_status_task.delay()
+│   └─ Create/fetch Book → if new/no genres: enrich_book_task.delay() [rate-limited]
+├─ Create UserBook records (auth only)
+├─ Calculate stats, reader type, vibe (LLM)
+├─ Auth: _save_dna_to_profile() → generate_recommendations_task(user.id) [inline]
+└─ Anon: cache dna_result_{task_id} + session_key_{task_id} (1hr TTL)
+```
+
+## Progress Tracking
+
+`generate_reading_dna_task` passes a `progress_cb` to `calculate_full_dna()`:
+```python
+self.update_state(state="PROGRESS", meta={"current": N, "total": M, "stage": "description"})
+```
+
+**Stages:** "Parsing your library" → "Syncing books" → "Crunching stats" → "Finishing up"
+
+Progress updates are wrapped in try/except — they fail silently if the result backend is unavailable.
+
+**Frontend polling:** `get_task_result_view` returns progress JSON every 3 seconds. Percentage calculated client-side with stage-based caps (syncing: 70%, crunching: 90%, finishing: 98%).
+
+## Anonymous → Claim Flow
+
+```
+claim_anonymous_dna_task(user_id, task_id)
+1. Check cache: safe_cache_get("dna_result_{task_id}")
+2. If cached: save to profile, create UserBooks from AnonymousUserSession
+3. If not cached: check AsyncResult(task_id)
+   - Ready + successful: save to profile
+   - Ready + failed: clear pending_dna_task_id
+   - Not ready: retry with 10s countdown (max 5 retries)
+```
+
+## Error Handling
+
+- **All tasks:** Log errors via `logger.error(exc_info=True)`
+- **DNA tasks:** Track failures in PostHog (`track_dna_generation_failed`)
+- **Model.DoesNotExist:** Log and return early (don't retry)
+- **Generic Exception:** Log and re-raise (triggers retry if configured)
+- **Progress callback failures:** Silently caught (never blocks DNA generation)
+
+## Testing
+
+```python
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True,          # Tasks run synchronously
+    CELERY_TASK_EAGER_PROPAGATES=True,      # Exceptions propagate
+    CELERY_RESULT_BACKEND="django-db",
+)
+class MyTaskTest(TransactionTestCase):      # Must use TransactionTestCase
+```
+
+Always mock external service calls (`generate_vibe_with_llm`, `enrich_book_task.delay`, API calls).

--- a/.claude/rules/models.md
+++ b/.claude/rules/models.md
@@ -1,0 +1,80 @@
+---
+paths:
+  - "core/models.py"
+  - "core/services/**"
+---
+
+# Data Models
+
+## Normalization Pattern
+
+Author, Book, and Publisher auto-compute normalized fields in `save()` overrides. These are used for deduplication via unique constraints.
+
+**Author._normalize(name):** lowercase → remove punctuation → remove whitespace
+- "J.K. Rowling" → "jkrowling"
+
+**Book._normalize_title(title):** lowercase → remove parenthetical/bracketed content → remove punctuation → remove whitespace
+- "The Hobbit (1937 Edition)" → "thehobbit"
+
+**Publisher:** Reuses `Author._normalize()` for its `normalized_name`.
+
+Normalization is **lossy and one-way** — can cause false matches (rare) or miss edge cases.
+
+## Signals
+
+Two `post_save` receivers on User:
+1. `create_user_profile` — creates UserProfile when User is created
+2. `save_user_profile` — propagates User saves to UserProfile
+
+**Disconnected during fixture loading** (`load_fixture_data.py`) to prevent duplicate creation errors. Reconnected in `finally` block.
+
+## Key Relationships
+
+- **Book → Author:** CASCADE (author deleted = books deleted)
+- **Book → Publisher:** SET_NULL (publisher deleted = book keeps existing, publisher becomes null)
+- **Publisher → Publisher (parent):** SET_NULL, self-referential FK (related_name="subsidiaries")
+- **UserBook:** unique_together("user", "book") — one record per user per book
+- **Book:** unique_together("normalized_title", "author") — prevents duplicate books per author
+
+## AggregateAnalytics (Singleton)
+
+Forced `pk=1` in `save()`. Access via `AggregateAnalytics.get_instance()` (uses `get_or_create`).
+Contains histogram distributions for percentile calculations: `avg_book_length_dist`, `avg_publish_year_dist`, `total_books_read_dist`, `avg_books_per_year_dist`.
+
+## Three User Data Storage Models
+
+1. **UserProfile** — Persistent authenticated user data (dna_data, recommendations, reader_type)
+2. **AnonymousUserSession** — Temporary 7-day storage (session_key, dna_data, books_data, ratings). Indexed by (session_key, expires_at) for cleanup
+3. **AnonymizedReadingProfile** — Permanent anonymized aggregates for community comparisons (no identifiers)
+
+Flow: AnonymousUserSession → (expire) → AnonymizedReadingProfile (via `anonymize_expired_sessions_task`)
+
+## JSONField Schemas (no validation)
+
+**UserProfile.dna_data:** Complex nested dict with `user_stats`, `reader_type`, `top_genres`, `top_authors`, `ratings_distribution`, `reading_vibe`, `mainstream_score_percent`, `fiction_nonfiction_split`, and many more. Schema evolves without migrations.
+
+**UserProfile.reading_vibe:** List of strings (LLM-generated). Regenerated only when `vibe_data_hash` (SHA256 of book fingerprints) changes.
+
+**UserProfile.recommendations_data:** List of recommendation dicts with book info, confidence scores, and explanation components.
+
+**AnonymousUserSession fields:**
+- `books_data`: list of book IDs
+- `top_books_data`: top 5 book IDs
+- `genre_distribution` / `author_distribution`: {"name": count}
+- `book_ratings`: {"book_id": rating_int}
+
+## UserBook Top Books
+
+- `is_top_book` (bool) + `top_book_position` (1-5 or null)
+- Calculated by `calculate_and_store_top_books()` in top_books_service.py
+- Scoring: rating weight (5★=100, 4★=80, else rating×15) + sentiment weight (±30)
+- Resets ALL books to false, then marks top 5
+- Compound indexes on (user, is_top_book) and (book, is_top_book)
+
+## Gotchas
+
+- `Book.isbn13` is unique but nullable — multiple NULL values allowed (PostgreSQL behavior)
+- Publisher.parent allows cycles (no constraint preventing circular references)
+- `save_user_profile` signal fires on every User save — be careful of infinite loops in custom save logic
+- JSONField schemas are unvalidated — fields can be missing on older profiles (use `.get()` with defaults)
+- Author/Book normalized fields can diverge from display fields after manual edits

--- a/.claude/rules/posthog-analytics.md
+++ b/.claude/rules/posthog-analytics.md
@@ -1,0 +1,90 @@
+---
+paths:
+  - "core/analytics/**"
+  - "core/views.py"
+  - "core/tasks.py"
+  - "core/cache_utils.py"
+---
+
+# PostHog Analytics
+
+## Adding a New Event
+
+1. Add a `track_*` function in `core/analytics/events.py`:
+```python
+def track_my_event(user_id, custom_prop):
+    capture_event(
+        distinct_id=str(user_id) if user_id else "anonymous",
+        event_name="my_event",
+        properties={"user_id": user_id, "custom_prop": custom_prop},
+    )
+```
+
+2. Export in `core/analytics/__init__.py`
+3. Call from your view/task: `from core.analytics import track_my_event`
+
+## Conventions
+
+- **Event names:** snake_case (`file_upload_started`, `dna_generation_completed`)
+- **Distinct IDs:** `str(user.id)` for authenticated, `session.session_key` for anonymous, `"system"` for infrastructure events
+- **All events** automatically include `environment` ("production"/"development") and `server_hostname`
+- **Error messages:** Always truncated to 500 chars, sensitive patterns (api_key, password, secret, token) regex-stripped
+
+## Client Initialization
+
+- Lazy init on first `capture_event()` call — not at startup
+- API key from `POSTHOG_API_KEY` env var
+- EU instance: `https://eu.i.posthog.com`
+- Missing API key silently disables all tracking (logs warning once)
+
+## Frontend (`base.html`)
+
+```javascript
+posthog.init(API_KEY, {
+    api_host: 'https://eu.i.posthog.com',
+    person_profiles: 'identified_only',  // No anon person profiles
+    cookieless_mode: 'always',           // No cookies needed
+});
+// Authenticated users: posthog.identify('{{ user.id }}')
+```
+
+Context processor `posthog_settings` provides `POSTHOG_API_KEY` to templates.
+
+## Active Middleware
+
+- `PostHogExceptionMiddleware` — **ACTIVE** (in settings.py middleware stack). Catches unhandled exceptions, sanitizes error info, tracks as `"exception"` event. **Production only.**
+- `PostHogPageviewMiddleware` — **DEFINED BUT NOT ACTIVE** (not in middleware stack)
+
+## Event Registry
+
+**DNA lifecycle:**
+- `file_upload_started` — CSV uploaded (views.py)
+- `dna_generation_started` / `completed` / `failed` — Task lifecycle (tasks.py)
+- `anonymous_dna_generated` — Anonymous success (tasks.py)
+- `dna_displayed` / `anonymous_dna_displayed` — Dashboard viewed (views.py)
+
+**Authentication:**
+- `user_signed_up` — With `signup_source`: "with_task_claim", "with_session_dna", "before_dna"
+- `user_logged_in` — With `had_dna_in_session` flag
+- `anonymous_dna_claimed` — Anonymous DNA transferred to account
+
+**Profile & settings:**
+- `profile_made_public` — Privacy toggle
+- `public_profile_viewed` — With viewer/owner context
+- `settings_updated` — With `setting_type`: "display_name" or "recommendation_visibility"
+- `recommendations_generated` — With count
+
+**Infrastructure (distinct_id = "system"):**
+- `external_api_call` — Open Library/Google Books calls with status (success/error/not_found)
+- `redis_cache_error` — Cache failures with operation/key/error (production only)
+
+## Error Tracking in Cache (`cache_utils.py`)
+
+`track_redis_cache_error(operation, key, error_type, error_message)`:
+- Sanitizes long keys: `key[:50] + "..." + key[-50:]` if >100 chars
+- Truncates error messages to 500 chars
+- **Production only** — skips in development
+
+## Graceful Failure
+
+All tracking operations are wrapped in try/except. If PostHog is down or misconfigured, the app continues normally — events are simply lost.

--- a/.claude/rules/ui-and-styling.md
+++ b/.claude/rules/ui-and-styling.md
@@ -1,0 +1,102 @@
+---
+paths:
+  - "core/templates/**/*.html"
+  - "static/**"
+---
+
+# UI & Styling Patterns
+
+## Design System: Neobrutalist
+
+Hard 2px borders, heavy offset shadows, bright saturated colors, VT323 retro monospace font, no rounded corners.
+
+## Tailwind @theme Variables (`static/src/input.css`)
+
+**Colors:**
+- `brand-background` (#f5f5f5), `brand-text` (#1f2937)
+- Accents: `brand-yellow`, `brand-orange`, `brand-pink`, `brand-cyan`, `brand-green`, `brand-purple`
+- Badge scale: `badge-5` (strongest, green) → `badge-2` (weakest, light)
+
+**Shadows:**
+- `shadow-neo`: `4px 4px 0px 0px var(--color-brand-text)` (standard)
+- `shadow-neo-sm`: `2px 2px 0px 0px var(--color-brand-text)` (small)
+
+**Font:** `--font-sans: "VT323", ui-sans-serif, system-ui, sans-serif`
+
+## Component Patterns
+
+**Card:**
+```html
+<div class="border-brand-text shadow-neo border-2 bg-white p-6">
+```
+
+**Button (all buttons follow this):**
+```html
+<button class="bg-brand-green shadow-neo border-brand-text border-2 px-4 py-3 font-bold
+    transition-all duration-150 ease-in-out hover:shadow-none
+    active:translate-x-1 active:translate-y-1 cursor-pointer">
+```
+- Hover removes shadow (pressed effect)
+- Active translates 0.5-1px (tactile feedback)
+
+**Button partials** in `templates/core/partials/buttons/`: `primary_button`, `secondary_button` (multi-color/size), `nav_button`, `small_button`, `small_link_button`, `link_button`, `close_button`, `icon_button`. Include with context vars like `text`, `color`, `size`, `hover_color`.
+
+**DNA card partials** in `templates/core/partials/dna/`: 16 components for dashboard display. Include via `{% include %}` with `dna`, `pronoun_pos`, `enrichment` context.
+
+## Alpine.js Patterns (v3.x via CDN)
+
+- `x-data` objects on container divs with methods and computed getters
+- `[x-cloak]` hides elements until Alpine loads (prevents FOUC)
+- `x-teleport="body"` for modals (z-index management)
+- `@keydown.escape.window` to close modals
+- `Alpine.store('enrichment', {...})` for cross-component state
+- Polling: `setInterval` with `fetch()` + `clearInterval` on success
+
+**Common patterns:**
+- File upload drag-drop: `@dragover.prevent`, `@drop.prevent`
+- Scroll-triggered animations: `IntersectionObserver` with `threshold: 0.3`
+- Counter animations: `requestAnimationFrame` with cosine easing over 800ms
+- Loading dots: `setInterval(() => dots = dots.length >= 3 ? '' : dots + '.', 500)`
+
+## Chart.js
+
+```javascript
+Chart.defaults.font.family = "VT323";
+Chart.defaults.font.size = 16;
+Chart.defaults.color = "#1f2937";
+
+const chartColors = [
+    "#ffb4dd", "#40e7aa", "#ffa75e", "#8bbfff", "#FFE9CE",
+    "#ff647c", "#ffe56c", "#A1CDF1", "#9af6d4", "#fe9393"
+];
+```
+
+- Charts are **scroll-triggered** via `createChartOnScroll()` using IntersectionObserver
+- Classes toggle from `.chart-await` (hidden) to `.chart-visible` (shown)
+- Canvas drop-shadow: `4px 4px 0px #1f2937`
+- Chart config in `templates/core/partials/dna/charts_scripts.html`
+
+## CSS Custom Classes
+
+- `.grid-background`: 2rem grid pattern background
+- `.cover-crosshatch`: diagonal stripe pattern for book cover placeholders
+- `.scroll-fade-left` / `.scroll-fade-up`: scroll-triggered fade animations (0.6s ease-out)
+- `.enrichPulse`: opacity 1→0.5→1 infinite animation for enrichment banners
+
+## Responsive
+
+- Mobile-first with `md:` and `sm:` breakpoints
+- Grid: `grid grid-cols-1 gap-6 md:grid-cols-2` or `md:grid-cols-3`
+- Container: `container mx-auto max-w-4xl`
+- Input focus: `focus:ring-2 focus:ring-brand-purple focus:outline-none`
+
+## Template Inheritance
+
+All pages extend `core/base.html`. Key blocks: `seo_title`, `seo_description`, `og_*`, `twitter_*`, `structured_data`, `extra_head_js`, `content`.
+
+## JavaScript
+
+- **All inline** in templates — no separate JS files
+- Libraries via CDN: Alpine.js 3.15.8, Chart.js, html-to-image 1.11.11
+- Vanilla ES6+: arrow functions, async/await, optional chaining, template literals
+- Data serialization: `{{ dna|json_script:"dna-data" }}` + `JSON.parse()`

--- a/.claude/rules/user-flows.md
+++ b/.claude/rules/user-flows.md
@@ -1,0 +1,91 @@
+---
+paths:
+  - "core/views.py"
+  - "core/tasks.py"
+---
+
+# User Flows
+
+## Three Parallel Paths
+
+### 1. Authenticated Upload
+```
+upload_view: POST CSV → validate (10MB, .csv) → read UTF-8-SIG
+→ generate_reading_dna_task.delay(csv_content, user.id)
+→ save pending_dna_task_id on UserProfile
+→ clear session["dna_data"]
+→ redirect to /dashboard/?processing=true
+```
+
+### 2. Anonymous Upload
+```
+upload_view: POST CSV → same validation
+→ generate_reading_dna_task.delay(csv_content, None, session.session_key)
+→ save task_id in session["anonymous_task_id"]
+→ redirect to /task/<task_id>/
+```
+
+### 3. Login/Signup with Session DNA
+- **Signup with task_id:** `?task_id=X` param → `claim_anonymous_dna_task.delay(user.id, task_id)` → redirect to `/dashboard/?processing=true`
+- **Signup with session DNA:** Pop `session["dna_data"]` → `_save_dna_to_profile()` → redirect to `/dashboard/`
+- **Login with session DNA:** If `dna_data` in session AND user has no existing DNA → save and redirect
+
+## Status Polling (Two Different Endpoints)
+
+**Authenticated:** `check_dna_status_view`
+- Checks `profile.pending_dna_task_id` → `AsyncResult` state
+- Returns `{"status": "PENDING"|"SUCCESS"|"FAILURE", "progress": {...}}`
+
+**Anonymous:** `get_task_result_view`
+- Checks Redis cache `dna_result_{task_id}` first (fast path)
+- Falls back to `AsyncResult` if cache miss
+- On SUCCESS: stores DNA in session, loads book data from `AnonymousUserSession`
+- Returns `{"status": "SUCCESS", "redirect_url": "/dashboard/"}`
+
+## Dashboard (`display_dna_view`)
+
+**Authenticated:**
+- Loads from `session["dna_data"]` first, then `profile.dna_data`
+- Enriches with fresh community averages and percentiles (cached 10min)
+- Loads recommendations from `profile.recommendations_data`
+- If recommendations missing: triggers `generate_recommendations_task.delay()` and shows pending state
+- Checks enrichment progress (genre/page_count completion on UserBooks)
+
+**Anonymous:**
+- Loads from `session["dna_data"]`
+- Generates recommendations on-the-fly via `get_recommendations_for_anonymous(session_key)`
+- If `AnonymousUserSession` expired: recreates from session data with 7-day expiry
+
+## Session Data Keys
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `dna_data` | dict | Complete DNA analysis result |
+| `anonymous_task_id` | str | Task ID for progress polling |
+| `book_ids` | list | Book IDs from AnonymousUserSession.books_data |
+| `top_book_ids` | list | Top 5 book IDs |
+| `book_ratings` | dict | {book_id: rating} for correlation |
+
+## CAPTCHA (Cloudflare Turnstile)
+
+- Checked on signup and password reset
+- `verify_turnstile_token(token, remote_ip)` in `core/turnstile.py`
+- **Dev mode:** Returns `True` if no `TURNSTILE_SECRET_KEY` set
+- Frontend: `<div class="cf-turnstile" data-sitekey="...">`
+
+## Public Profiles (`public_profile_view`)
+
+- Checks `profile.is_public` (or viewer is owner)
+- Enriches DNA with fresh percentiles/community data
+- Reconstructs recommendation book dicts for template
+- Tracks view via `track_public_profile_viewed()` with viewer info
+- Returns 404 template (not Http404) for missing users
+
+## Gotchas
+
+- **Authentication is email-based** (case-insensitive `email__iexact` lookup), not username-based
+- Anonymous DNA cache expires after 1 hour — claiming after that falls back to Celery result backend
+- `session["dna_data"]` is only saved to profile on login if user has NO existing DNA
+- `?processing=true` is just a UI hint — the view doesn't validate it
+- CAPTCHA is production-only (bypassed when `TURNSTILE_SECRET_KEY` is unset)
+- `claim_anonymous_dna_task` failure doesn't surface errors to the user

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,405 +1,148 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Bibliotype is a Django app that analyzes Goodreads/StoryGraph CSV exports to generate "Reading DNA" dashboards with AI insights. Neobrutalist design (bold borders, offset shadows, VT323 font).
 
-## Project Overview
+## Quick Start (Docker — recommended)
 
-Bibliotype is a Django web application that analyzes reading data from Goodreads/StoryGraph CSV exports to generate personalized "Reading DNA" dashboards with AI-powered insights. It features a neobrutalist design aesthetic with bold borders, offset shadows, bright colors, and a retro monospace font (VT323).
-
-## Package Management (Poetry)
-
-**Poetry is the required package manager.** All Python dependencies are managed via `pyproject.toml` and `poetry.lock`. Never use `pip install` directly — always use Poetry commands.
+Local development uses `docker-compose.local.yml`, which runs all 4 services (PostgreSQL, Redis, Django, Celery worker) and mounts source code for live reload.
 
 ```bash
-poetry install                     # Install all dependencies (reads poetry.lock)
-poetry add <package>               # Add a new dependency
-poetry add --group dev <package>   # Add a dev-only dependency
-poetry run <command>               # Run a command inside the Poetry virtualenv
-poetry shell                       # Activate the virtualenv in your shell
-```
-
-- **Build system:** `poetry-core>=2.0.0` (defined in `[build-system]`)
-- **Virtual environment:** Created in-project (`.venv/`) via `POETRY_VIRTUALENVS_IN_PROJECT=true`
-- All `python manage.py` commands should be run via `poetry run python manage.py ...` unless the virtualenv is already activated
-- The `Procfile` (used by `honcho start`) already uses `poetry run` for Django and Celery processes
-
-## Development Commands
-
-### Running the Application
-```bash
-# Start both Django server and Tailwind watcher (recommended)
-honcho start
-
-# Or run separately:
-poetry run python manage.py runserver     # Django backend
-pnpm run dev                              # Tailwind CSS watch mode
-```
-
-### Database
-```bash
-poetry run python manage.py migrate
-poetry run python manage.py loaddata core/fixtures/initial_data.json
-poetry run python manage.py createsuperuser
-```
-
-### Testing
-```bash
-poetry run python manage.py test                              # Run all tests
-poetry run python manage.py test core.tests.test_views_e2e    # Run specific test module
-poetry run python manage.py test core.tests.test_views_e2e.TestClassName.test_method  # Single test
-```
-
-### Docker
-
-#### Local Development (`docker-compose.local.yml`)
-```bash
-docker-compose -f docker-compose.local.yml up --build -d      # Build and start all services
+docker-compose -f docker-compose.local.yml up --build -d      # Build and start everything
 docker-compose -f docker-compose.local.yml exec web poetry run python manage.py migrate
-docker-compose -f docker-compose.local.yml exec web poetry run python manage.py test
-docker-compose -f docker-compose.local.yml logs -f web         # Tail web logs
-docker-compose -f docker-compose.local.yml down                # Stop all services
-docker-compose -f docker-compose.local.yml down -v             # Stop and delete volumes (resets DB)
+docker-compose -f docker-compose.local.yml exec web poetry run python manage.py loaddata core/fixtures/initial_data.json
+docker-compose -f docker-compose.local.yml exec web poetry run python manage.py createsuperuser
+# App at http://localhost:8000
+
+docker-compose -f docker-compose.local.yml logs -f web         # Tail logs
+docker-compose -f docker-compose.local.yml exec web poetry run python manage.py test  # Run tests
+docker-compose -f docker-compose.local.yml down                # Stop
+docker-compose -f docker-compose.local.yml down -v             # Stop and reset DB
 ```
 
-#### Production (`docker-compose.prod.yml`)
+### Without Docker (alternative)
+
+Requires local PostgreSQL and Redis.
+
 ```bash
-docker compose -f docker-compose.prod.yml up -d --force-recreate   # Deploy/update
-docker compose -f docker-compose.prod.yml logs -f web worker       # Tail logs
+poetry install && pnpm install
+poetry run python manage.py migrate
+honcho start                    # Runs Django + Tailwind watcher via Procfile
 ```
 
-#### Docker Architecture
+## Package Management
 
-**Services (4 containers):**
-| Service | Image | Purpose |
-|---|---|---|
-| `db` | `postgres:15` | PostgreSQL database with named volume `postgres_data` for persistence |
-| `redis` | `redis:7-alpine` | Celery broker (db 0), result backend (db 0), Django cache (db 1) |
-| `web` | Built from `Dockerfile` | Django app server |
-| `worker` | Built from `Dockerfile` | Celery worker for async tasks |
+**Poetry only** — never `pip install`. All commands via `poetry run` unless virtualenv is activated.
 
-**Dockerfile build stages** (single-stage, `python:3.13-slim-bookworm`):
-1. Install system deps: `postgresql-client`, `dos2unix`, `curl`
-2. Install Node.js 20 (via nodesource) + pnpm (via npm)
-3. Set Poetry env vars (`POETRY_VIRTUALENVS_IN_PROJECT=true`, `POETRY_NO_INTERACTION=1`)
-4. Copy `pyproject.toml` + `poetry.lock` → `pip install poetry` → `poetry install --no-root`
-5. Copy `package.json` + `pnpm-lock.yaml` + `static/` + `tailwind.config.js` → `pnpm install --frozen-lockfile` → `pnpm run build`
-6. Copy rest of app, fix line endings (`dos2unix`), make scripts executable
-7. Entrypoint: `/app/docker-entrypoint.sh`
-
-**Entrypoint (`docker-entrypoint.sh`):**
-1. Waits for PostgreSQL to be ready (`wait-for-postgres.sh db`)
-2. Runs `poetry run python manage.py migrate`
-3. If `DJANGO_ENV=production`: runs `collectstatic --noinput`, sets file ownership to `www-data` (UID 33) on `/app/staticfiles`
-4. Executes the `command` from docker-compose via `exec "$@"`
-
-**Local vs Production differences:**
-| Aspect | Local | Production |
-|---|---|---|
-| **Web command** | `pnpm run dev & poetry run python manage.py runserver 0.0.0.0:8000` | `poetry run gunicorn bibliotype.wsgi:application --bind 0.0.0.0:8000` |
-| **Volumes** | Source code mounted (`.:/app`) for live reload; `.venv` and `node_modules` excluded via anonymous volumes | Only `./staticfiles:/app/staticfiles` for Nginx to serve |
-| **Ports** | `8000:8000` (all interfaces), `5432:5432`, `6379:6379` exposed | `127.0.0.1:8000:8000` (localhost only — Nginx proxies), no DB/Redis ports exposed |
-| **Image tag** | Built locally | `${DOCKERHUB_USERNAME}/bibliotype:${IMAGE_TAG:-latest}` |
-| **DJANGO_ENV** | `development` | `production` |
-
-**Environment variables** are passed from `.env` file via `${VAR}` interpolation in compose files. Both compose files share the same `.env` file.
-
-### Code Formatting
 ```bash
-# Python
+poetry install                          # Install deps
+poetry add <pkg>                        # Add dependency
+poetry add --group dev <pkg>            # Dev dependency
+poetry run python manage.py <cmd>       # Run Django commands
+```
+
+## Testing
+
+```bash
+poetry run python manage.py test                                                     # All tests
+poetry run python manage.py test core.tests.test_views_e2e                           # Module
+poetry run python manage.py test core.tests.test_views_e2e.TestClassName.test_method # Single test
+```
+
+Key patterns:
+- `django.test.TestCase` for most tests, `TransactionTestCase` for Celery task tests
+- **Always mock external services** (Gemini, Open Library, Google Books) with `@patch`
+- Celery sync in tests: `@override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPAGATES=True)`
+- In-memory cache: `@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})`
+- Test data created directly with ORM in `setUp()` — no factory libraries
+- Custom runner `ForceDisconnectTestRunner` handles PostgreSQL connection cleanup
+
+## Tailwind CSS Build
+
+`static/dist/output.css` is a compiled artifact checked into git. After any Tailwind/CSS changes (including changes to HTML templates that add new utility classes), you must rebuild and commit the output:
+
+```bash
+pnpm run build          # Compiles static/src/input.css → static/dist/output.css (minified)
+```
+
+If Tailwind changes aren't showing up locally, make sure either `pnpm run dev` (watch mode) is running or run `pnpm run build` manually.
+
+## Code Formatting
+
+```bash
 black --line-length 120 .
 isort --profile black --line-length 120 .
-
-# HTML/Templates (Prettier with jinja-template and tailwindcss plugins)
 npx prettier --write "**/*.html"
 ```
 
+Config is in `pyproject.toml` (Black, isort) and `.prettierrc` (Prettier with jinja-template + tailwindcss plugins).
+
 ## Architecture
 
-### Data Flow
 ```
-CSV Upload → Validation (10MB limit, .csv ext) → Celery Task (async) → DNA Analysis
-→ Book/Author DB Sync → API Enrichment (Open Library, Google Books)
-→ AI Vibe Generation (Gemini) → Results stored in UserProfile/AnonymousUserSession
-→ Recommendation Generation (async) → Cache
+CSV Upload → Celery Task (async) → DNA Analysis → Book/Author DB Sync
+→ API Enrichment (Open Library, Google Books) → AI Vibe (Gemini)
+→ Results in UserProfile/AnonymousUserSession → Recommendations (async)
 ```
 
-### Key Directories
-- `bibliotype/` - Django project config (settings.py, urls.py, celery.py, wsgi.py, runner.py)
-- `core/` - Main Django app
-  - `services/` - Business logic layer (9 service modules)
-  - `templates/core/` - HTML templates (base.html + page templates + partials/)
-  - `tests/` - Test suite (unit, integration, e2e, feature)
-  - `management/commands/` - 25 custom Django management commands
-  - `analytics/` - PostHog event tracking (posthog_client.py, events.py, middleware.py)
-  - `forms.py` - CustomUserCreationForm, UpdateDisplayNameForm
-  - `utils.py` - calculate_mainstream_score()
-  - `dna_constants.py` - Reader types, genre mappings, publisher hierarchies (~40KB)
-- `static/` - Static assets
-  - `src/input.css` - Tailwind CSS source with custom @theme variables
-  - `dist/output.css` - Compiled Tailwind CSS
+**Key directories:**
+- `bibliotype/` — Django project config
+- `core/services/` — Business logic (9 modules). Entry point: `dna_analyser.py:calculate_full_dna()`
+- `core/analytics/` — PostHog event tracking
+- `core/templates/core/partials/` — Reusable template components
+- `core/dna_constants.py` — Reader types, genre mappings, publisher hierarchies (~40KB)
 
-### Service Layer (`core/services/`)
-- `dna_analyser.py` - Core analysis engine: CSV parsing, book syncing, reader type assignment, statistics, vibe generation orchestration. Entry point: `calculate_full_dna()`
-- `llm_service.py` - Gemini 2.5 Flash integration with few-shot prompting. Returns JSON `{"vibe_phrases": [...]}`. No internal caching (handled by dna_analyser hash comparison)
-- `recommendation_service.py` - Class-based `RecommendationEngine` with multi-source candidate collection (similar users, anonymized profiles, fallback), scoring with diminishing returns (sqrt), diversity filtering, and explanation generation. Has `safe_cache_get/set()` wrappers for graceful Redis failure
-- `user_similarity_service.py` - Multi-component similarity: shared book correlation (35%), Jaccard overlap (15-25%), top books overlap (20%), genre cosine similarity (15%), author cosine similarity (15%), rating pattern (8%), reading era (7%). Bulk-optimized with `_bulk_build_user_contexts()`
-- `book_enrichment_service.py` - Two-stage: Open Library API (genres, metadata) then Google Books API (ratings). Genre canonicalization against `CANONICAL_GENRE_MAP`
-- `author_service.py` - Mainstream detection via Open Library (work count >= 10) + Wikipedia (monthly pageviews >= 2,000 or cultural icon >= 50,000)
-- `publisher_service.py` - Wikipedia + Gemini LLM analysis for Big 5 publisher hierarchy
-- `top_books_service.py` - Top book calculation with VADER sentiment scoring
-- `anonymization_service.py` - Batch anonymization of expired anonymous sessions
+**Non-obvious patterns:**
+- All views are function-based (no CBVs)
+- Authentication is email-based (case-insensitive), not username-based
+- Authenticated users get persistent `UserProfile` storage; anonymous users get session-based `AnonymousUserSession` (7-day expiry) that can be claimed on signup
+- Services query the ORM directly — no dependency injection
+- f-strings exclusively — no `.format()` or `%` formatting
+- All Redis operations go through `safe_cache_get/set/delete()` in `core/cache_utils.py` for graceful degradation
 
-Services are standalone functions (except `RecommendationEngine` class). Internal helpers use `_underscore` prefix. Data is passed as dicts and Counters. No dependency injection — services query the ORM directly.
+## Deep-Dive Rules (`.claude/rules/`)
 
-### Core Models (`core/models.py`)
-- `Genre` - name (unique, indexed)
-- `Publisher` - name, normalized_name (auto-computed in save()), is_mainstream, parent (self-referential FK)
-- `Author` - name (unique, indexed), normalized_name (auto-computed), popularity_score, is_mainstream. Static `_normalize()` method for string normalization
-- `Book` - title, author (FK CASCADE), normalized_title (auto-computed), genres (M2M), publisher (FK SET_NULL), isbn13 (unique), page_count, publish_year, average_rating, Google Books fields. unique_together on (normalized_title, author)
-- `UserBook` - user (FK CASCADE), book (FK CASCADE), user_rating (1-5), date_read, is_top_book, top_book_position. unique_together on (user, book)
-- `UserProfile` - user (OneToOne CASCADE), dna_data (JSONField), reader_type, reading_vibe (JSONField), vibe_data_hash, pending_dna_task_id, recommendations_data (JSONField), is_public, visible_in_recommendations
-- `AnonymousUserSession` - Temporary storage with session_key, dna_data, books_data, book_ratings (JSONField), expires_at
-- `AnonymizedReadingProfile` - Permanent anonymized profiles for community comparisons
-- `AggregateAnalytics` - Singleton (forced pk=1) with community distribution stats. Access via `get_instance()`
+These load automatically when you work on matching files:
 
-**Signals:** Two `post_save` receivers on User auto-create/save UserProfile. Disconnected during fixture loading (`load_fixture_data.py`).
+- `ui-and-styling.md` — Neobrutalist design system, Tailwind @theme, component patterns, Alpine.js, Chart.js
+- `caching.md` — safe_cache wrappers, Redis key registry, invalidation strategy, graceful degradation
+- `celery-tasks.md` — Task registry, retry/backoff, progress tracking, task chains, testing
+- `user-flows.md` — Auth vs anonymous uploads, DNA claim on signup, session data, CAPTCHA, polling
+- `posthog-analytics.md` — How to add events, naming conventions, middleware, event registry
+- `models.md` — Normalization, signals, JSONField schemas, constraints, singleton pattern
 
-**Normalization pattern:** Author, Book, and Publisher models auto-compute normalized fields in `save()` overrides using `_normalize()` / `_normalize_title()`.
+## Tech Stack
 
-### Views (`core/views.py`)
-All function-based views (no CBVs). Key decorators: `@login_required`, `@require_POST` (often stacked). Authentication is email-based (case-insensitive lookup), not username-based.
-
-Authenticated and anonymous users have separate flows — anonymous users get session-based temporary storage, authenticated users get persistent UserProfile storage. AJAX endpoints return `JsonResponse`, page views use `render()` with context dicts.
-
-### URL Conventions (`core/urls.py`)
-- App namespace: `core` (reversed as `core:view_name`)
-- URL paths use kebab-case: `update-privacy/`, `update-recommendation-visibility/`
-- API endpoints prefixed with `api/`: `api/update-username/`, `api/task-result/<str:task_id>/`
-- Public profiles at `u/<str:username>/`
-
-### Tech Stack
-- **Backend:** Django 5.2.5, Python 3.13+, Poetry 2.0+, Celery 5.5 + Redis 7
-- **Frontend:** Tailwind CSS 4.x (with custom @theme), Alpine.js 3.x (CDN), Chart.js (CDN)
-- **Database:** PostgreSQL 15 (prod), SQLite (dev fallback via dj-database-url)
-- **AI:** Google Generative AI — Gemini 2.5 Flash (`genai.GenerativeModel("gemini-2.5-flash")`)
-- **Analytics:** PostHog (EU instance, `https://eu.i.posthog.com`)
-- **Profiling:** Django Silk (dev-only)
-
-## Coding Conventions
-
-### Python
-- **Line length:** 120 characters (Black + isort)
-- **Formatting:** Black with `line-length = 120`; isort with `profile = "black"`, `multi_line_output = 3`, `include_trailing_comma = true`
-- **Imports:** Grouped with blank-line separators — stdlib first, third-party second, local third. Multi-line imports use parentheses
-- **Naming:** snake_case for functions/variables, PascalCase for classes, ALL_CAPS for constants, `_underscore` prefix for private functions
-- **Strings:** f-strings exclusively — no `.format()` or `%` formatting anywhere
-- **Type hints:** Used selectively, more prevalent in service functions (e.g., `author_name: str`, `user_id: int | None`). Not required on views or model methods
-- **Docstrings:** Selective, Google-style. Short one-liners for simple functions, multi-line for complex public methods. Not required on every function
-- **Logging:** Module-level `logger = logging.getLogger(__name__)` in every file. Use `logger.info/warning/error` with f-strings. Always pass `exc_info=True` on `logger.error` for tracebacks
-- **Error handling:** Catch specific Django exceptions first (`Model.DoesNotExist`), generic `Exception` last with logging. Graceful degradation preferred (continue/return, not crash). No custom exception classes — uses Django built-ins
-- **Constants:** Shared constants in `core/dna_constants.py`. Module-local constants defined inline near usage in ALL_CAPS
-
-### HTML / Templates
-- **Naming:** snake_case for all template files (e.g., `primary_button.html`, `reader_type_card.html`)
-- **Indentation:** 4 spaces (Prettier configured: `tabWidth: 4`, `printWidth: 120`)
-- **Parser:** Prettier with `jinja-template` parser for `.html` files and `tailwindcss` plugin for class sorting
-- **Inheritance:** All pages extend `core/base.html` which defines blocks: `seo_title`, `seo_description`, `og_*`, `twitter_*`, `structured_data`, `content`
-- **Partials:** Reusable components in `templates/core/partials/` organized by function (`buttons/`, `dna/`). Included with explicit context: `{% include 'core/partials/buttons/primary_button.html' with text="Click" %}`
-- **No custom template tags or filters** — all logic via context variables and built-in Django template features
-
-### Tailwind / CSS
-- **Design system:** Neobrutalist — 2px borders (`border-brand-text border-2`), offset shadows (`shadow-neo`: 4px 4px, `shadow-neo-sm`: 2px 2px), bright flat colors
-- **Custom theme** (in `static/src/input.css` @theme block): `brand-background`, `brand-text`, `brand-yellow/orange/pink/cyan/green/purple`, match colors, quality colors
-- **Font:** VT323 (retro monospace) via `--font-sans`
-- **Card pattern:** `class="border-brand-text shadow-neo border-2 bg-white p-6"`
-- **Button pattern:** Background color + `shadow-neo border-brand-text border-2` + `hover:shadow-none active:translate-x-1 active:translate-y-1 transition-all duration-150 ease-in-out`
-- **Responsive:** Mobile-first with `md:` / `sm:` breakpoint prefixes
-- **Grid:** `grid grid-cols-1 gap-6 md:grid-cols-2` or `md:grid-cols-3`
-
-### JavaScript
-- **No separate JS files** — all JavaScript is inline in templates or `<script>` tags
-- **Libraries:** Alpine.js for interactivity (drag-drop, toggles, animations), Chart.js for data visualization. Both loaded via CDN in base.html
-- **Style:** Vanilla ES6+ with arrow functions, optional chaining (`?.`), template literals, array methods (`.map()`, `.forEach()`)
-- **Alpine.js pattern:** `x-data` objects on container divs with methods and computed getters. Event handlers via `@click`, `@change`, `@submit.prevent`
-- **Chart.js pattern:** Canvas elements with `getElementById()?.getContext("2d")`, inline config objects. Global defaults set: `Chart.defaults.font.family = "VT323"`
-- **Chart colors:** `['#ffb4dd', '#40e7aa', '#ffa75e', '#8bbfff', '#FFE9CE', '#ff647c', '#ffe56c', '#A1CDF1', '#9af6d4', '#fe9393']`
-
-## Testing Conventions
-
-### Structure
-- Files in `core/tests/` named `test_<feature>.py`
-- Classes: `<Feature><Type>TestCase` or `<Feature>Tests` (e.g., `ViewE2E_Tests`, `TaskUnitTests`, `RecommendationTestCase`)
-- Methods: `test_<description>` in snake_case
-
-### Patterns
-- **Base classes:** `django.test.TestCase` for most tests, `TransactionTestCase` for e2e tests requiring real transactions
-- **Setup:** `setUp()` with direct ORM model creation. CSV data via `SimpleUploadedFile`
-- **Mocking:** `unittest.mock` with stacked `@patch("core.services.module.function")` decorators. External services (LLM, APIs, Celery tasks) always mocked
-- **Assertions:** Standard `self.assert*` methods — `assertEqual`, `assertContains`, `assertRedirects`, `assertGreater`, `assertIn`
-- **Celery in tests:** `@override_settings(CELERY_TASK_ALWAYS_EAGER=True)` makes tasks run synchronously
-- **Cache in tests:** `@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})` for in-memory cache
-- **Custom runner:** `ForceDisconnectTestRunner` in `bibliotype/runner.py` handles PostgreSQL connection cleanup during teardown
-
-## User Flows
-
-### Authenticated User Flow
-1. **Upload** (`upload_view`): User POSTs CSV → validated (10MB, .csv) → `request.session.pop("dna_data")` clears old session data → `generate_reading_dna_task.delay(csv_content, user.id)` queued → `pending_dna_task_id` saved on UserProfile → redirect to `/dashboard/?processing=true`
-2. **Processing** (`display_dna_view`): Sees processing spinner → frontend polls `check_dna_status_view` via AJAX → checks `profile.pending_dna_task_id` → queries `AsyncResult` for PROGRESS state (current/total/stage/percent) → returns `{"status": "PENDING", "progress": {...}}` or `{"status": "SUCCESS"}`
-3. **DNA Generation** (`generate_reading_dna_task` → `calculate_full_dna`):
-   - Parses CSV with pandas, filters to "read" shelf
-   - Generates SHA256 hash of book fingerprints (`title+author`) for cache invalidation
-   - Syncs books to DB: `Author.get_or_create()` by normalized_name, `Book.update_or_create()` by (normalized_title, author). New authors trigger `check_author_mainstream_status_task.delay(author.id)`
-   - Creates `UserBook` records with ratings/reviews via `update_or_create(user=user, book=book)`
-   - Assigns reader type via scoring system (`Counter`-based, checks genres, page lengths, publication years, mainstream status)
-   - Calculates stats: top genres/authors, ratings distribution, controversial books, sentiment analysis (VADER), yearly stats, mainstream score
-   - **Vibe caching**: Compares `new_data_hash` against `profile.vibe_data_hash` — if unchanged, reuses cached `profile.reading_vibe`; if changed, calls `generate_vibe_with_llm(dna)` (Gemini API)
-   - Calculates top 5 books via `calculate_and_store_top_books(user)`
-   - Saves via `_save_dna_to_profile()` which clears `pending_dna_task_id`, clears old `recommendations_data`, and triggers `generate_recommendations_task.delay(user.id)`
-   - Returns string `"DNA saved for user {id}"` (not the DNA dict)
-4. **Recommendations** (`generate_recommendations_task`): Runs asynchronously after DNA save → `RecommendationEngine.get_recommendations_for_user()` → processes results into serializable dicts (book_id, title, author, confidence, sources, explanation_components) → stores in `profile.recommendations_data` (JSONField) → invalidates Redis cache
-5. **Dashboard** (`display_dna_view`): Loads `profile.dna_data` + `profile.recommendations_data` → transforms stored recommendations to template-expected format (nested `rec["book"]` dict) → adds badge classes for display → renders `dashboard.html`
-6. **Re-upload**: Same flow — clears session data, sets new `pending_dna_task_id`, old DNA remains visible until new one replaces it
-
-### Anonymous User Flow
-1. **Upload** (`upload_view`): User POSTs CSV → `generate_reading_dna_task.delay(csv_content, None, session_key)` → `session["anonymous_task_id"] = task_id` → redirect to `/task/<task_id>/`
-2. **Processing** (`task_status_view` + `get_task_result_view`): Renders `task_status.html` (polling page) → frontend polls `get_task_result_view` via AJAX → checks Redis cache first (`dna_result_{task_id}`), then falls back to `AsyncResult` → returns PENDING/PROGRESS/SUCCESS/FAILURE
-3. **DNA Generation** (`generate_reading_dna_task` → `calculate_full_dna`):
-   - Same CSV parsing and book syncing as authenticated flow
-   - **No `UserBook` records created** — anonymous users don't have user FK
-   - Vibe always regenerated (no hash cache — anonymous users have no profile)
-   - Calls `save_anonymous_session_data()` → creates `AnonymousUserSession` with: dna_data, books_data (book IDs), top_books_data (top 5 IDs by rating+sentiment), genre_distribution, author_distribution, book_ratings (for correlation), expires_at (+7 days)
-   - Caches result: `safe_cache_set(f"dna_result_{task_id}", result_data, timeout=3600)` + `safe_cache_set(f"session_key_{task_id}", session_key, timeout=3600)`
-   - Returns the full DNA dict (not a string)
-4. **Result retrieval** (`get_task_result_view`): On SUCCESS → stores DNA in `request.session["dna_data"]` + stores `book_ids`, `top_book_ids`, `book_ratings` from `AnonymousUserSession` into session → returns `{"status": "SUCCESS", "redirect_url": "/dashboard/"}`
-5. **Dashboard** (`display_dna_view`): Reads `request.session["dna_data"]` → generates recommendations on-the-fly via `get_recommendations_for_anonymous(session_key)` (not pre-stored) → if `AnonymousUserSession` expired but session data exists, recreates it from dna_data → renders `dashboard.html`
-6. **Claiming DNA on signup** (`signup_view`): If `task_id` in query params → user signs up → `claim_anonymous_dna_task.delay(user.id, task_id)` → task checks Redis cache for `dna_result_{task_id}` → saves to UserProfile via `_save_dna_to_profile()` → creates `UserBook` records from `AnonymousUserSession` → sets top books. If task not ready yet, retries with 10s countdown (max 5 retries)
-7. **Session data on login** (`login_view`): If `dna_data` in session → pops it and saves to profile via `_save_dna_to_profile()` (only if user has no existing DNA)
-
-### Key Differences Between Flows
-| Aspect | Authenticated | Anonymous |
-|---|---|---|
-| **DNA storage** | `UserProfile.dna_data` (persistent) | `request.session["dna_data"]` + `AnonymousUserSession` (7-day expiry) |
-| **Book records** | `UserBook` rows created | No UserBook — book IDs stored in `AnonymousUserSession.books_data` |
-| **Progress polling** | `check_dna_status_view` (checks `pending_dna_task_id` on profile) | `get_task_result_view` (checks Redis cache then `AsyncResult`) |
-| **Recommendations** | Pre-generated async, stored in `profile.recommendations_data` | Generated on-the-fly in `display_dna_view` |
-| **Vibe caching** | Hash-based — reuses if library unchanged | Always regenerated |
-| **Task return value** | String `"DNA saved for user {id}"` | Full DNA dict (cached in Redis) |
-
-## Celery Task Details (`core/tasks.py`)
-
-### Task Registry
-| Task | Decorator | Retry | Purpose |
-|---|---|---|---|
-| `generate_reading_dna_task` | `@shared_task(bind=True)` | No auto-retry (raises on failure) | Main DNA pipeline with `progress_cb` for UI updates |
-| `claim_anonymous_dna_task` | `@shared_task(bind=True, max_retries=5)` | 10s countdown per retry | Transfer anonymous DNA to new user account |
-| `generate_recommendations_task` | `@shared_task(bind=True, max_retries=3)` | Exponential backoff: `60 * 2^retries` (60s, 120s, 240s) | Generate and store recommendations after DNA creation |
-| `check_author_mainstream_status_task` | `@shared_task` | No retry (raises on failure) | Check author via Open Library + Wikipedia APIs |
-| `anonymize_expired_sessions_task` | `@shared_task` | No retry | Celery Beat: daily at 2:00 AM UTC, converts expired sessions to `AnonymizedReadingProfile` |
-
-### Progress Tracking
-`generate_reading_dna_task` reports progress via `self.update_state(state="PROGRESS", meta={"current": N, "total": M, "stage": "description"})`. Stages: "Parsing your library" → "Syncing books" → "Crunching stats" → "Finishing up". Frontend polls and displays percent = `round((current * 100) / total)`.
-
-### Task Chain: DNA → Recommendations
-```
-upload_view → generate_reading_dna_task.delay()
-                  └→ calculate_full_dna()
-                       └→ _save_dna_to_profile()
-                            ├→ profile.save() (clears recommendations_data)
-                            └→ generate_recommendations_task.delay(user.id)
-                                 └→ get_recommendations_for_user()
-                                      └→ find_similar_users()
-                                      └→ Score, rank, filter, explain
-                                      └→ profile.recommendations_data = processed_recs
-```
-
-### Task Chain: Anonymous Upload → Signup → Claim
-```
-upload_view → generate_reading_dna_task.delay(csv, None, session_key)
-                  └→ calculate_full_dna() → returns DNA dict
-                  └→ safe_cache_set("dna_result_{task_id}", dna, 3600)
-                  └→ safe_cache_set("session_key_{task_id}", session_key, 3600)
-                  └→ save_anonymous_session_data() → AnonymousUserSession
-
-signup_view → claim_anonymous_dna_task.delay(user.id, task_id)
-                  └→ safe_cache_get("dna_result_{task_id}")
-                  ├→ Cache hit: _save_dna_to_profile() + _create_userbooks_from_anonymous_session()
-                  └→ Cache miss: AsyncResult(task_id).get() → _save_dna_to_profile()
-                  └→ If task not ready: self.retry(countdown=10)
-```
-
-## Caching Architecture
-
-### Redis Cache (django.core.cache)
-| Cache Key Pattern | TTL | Set By | Read By |
-|---|---|---|---|
-| `dna_result_{task_id}` | 3600s (1 hr) | `generate_reading_dna_task` (anonymous only) | `get_task_result_view`, `claim_anonymous_dna_task` |
-| `session_key_{task_id}` | 3600s (1 hr) | `generate_reading_dna_task` (anonymous only) | `claim_anonymous_dna_task` |
-| `user_recommendations_{user_id}_{limit}` | 900s (15 min) | `RecommendationEngine` | `RecommendationEngine` (check before computing) |
-| `similar_users_{user_id}_{top_n}_{min_similarity}` | 1800s (30 min) | `find_similar_users()` | `find_similar_users()` |
-| `anon_profiles_sample_{user_id}` | 3600s (1 hr) | `RecommendationEngine` | `RecommendationEngine` (100-profile sample) |
-| `public_users_for_recs_sample` | 1800s (30 min) | `RecommendationEngine` | `RecommendationEngine` |
-
-### Database-Level Caching
-| Field | Location | Invalidation |
-|---|---|---|
-| `dna_data` | `UserProfile` (JSONField) | Overwritten on re-upload |
-| `reading_vibe` + `vibe_data_hash` | `UserProfile` | Hash comparison — regenerated only when book fingerprint changes |
-| `recommendations_data` + `recommendations_generated_at` | `UserProfile` | Cleared by `_save_dna_to_profile()`, regenerated by `generate_recommendations_task` |
-| `dna_data` + distributions | `AnonymousUserSession` | Expires after 7 days, then anonymized by `anonymize_expired_sessions_task` |
-
-### Graceful Redis Failure
-All Redis operations go through `safe_cache_get(key, default=None)` / `safe_cache_set(key, value, timeout)` in `recommendation_service.py`. These catch any `Exception`, log a warning, track the error via `track_redis_cache_error()` in PostHog, and return the default value. The app continues functioning without cache — queries just run slower.
-
-### DNA Data Structure
-The DNA dict (stored in `UserProfile.dna_data` JSONField) contains:
-```python
-{
-    "user_stats": {"total_books_read", "total_pages_read", "avg_book_length", "avg_publish_year"},
-    "bibliotype_percentiles": {...},           # Percentile ranks vs community
-    "global_averages": {...},                  # From GLOBAL_AVERAGES constant
-    "most_niche_book": {"title", "author", "read_count"},
-    "reader_type": str,                        # e.g., "Fantasy Fanatic", "Tome Tussler"
-    "reader_type_explanation": str,
-    "top_reader_types": [{"type", "score"}],   # Top 3
-    "reader_type_scores": {type: score},
-    "top_genres": [(genre, count), ...],       # Top 10, canonicalized
-    "top_authors": [(author, count), ...],     # Top 10
-    "average_rating_overall": float,
-    "ratings_distribution": {"1": N, "2": N, ...},
-    "top_controversial_books": [{"Title", "Author", "my_rating", "average_rating", "rating_difference"}],
-    "most_positive_review": {"Title", "Author", "my_review", "sentiment"},
-    "most_negative_review": {"Title", "Author", "my_review", "sentiment"},
-    "stats_by_year": [{"year", "count", "avg_rating"}],
-    "mainstream_score_percent": int,           # 0-100
-    "reading_vibe": [str, str, str, str],      # 4 LLM-generated phrases
-    "vibe_data_hash": str,                     # SHA256 for cache invalidation
-}
-```
-
-## Analytics (PostHog)
-- Events use snake_case: `file_upload_started`, `dna_generation_completed`, `user_signed_up`, `recommendations_generated`
-- Distinct IDs: `str(user.id)` for authenticated, `session.session_key` for anonymous, `"system"` for background tasks
-- All events include `environment` property ("production" / "development")
-- Error messages sanitized: truncated to 500 chars, API keys/passwords stripped via regex
-- Two custom middleware classes: `PostHogPageviewMiddleware` (tracks `$pageview`, excludes /admin/, /static/, /api/, /silk/) and `PostHogExceptionMiddleware` (production-only exception tracking)
-
-## Constants
-`core/dna_constants.py` (~40KB) contains `READER_TYPE_DESCRIPTIONS`, `CANONICAL_GENRE_MAP`, `EXCLUDED_GENRES`, `MAINSTREAM_PUBLISHERS_HIERARCHY`, and `GLOBAL_AVERAGES`. Reference this when working with DNA analysis or genre logic.
+- **Backend:** Django 5.2, Python 3.13+, Celery 5.5, Redis 7, PostgreSQL 15
+- **Frontend:** Tailwind CSS 4 (custom @theme in `static/src/input.css`), Alpine.js 3, Chart.js (both CDN)
+- **AI:** Gemini 2.5 Flash via `google-generativeai`
+- **Analytics:** PostHog (EU instance)
 
 ## Environment Variables
 
-Required:
-- `SECRET_KEY`, `GEMINI_API_KEY`
-- `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` (or `DATABASE_URL`)
+Required: `SECRET_KEY`, `GEMINI_API_KEY`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` (or `DATABASE_URL`)
 
-Optional:
-- `REDIS_CACHE_URL` (default: `redis://localhost:6379/1`), `CELERY_BROKER_URL` (default: `redis://localhost:6379/0`)
-- `POSTHOG_API_KEY`, `NYT_API_KEY`, `GOOGLE_BOOKS_API_KEY`
-- `DEBUG` (defaults True in dev), `ALLOWED_HOSTS`, `DJANGO_ENV` ("production" or "development")
+Optional: `REDIS_CACHE_URL`, `CELERY_BROKER_URL`, `POSTHOG_API_KEY`, `GOOGLE_BOOKS_API_KEY`, `NYT_API_KEY`, `DEBUG`, `ALLOWED_HOSTS`, `DJANGO_ENV`
+
+See `.env.example` for the full list including email and Turnstile CAPTCHA config.
 
 ## CI/CD
 
-- **Tests:** GitHub Actions on push to `main` and PRs — builds Docker containers, runs `poetry run python manage.py test` inside container
-- **Deploy:** On push to `main` — builds and pushes Docker image to Docker Hub (tagged with commit SHA), then SSH deploys to DigitalOcean VPS with `docker compose -f docker-compose.prod.yml up -d --force-recreate`
-- **Production stack:** Nginx reverse proxy (SSL via Certbot) → Gunicorn (via `poetry run`) → Django, with separate Celery worker container
-- **No pre-commit hooks configured**
+- **Tests:** GitHub Actions on push to `main` and PRs — runs in Docker
+- **Deploy:** Push to `main` → Docker Hub image → SSH deploy to DigitalOcean VPS
+- **Production:** Nginx (SSL/Certbot) → Gunicorn → Django + Celery worker
+- No pre-commit hooks configured
+
+## Docker
+
+4 containers: `db` (PostgreSQL 15), `redis` (Redis 7), `web` (Django), `worker` (Celery).
+
+```bash
+# Local
+docker-compose -f docker-compose.local.yml up --build -d
+docker-compose -f docker-compose.local.yml down -v          # Reset DB
+
+# Production
+docker compose -f docker-compose.prod.yml up -d --force-recreate
+```
+
+Local mounts source code for live reload. Production uses Gunicorn with staticfiles served by Nginx. Both share the same `.env` file.


### PR DESCRIPTION
## Summary
- Rewrites CLAUDE.md from ~405 lines to ~130 lines, cutting content Claude can infer from code (model fields, detailed user flows, caching tables, DNA data structure, standard Python/Django conventions)
- Adds 6 path-scoped rules files in `.claude/rules/` that load on-demand only when Claude works on matching files
- Recommends Docker for local development, documents Tailwind build/commit workflow

## Rules files added
| File | Scoped to | Content |
|------|-----------|---------|
| `ui-and-styling.md` | `*.html`, `static/**` | Neobrutalist design system, Tailwind @theme, component patterns, Alpine.js, Chart.js |
| `caching.md` | `cache_utils.py`, `services/**`, `views.py` | safe_cache wrappers, Redis key registry, invalidation, graceful degradation |
| `celery-tasks.md` | `tasks.py`, `celery.py` | Task registry, retry/backoff, progress tracking, task chains |
| `user-flows.md` | `views.py`, `tasks.py` | Auth vs anonymous flows, DNA claim, session data, CAPTCHA |
| `posthog-analytics.md` | `analytics/**`, `views.py`, `tasks.py` | How to add events, naming conventions, middleware, event registry |
| `models.md` | `models.py`, `services/**` | Normalization, signals, JSONField schemas, constraints |

## Why
Based on research (ETH Zurich study, Anthropic docs, community best practices): shorter CLAUDE.md files improve instruction-following. Path-scoped rules keep context lean by only loading when relevant files are touched.

## Test plan
- [ ] Verify Claude Code loads rules when editing matching files
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Spot-check rules accuracy against current codebase