### PR TITLE
Stop Silk dropping .prof files in repo root

### DIFF
--- a/bibliotype/settings.py
+++ b/bibliotype/settings.py
@@ -265,7 +265,7 @@ handler404 = 'core.views.handler404'
 # Django Silk configuration - only used when DEBUG=True (local development)
 if DEBUG:
     SILKY_PYTHON_PROFILER = True
-    SILKY_PYTHON_PROFILER_BINARY = True
+    SILKY_PYTHON_PROFILER_BINARY = False
     SILKY_META = True
     # Limit the number of requests to store (prevents database bloat)
     SILKY_MAX_RECORDED_REQUESTS = 1000


### PR DESCRIPTION
## Summary
- Sets `SILKY_PYTHON_PROFILER_BINARY = False` so Silk stops writing cProfile binary files to the working directory on every profiled request.
- Silk's in-DB traces remain available for normal profiling — only the standalone `.prof` files are gone.
- Binary files are only useful with snakeviz / pyprof2calltree, which we don't use.

Local impact: a fresh dev session no longer accumulates hundreds of `*.prof` files in the repo root.

## Test plan
- [ ] Restart local dev server (`docker-compose -f docker-compose.local.yml restart web`)
- [ ] Make a few requests against the app
- [ ] Confirm no new `*.prof` files appear in the repo root
- [ ] Confirm Silk UI at `/silk/` still shows requests with profiler data