### PR TITLE
Gate Django Silk behind ENABLE_SILK flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ GOOGLE_BOOKS_API_KEY=
 
 # CELERY_BROKER_URL=redis://127.0.0.1:6379/0
 # CELERY_RESULT_BACKEND=redis://127.0.0.1:6379/0
+
+# Set to True to enable Django Silk profiling at /silk/ (local development only).
+# Off by default to avoid the runtime overhead and DB writes Silk does on every request.
+# ENABLE_SILK=True

--- a/bibliotype/settings.py
+++ b/bibliotype/settings.py
@@ -9,6 +9,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 DEBUG = os.environ.get("DEBUG", "True") == "True"
+ENABLE_SILK = os.environ.get("ENABLE_SILK", "False") == "True"
 
 allowed_hosts_str = os.environ.get("ALLOWED_HOSTS", "")
 ALLOWED_HOSTS = [host.strip() for host in allowed_hosts_str.split(",") if host.strip()]
@@ -28,8 +29,8 @@ INSTALLED_APPS = [
     "django_celery_results",
 ]
 
-# Django Silk for profiling - only enabled in local development (DEBUG=True)
-if DEBUG:
+# Django Silk for profiling - opt-in via ENABLE_SILK=True (local development only)
+if ENABLE_SILK:
     INSTALLED_APPS.insert(0, "silk")  # Insert at beginning to ensure it's loaded first
 
 
@@ -44,8 +45,8 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-# Django Silk middleware for profiling - only enabled in local development (DEBUG=True)
-if DEBUG:
+# Django Silk middleware for profiling - opt-in via ENABLE_SILK=True (local development only)
+if ENABLE_SILK:
     MIDDLEWARE.insert(0, "silk.middleware.SilkyMiddleware")
 
 
@@ -262,8 +263,8 @@ CELERY_BEAT_SCHEDULE = {
 # Custom 404 handler
 handler404 = 'core.views.handler404'
 
-# Django Silk configuration - only used when DEBUG=True (local development)
-if DEBUG:
+# Django Silk configuration - opt-in via ENABLE_SILK=True (local development only)
+if ENABLE_SILK:
     SILKY_PYTHON_PROFILER = True
     SILKY_PYTHON_PROFILER_BINARY = False
     SILKY_META = True

--- a/bibliotype/urls.py
+++ b/bibliotype/urls.py
@@ -48,8 +48,8 @@ urlpatterns = [
     path("", include("core.urls")),
 ]
 
-# Django Silk URLs for profiling - only available in local development (DEBUG=True)
-if settings.DEBUG:
+# Django Silk URLs for profiling - opt-in via ENABLE_SILK=True (local development only)
+if settings.ENABLE_SILK:
     urlpatterns.insert(0, path("silk/", include("silk.urls")))
 
 # Custom 404 handler - must be a callable in root URLconf (string format only works in settings.py)

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -56,6 +56,7 @@ services:
             - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL}
             - TURNSTILE_SITE_KEY=${TURNSTILE_SITE_KEY}
             - TURNSTILE_SECRET_KEY=${TURNSTILE_SECRET_KEY}
+            - ENABLE_SILK=${ENABLE_SILK:-False}
         depends_on:
             db:
                 condition: service_healthy
@@ -82,6 +83,7 @@ services:
             - POSTGRES_DB=${POSTGRES_DB}
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+            - ENABLE_SILK=${ENABLE_SILK:-False}
         depends_on:
             db:
                 condition: service_healthy


### PR DESCRIPTION
## Summary
- Silk was loaded whenever `DEBUG=True`, which meant every local Docker run paid Silk's per-request overhead (extra DB writes, profiler hooks) regardless of whether profiling was actually wanted.
- Replaced the `DEBUG` gate with a dedicated `ENABLE_SILK` env var (default `False`) in `settings.py` and `urls.py`.
- Wired `ENABLE_SILK=${ENABLE_SILK:-False}` into both `web` and `worker` services in `docker-compose.local.yml`, and documented the flag in `.env.example`.

## How to enable Silk
Add `ENABLE_SILK=True` to `.env`, then:

\`\`\`bash
docker-compose -f docker-compose.local.yml up --build -d
# Visit http://localhost:8000/silk/
\`\`\`

Default is off, so day-to-day Docker runs no longer pay the Silk overhead.

## Test plan
- [ ] `docker-compose -f docker-compose.local.yml up --build -d` with no `ENABLE_SILK` in `.env` — `/silk/` should 404 and `silk` should not appear in `INSTALLED_APPS`.
- [ ] Add `ENABLE_SILK=True` to `.env`, rebuild — `/silk/` loads the Silk dashboard and middleware records requests.