### PR TITLE
Revoke prior DNA task on re-upload (fix stuck-at-50%)

### DIFF
--- a/core/tests/test_storygraph_integration.py
+++ b/core/tests/test_storygraph_integration.py
@@ -326,3 +326,129 @@ class UploadNonceTests(TransactionTestCase):
         self.assertIsNotNone(first_nonce)
         self.assertIsNotNone(second_nonce)
         self.assertNotEqual(first_nonce, second_nonce)
+
+
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_STORE_EAGER_RESULT=True,
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "concurrent-upload-tests",
+        }
+    },
+)
+class ConcurrentUploadRevokeTests(TransactionTestCase):
+    """Re-uploading while a prior DNA task is still pending revokes the prior task.
+
+    Without this, the prior task keeps running and contends on Postgres row locks
+    with the new task, stalling the new task's progress bar at ~50%.
+    """
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="revoke_user", email="revoke@test.com", password="testpass123"
+        )
+        self.client.force_login(self.user)
+
+    def tearDown(self):
+        from django.db import connections
+
+        for conn in connections.all():
+            if conn.connection is not None:
+                conn.close()
+        connections.close_all()
+        super().tearDown()
+
+    def _upload(self):
+        csv_content = (
+            "Title,Author,Exclusive Shelf,My Rating\n"
+            "Test Book,Test Author,read,4\n"
+        ).encode("utf-8")
+        csv_file = SimpleUploadedFile("g.csv", csv_content, content_type="text/csv")
+        return self.client.post(reverse("core:upload"), {"csv_file": csv_file})
+
+    @patch("core.views.AsyncResult")
+    @patch("core.services.dna_analyser.generate_vibe_with_llm", return_value=["a vibe"])
+    @patch("core.book_enrichment_service.enrich_book_from_apis")
+    def test_upload_revokes_prior_pending_task(self, mock_enrich, mock_vibe, mock_async_result):
+        """If a prior DNA task is still pending, the new upload revokes it."""
+        prior_id = "prior-task-id-123"
+        self.user.userprofile.pending_dna_task_id = prior_id
+        self.user.userprofile.save()
+
+        prior_result = mock_async_result.return_value
+        prior_result.ready.return_value = False
+
+        self._upload()
+
+        mock_async_result.assert_any_call(prior_id)
+        prior_result.revoke.assert_called_once_with(terminate=True, signal="SIGTERM")
+
+    @patch("core.views.AsyncResult")
+    @patch("core.services.dna_analyser.generate_vibe_with_llm", return_value=["a vibe"])
+    @patch("core.book_enrichment_service.enrich_book_from_apis")
+    def test_upload_does_not_revoke_completed_task(self, mock_enrich, mock_vibe, mock_async_result):
+        """If the prior task has already finished, no revoke is attempted."""
+        prior_id = "prior-task-id-456"
+        self.user.userprofile.pending_dna_task_id = prior_id
+        self.user.userprofile.save()
+
+        prior_result = mock_async_result.return_value
+        prior_result.ready.return_value = True
+
+        self._upload()
+
+        prior_result.revoke.assert_not_called()
+
+    @patch("core.views.AsyncResult")
+    @patch("core.services.dna_analyser.generate_vibe_with_llm", return_value=["a vibe"])
+    @patch("core.book_enrichment_service.enrich_book_from_apis")
+    def test_upload_succeeds_when_revoke_raises(self, mock_enrich, mock_vibe, mock_async_result):
+        """A failure to revoke the prior task must not block the new upload."""
+        prior_id = "prior-task-id-789"
+        self.user.userprofile.pending_dna_task_id = prior_id
+        self.user.userprofile.save()
+
+        prior_result = mock_async_result.return_value
+        prior_result.ready.return_value = False
+        prior_result.revoke.side_effect = RuntimeError("broker unavailable")
+
+        response = self._upload()
+
+        # Upload still redirects to the dashboard processing view
+        self.assertEqual(response.status_code, 302)
+        self.user.userprofile.refresh_from_db()
+        self.assertIsNotNone(self.user.userprofile.pending_dna_task_id)
+        self.assertNotEqual(self.user.userprofile.pending_dna_task_id, prior_id)
+
+    @patch("core.services.dna_analyser.generate_vibe_with_llm", return_value=["a vibe"])
+    @patch("core.book_enrichment_service.enrich_book_from_apis")
+    def test_reupload_clears_stale_userbooks(self, mock_enrich, mock_vibe):
+        """Books from a prior upload that aren't in the new CSV are removed (handhles
+        orphans from a revoked task — calculate_full_dna deletes UserBooks not in the
+        current upload)."""
+        # First upload: one book
+        first_csv = (
+            "Title,Author,Exclusive Shelf,My Rating\n"
+            "Old Book,Old Author,read,5\n"
+        ).encode("utf-8")
+        self.client.post(
+            reverse("core:upload"),
+            {"csv_file": SimpleUploadedFile("a.csv", first_csv, content_type="text/csv")},
+        )
+        self.assertTrue(UserBook.objects.filter(user=self.user, book__title="Old Book").exists())
+
+        # Second upload: different book
+        second_csv = (
+            "Title,Author,Exclusive Shelf,My Rating\n"
+            "New Book,New Author,read,4\n"
+        ).encode("utf-8")
+        self.client.post(
+            reverse("core:upload"),
+            {"csv_file": SimpleUploadedFile("b.csv", second_csv, content_type="text/csv")},
+        )
+
+        self.assertFalse(UserBook.objects.filter(user=self.user, book__title="Old Book").exists())
+        self.assertTrue(UserBook.objects.filter(user=self.user, book__title="New Book").exists())

--- a/core/views.py
+++ b/core/views.py
@@ -745,6 +745,28 @@ def upload_view(request):
             # Clear old session data so the view will use the updated profile data
             request.session.pop("dna_data", None)
 
+            # If a previous upload is still running, revoke it before dispatching
+            # the new one. Without this, both tasks contend on the same Book/Author
+            # row locks in Postgres and the new task's progress bar stalls until
+            # the old task releases its locks ("stuck at 50%").
+            prior_task_id = request.user.userprofile.pending_dna_task_id
+            if prior_task_id:
+                try:
+                    prior_result = AsyncResult(prior_task_id)
+                    if not prior_result.ready():
+                        prior_result.revoke(terminate=True, signal="SIGTERM")
+                        logger.info(
+                            f"Revoked pending DNA task {prior_task_id} for user {request.user.id} "
+                            f"because a new upload superseded it"
+                        )
+                except Exception as e:
+                    # Best-effort: a failed revoke shouldn't block the new upload.
+                    # The nonce mechanism still protects enrichment tasks; the worst
+                    # case is brief lock contention until the prior task finishes.
+                    logger.warning(
+                        f"Failed to revoke prior DNA task {prior_task_id} for user {request.user.id}: {e}"
+                    )
+
             # Store upload nonce BEFORE dispatching the task so enrichment tasks
             # from previous uploads can detect they've been superseded. Using uuid
             # rather than task ID since the task hasn't been created yet.
@@ -755,9 +777,13 @@ def upload_view(request):
 
             result = generate_reading_dna_task.delay(csv_content, request.user.id)
 
-            # Save the pending task ID to track regeneration progress
-            request.user.userprofile.pending_dna_task_id = result.id
-            request.user.userprofile.save()
+            # Save the pending task ID to track regeneration progress.
+            # Use .update() instead of fetching + saving the related object — the
+            # eager task path runs the DNA save inline, and a cached stale
+            # UserProfile instance here would clobber the DNA the task just wrote.
+            from .models import UserProfile
+
+            UserProfile.objects.filter(user=request.user).update(pending_dna_task_id=result.id)
 
             messages.success(
                 request,


### PR DESCRIPTION
## Summary

Fixes the "stuck at 50%" bug from PR #98's handoff doc (§2): uploading a CSV while a previous DNA task was still running caused the new task's progress bar to stall at ~50% until the old task finished.

**Root cause:** Both tasks ran concurrently and contended on Postgres row locks during \`get_or_create\` on shared Book/Author rows. The new task blocked on the old task's open transaction, so the dashboard's polling saw frozen progress.

**Fix:** Before dispatching the new DNA task, \`upload_view\` revokes the prior pending task (\`AsyncResult.revoke(terminate=True, signal="SIGTERM")\`) — best-effort, with a try/except so a failed revoke can't block the new upload. This matches user intent ("I clearly meant to replace that upload"), which the handoff doc preferred over a reject-while-pending guard.

**Why no orphan-row cleanup is needed:**
- \`calculate_full_dna\` already deletes \`UserBook\` rows not in the current upload (\`core/services/dna_analyser.py:687\`).
- Orphan \`Book\` and \`Author\` rows are shared resources — nothing depends on them being scoped to a single user's upload.
- The existing upload-nonce mechanism makes any in-flight \`enrich_book_task\` from the revoked upload exit early.

**Side fix:** Switched \`pending_dna_task_id\` write to \`UserProfile.objects.filter(...).update(...)\`. The previous code accessed \`request.user.userprofile\` *after* \`.delay()\`, which in eager-mode tests fetched fresh after the task wrote DNA. My new revoke logic accesses \`userprofile\` *before* dispatch, caching a stale instance whose later \`.save()\` clobbered the DNA. \`.update()\` sidesteps the cached instance entirely.

## Test plan

- [x] \`test_upload_revokes_prior_pending_task\` — prior task ready=False → revoke called with terminate=True, SIGTERM
- [x] \`test_upload_does_not_revoke_completed_task\` — prior task ready=True → revoke not called
- [x] \`test_upload_succeeds_when_revoke_raises\` — revoke raises → upload still succeeds, new task ID written
- [x] \`test_reupload_clears_stale_userbooks\` — re-upload with different books removes the old UserBook rows
- [x] Full suite: \`docker-compose -f docker-compose.local.yml exec web poetry run python manage.py test\` → 343 passed
- [ ] Manual: upload a large CSV, immediately re-upload before the first finishes; confirm the second progress bar advances normally instead of stalling