### PR TITLE
Gate page-count and publish-year banners on per-stat pending flags

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -312,7 +312,11 @@
                 {% if enrichment.pending %}
                 <script>
                     document.addEventListener('alpine:init', () => {
-                        Alpine.store('enrichment', { pending: true });
+                        Alpine.store('enrichment', {
+                            pending: true,
+                            pages_any_missing: {{ enrichment.pages_any_missing|yesno:"true,false" }},
+                            year_any_missing: {{ enrichment.year_any_missing|yesno:"true,false" }},
+                        });
                     });
 
                     function enrichmentPoller() {
@@ -346,13 +350,22 @@
                                     const data = await res.json();
                                     if (!data.pending) {
                                         this.pending = false;
-                                        Alpine.store('enrichment', { pending: false });
+                                        Alpine.store('enrichment', {
+                                            pending: false,
+                                            pages_any_missing: false,
+                                            year_any_missing: false,
+                                        });
                                         clearInterval(this.interval);
                                         setTimeout(() => window.location.reload(), 500);
                                         return;
                                     }
                                     this.adjustInterval(data.percent);
                                     this.bannerText = `Enriching your library — ${data.percent}% complete. ~${data.remaining_minutes} min remaining.`;
+                                    Alpine.store('enrichment', {
+                                        pending: true,
+                                        pages_any_missing: !!data.pages_any_missing,
+                                        year_any_missing: !!data.year_any_missing,
+                                    });
                                     const s = data.updated_stats;
                                     if (s) {
                                         // Update total pages read

--- a/core/templates/core/partials/dna/comparative_analytics_card.html
+++ b/core/templates/core/partials/dna/comparative_analytics_card.html
@@ -5,13 +5,15 @@
         <div class="space-y-4 text-lg">
             <!-- Average Book Length -->
             <div class="border-brand-text shadow-neo-sm border-2 bg-gray-50 p-3">
-                {% if enrichment.length_pending %}
+                {% if enrichment.pages_any_missing %}
                 <p class="-mx-3 -mt-3 mb-2 bg-brand-yellow/30 py-0.5 text-center text-xs animate-[enrichPulse_2s_ease-in-out_infinite]"
-                   x-data x-show="$store.enrichment?.pending" x-cloak>
+                   x-data x-show="$store.enrichment?.pages_any_missing" x-cloak>
                     Still enriching
                 </p>
                 {% endif %}
-                <div class="{% if enrichment.length_pending %}opacity-60 transition-opacity duration-500{% endif %}">
+                <div x-data
+                     class="transition-opacity duration-500 {% if enrichment.pages_any_missing %}opacity-60{% endif %}"
+                     :class="{ 'opacity-60': $store.enrichment?.pages_any_missing }">
                 <p>
                     The average length of books {{ pronoun_sub|default:"you" }} read is
                     <strong><span id="stat-avg-length">{{ dna.user_stats.avg_book_length }}</span> pages</strong>.
@@ -31,13 +33,15 @@
 
             <!-- Average Book Age -->
             <div class="border-brand-text shadow-neo-sm border-2 bg-gray-50 p-3">
-                {% if enrichment.year_pending %}
+                {% if enrichment.year_any_missing %}
                 <p class="-mx-3 -mt-3 mb-2 bg-brand-yellow/30 py-0.5 text-center text-xs animate-[enrichPulse_2s_ease-in-out_infinite]"
-                   x-data x-show="$store.enrichment?.pending" x-cloak>
+                   x-data x-show="$store.enrichment?.year_any_missing" x-cloak>
                     Still enriching
                 </p>
                 {% endif %}
-                <div class="{% if enrichment.year_pending %}opacity-60 transition-opacity duration-500{% endif %}">
+                <div x-data
+                     class="transition-opacity duration-500 {% if enrichment.year_any_missing %}opacity-60{% endif %}"
+                     :class="{ 'opacity-60': $store.enrichment?.year_any_missing }">
                 <p>
                     The average age of books {{ pronoun_sub|default:"you" }} read is from
                     <strong>{{ dna.user_stats.avg_publish_year|floatformat:0 }}</strong>.

--- a/core/templates/core/partials/dna/comparative_analytics_card.html
+++ b/core/templates/core/partials/dna/comparative_analytics_card.html
@@ -5,11 +5,13 @@
         <div class="space-y-4 text-lg">
             <!-- Average Book Length -->
             <div class="border-brand-text shadow-neo-sm border-2 bg-gray-50 p-3">
+                {% if enrichment.length_pending %}
                 <p class="-mx-3 -mt-3 mb-2 bg-brand-yellow/30 py-0.5 text-center text-xs animate-[enrichPulse_2s_ease-in-out_infinite]"
                    x-data x-show="$store.enrichment?.pending" x-cloak>
                     Still enriching
                 </p>
-                <div class="{% if enrichment.pending %}opacity-60 transition-opacity duration-500{% endif %}">
+                {% endif %}
+                <div class="{% if enrichment.length_pending %}opacity-60 transition-opacity duration-500{% endif %}">
                 <p>
                     The average length of books {{ pronoun_sub|default:"you" }} read is
                     <strong><span id="stat-avg-length">{{ dna.user_stats.avg_book_length }}</span> pages</strong>.
@@ -29,11 +31,13 @@
 
             <!-- Average Book Age -->
             <div class="border-brand-text shadow-neo-sm border-2 bg-gray-50 p-3">
+                {% if enrichment.year_pending %}
                 <p class="-mx-3 -mt-3 mb-2 bg-brand-yellow/30 py-0.5 text-center text-xs animate-[enrichPulse_2s_ease-in-out_infinite]"
                    x-data x-show="$store.enrichment?.pending" x-cloak>
                     Still enriching
                 </p>
-                <div class="{% if enrichment.pending %}opacity-60 transition-opacity duration-500{% endif %}">
+                {% endif %}
+                <div class="{% if enrichment.year_pending %}opacity-60 transition-opacity duration-500{% endif %}">
                 <p>
                     The average age of books {{ pronoun_sub|default:"you" }} read is from
                     <strong>{{ dna.user_stats.avg_publish_year|floatformat:0 }}</strong>.

--- a/core/templates/core/partials/dna/enrichment_banner.html
+++ b/core/templates/core/partials/dna/enrichment_banner.html
@@ -1,6 +1,10 @@
-{% if enrichment.pending %}
+{% comment %}
+condition (required) — server-render gate (e.g. enrichment.pending or enrichment.pages_any_missing)
+store_key (optional, default "pending") — Alpine store key driving live x-show
+{% endcomment %}
+{% if condition %}
 <p class="enrichment-banner absolute inset-x-0 top-0 z-10 bg-brand-yellow/30 py-0.5 text-center text-xs animate-[enrichPulse_2s_ease-in-out_infinite]"
-   x-data x-show="$store.enrichment?.pending" x-cloak>
+   x-data x-show="$store.enrichment?.{{ store_key|default:'pending' }}" x-cloak>
     Still enriching
 </p>
 {% endif %}

--- a/core/templates/core/partials/dna/fiction_nonfiction_card.html
+++ b/core/templates/core/partials/dna/fiction_nonfiction_card.html
@@ -1,5 +1,5 @@
 <div class="border-brand-text shadow-neo relative flex flex-col border-2 bg-white p-6">
-    {% include 'core/partials/dna/enrichment_banner.html' %}
+    {% include 'core/partials/dna/enrichment_banner.html' with condition=enrichment.pending %}
     <h2 class="mb-1 text-center text-2xl font-bold uppercase">Fiction vs Nonfiction</h2>
     <p class="text-center text-base text-gray-500 italic">
         How {{ pronoun_pos|default:"your" }} library splits between fiction and nonfiction{% if enrichment.pending %} (so far){% endif %}

--- a/core/templates/core/partials/dna/fiction_nonfiction_skeleton.html
+++ b/core/templates/core/partials/dna/fiction_nonfiction_skeleton.html
@@ -1,5 +1,5 @@
 <div class="border-brand-text shadow-neo relative flex flex-col border-2 bg-white p-6">
-    {% include 'core/partials/dna/enrichment_banner.html' %}
+    {% include 'core/partials/dna/enrichment_banner.html' with condition=enrichment.pending %}
     <h2 class="mb-1 text-center text-2xl font-bold uppercase">Fiction vs Nonfiction</h2>
     <p class="text-center text-base text-gray-500 italic">
         Still figuring out what's fiction and what's not...

--- a/core/templates/core/partials/dna/key_stats_row.html
+++ b/core/templates/core/partials/dna/key_stats_row.html
@@ -54,13 +54,10 @@
         <div class="mt-2 text-lg uppercase">Total Books Read</div>
     </div>
     <div class="bg-brand-pink border-brand-text shadow-neo relative border-2 p-6 text-center">
-        {% if enrichment.length_pending %}
-        <p class="enrichment-banner absolute inset-x-0 top-0 z-10 bg-brand-yellow/30 py-0.5 text-center text-xs animate-[enrichPulse_2s_ease-in-out_infinite]"
-           x-data x-show="$store.enrichment?.pending" x-cloak>
-            Still enriching
-        </p>
-        {% endif %}
-        <div class="{% if enrichment.length_pending %}opacity-60 transition-opacity duration-500{% endif %}">
+        {% include 'core/partials/dna/enrichment_banner.html' with condition=enrichment.pages_any_missing store_key="pages_any_missing" %}
+        <div x-data
+             class="transition-opacity duration-500 {% if enrichment.pages_any_missing %}opacity-60{% endif %}"
+             :class="{ 'opacity-60': $store.enrichment?.pages_any_missing }">
             <div id="stat-pages" class="text-5xl font-bold" x-text="fmtPages(pages)">{{ dna.user_stats.total_pages_read|intcomma }}</div>
             <div class="mt-2 text-lg uppercase">Total Pages Read</div>
         </div>

--- a/core/templates/core/partials/dna/key_stats_row.html
+++ b/core/templates/core/partials/dna/key_stats_row.html
@@ -54,8 +54,13 @@
         <div class="mt-2 text-lg uppercase">Total Books Read</div>
     </div>
     <div class="bg-brand-pink border-brand-text shadow-neo relative border-2 p-6 text-center">
-        {% include 'core/partials/dna/enrichment_banner.html' %}
-        <div class="{% if enrichment.pending %}opacity-60 transition-opacity duration-500{% endif %}">
+        {% if enrichment.length_pending %}
+        <p class="enrichment-banner absolute inset-x-0 top-0 z-10 bg-brand-yellow/30 py-0.5 text-center text-xs animate-[enrichPulse_2s_ease-in-out_infinite]"
+           x-data x-show="$store.enrichment?.pending" x-cloak>
+            Still enriching
+        </p>
+        {% endif %}
+        <div class="{% if enrichment.length_pending %}opacity-60 transition-opacity duration-500{% endif %}">
             <div id="stat-pages" class="text-5xl font-bold" x-text="fmtPages(pages)">{{ dna.user_stats.total_pages_read|intcomma }}</div>
             <div class="mt-2 text-lg uppercase">Total Pages Read</div>
         </div>

--- a/core/templates/core/partials/dna/mainstream_gauge_card.html
+++ b/core/templates/core/partials/dna/mainstream_gauge_card.html
@@ -1,5 +1,5 @@
 <div class="border-brand-text shadow-neo relative border-2 bg-white p-6">
-    {% include 'core/partials/dna/enrichment_banner.html' %}
+    {% include 'core/partials/dna/enrichment_banner.html' with condition=enrichment.pending %}
     <h2 class="mb-1 text-center text-2xl font-bold uppercase">Mainstream Meter</h2>
     <p class="mb-4 text-center text-base italic text-gray-500">How mainstream the books in {{ pronoun_pos|default:"your" }} library are{% if enrichment.pending %} (so far){% endif %}</p>
     <div class="{% if enrichment.pending %}opacity-60 transition-opacity duration-500{% endif %}">

--- a/core/templates/core/partials/dna/top_genres_authors_row.html
+++ b/core/templates/core/partials/dna/top_genres_authors_row.html
@@ -26,7 +26,7 @@
          }"
          x-init="init()"
          class="border-brand-text shadow-neo relative overflow-hidden border-2 bg-white p-6">
-        {% include 'core/partials/dna/enrichment_banner.html' %}
+        {% include 'core/partials/dna/enrichment_banner.html' with condition=enrichment.pending %}
         <h2 class="mb-1 text-2xl font-bold uppercase md:pr-36">Top Genres</h2>
         {% if dna.top_genres %}
             <div class="flex items-start justify-between md:!block md:!max-h-none {% if enrichment.pending %}opacity-60 transition-opacity duration-500{% endif %}" style="max-height: 5rem;">

--- a/core/tests/test_storygraph_integration.py
+++ b/core/tests/test_storygraph_integration.py
@@ -257,7 +257,7 @@ class EnrichmentCompletionDetectionTests(TransactionTestCase):
         self.assertEqual(data["percent"], 75)
         self.assertEqual(data["total"], 4)
 
-    def test_length_pending_false_when_all_books_have_page_count(self):
+    def test_pages_any_missing_false_when_all_books_have_page_count(self):
         """Goodreads case: every book has page_count from the CSV — no length banner needed."""
         self._create_book("A", "9789000000020", attempted=False, page_count=300, publish_year=2020)
         self._create_book("B", "9789000000021", attempted=False, page_count=200, publish_year=2021)
@@ -265,18 +265,18 @@ class EnrichmentCompletionDetectionTests(TransactionTestCase):
         response = self.client.get(reverse("core:api_enrichment_status"))
         data = response.json()
         self.assertTrue(data["pending"])  # global enrichment still running
-        self.assertFalse(data["length_pending"])  # but page data is complete
+        self.assertFalse(data["pages_any_missing"])  # but page data is complete
 
-    def test_length_pending_true_when_any_book_missing_page_count(self):
+    def test_pages_any_missing_true_when_any_book_missing_page_count(self):
         """One book missing page_count → length banner should show."""
         self._create_book("A", "9789000000022", attempted=False, page_count=300)
         self._create_book("B", "9789000000023", attempted=False, page_count=None)
 
         response = self.client.get(reverse("core:api_enrichment_status"))
         data = response.json()
-        self.assertTrue(data["length_pending"])
+        self.assertTrue(data["pages_any_missing"])
 
-    def test_year_pending_false_when_all_books_have_publish_year(self):
+    def test_year_any_missing_false_when_all_books_have_publish_year(self):
         """Goodreads case: every book has publish_year from the CSV — no year banner needed."""
         self._create_book("A", "9789000000024", attempted=False, page_count=300, publish_year=1999)
         self._create_book("B", "9789000000025", attempted=False, page_count=200, publish_year=2010)
@@ -284,16 +284,16 @@ class EnrichmentCompletionDetectionTests(TransactionTestCase):
         response = self.client.get(reverse("core:api_enrichment_status"))
         data = response.json()
         self.assertTrue(data["pending"])
-        self.assertFalse(data["year_pending"])
+        self.assertFalse(data["year_any_missing"])
 
-    def test_year_pending_true_when_any_book_missing_publish_year(self):
+    def test_year_any_missing_true_when_any_book_missing_publish_year(self):
         """One book missing publish_year → year banner should show."""
         self._create_book("A", "9789000000026", attempted=False, publish_year=2020)
         self._create_book("B", "9789000000027", attempted=False, publish_year=None)
 
         response = self.client.get(reverse("core:api_enrichment_status"))
         data = response.json()
-        self.assertTrue(data["year_pending"])
+        self.assertTrue(data["year_any_missing"])
 
 
 @override_settings(

--- a/core/tests/test_storygraph_integration.py
+++ b/core/tests/test_storygraph_integration.py
@@ -196,7 +196,7 @@ class EnrichmentCompletionDetectionTests(TransactionTestCase):
         connections.close_all()
         super().tearDown()
 
-    def _create_book(self, title, isbn, attempted=False):
+    def _create_book(self, title, isbn, attempted=False, page_count=None, publish_year=None):
         """Create a book and link to test user via UserBook."""
         from core.models import Author
 
@@ -207,6 +207,8 @@ class EnrichmentCompletionDetectionTests(TransactionTestCase):
             author=author,
             isbn13=isbn,
             google_books_last_checked=timezone.now() if attempted else None,
+            page_count=page_count,
+            publish_year=publish_year,
         )
         UserBook.objects.create(user=self.user, book=book)
         return book
@@ -254,6 +256,44 @@ class EnrichmentCompletionDetectionTests(TransactionTestCase):
         data = response.json()
         self.assertEqual(data["percent"], 75)
         self.assertEqual(data["total"], 4)
+
+    def test_length_pending_false_when_all_books_have_page_count(self):
+        """Goodreads case: every book has page_count from the CSV — no length banner needed."""
+        self._create_book("A", "9789000000020", attempted=False, page_count=300, publish_year=2020)
+        self._create_book("B", "9789000000021", attempted=False, page_count=200, publish_year=2021)
+
+        response = self.client.get(reverse("core:api_enrichment_status"))
+        data = response.json()
+        self.assertTrue(data["pending"])  # global enrichment still running
+        self.assertFalse(data["length_pending"])  # but page data is complete
+
+    def test_length_pending_true_when_any_book_missing_page_count(self):
+        """One book missing page_count → length banner should show."""
+        self._create_book("A", "9789000000022", attempted=False, page_count=300)
+        self._create_book("B", "9789000000023", attempted=False, page_count=None)
+
+        response = self.client.get(reverse("core:api_enrichment_status"))
+        data = response.json()
+        self.assertTrue(data["length_pending"])
+
+    def test_year_pending_false_when_all_books_have_publish_year(self):
+        """Goodreads case: every book has publish_year from the CSV — no year banner needed."""
+        self._create_book("A", "9789000000024", attempted=False, page_count=300, publish_year=1999)
+        self._create_book("B", "9789000000025", attempted=False, page_count=200, publish_year=2010)
+
+        response = self.client.get(reverse("core:api_enrichment_status"))
+        data = response.json()
+        self.assertTrue(data["pending"])
+        self.assertFalse(data["year_pending"])
+
+    def test_year_pending_true_when_any_book_missing_publish_year(self):
+        """One book missing publish_year → year banner should show."""
+        self._create_book("A", "9789000000026", attempted=False, publish_year=2020)
+        self._create_book("B", "9789000000027", attempted=False, publish_year=None)
+
+        response = self.client.get(reverse("core:api_enrichment_status"))
+        data = response.json()
+        self.assertTrue(data["year_pending"])
 
 
 @override_settings(

--- a/core/views.py
+++ b/core/views.py
@@ -309,12 +309,12 @@ def _compute_enrichment_progress(user, profile, dna_data):
         "genres_pending": (genres_done / total) < 0.5,
         "pages_done": pages_done,
         "pages_pending": (pages_done / total) < 0.5,
-        # Distinct from pages_pending (a 50% sparseness threshold for skeletons):
-        # these are True iff any book is still missing the field, used to gate
-        # per-stat "Still enriching" banners. Goodreads supplies both fields
-        # per row, so they're False on Goodreads uploads even mid-enrichment.
-        "length_pending": pages_done < total,
-        "year_pending": counts["year_done"] < total,
+        # Per-stat banner gates: True iff any book is still missing this field.
+        # Distinct from pages_pending above (a 50%-done sparseness threshold
+        # for skeletons). Goodreads CSVs supply both fields per row, so these
+        # stay False throughout enrichment for Goodreads uploads.
+        "pages_any_missing": pages_done < total,
+        "year_any_missing": counts["year_done"] < total,
         "remaining_minutes": max(1, math.ceil((total - attempted) / 20)),
         "csv_source": dna_data.get("csv_source", "goodreads"),
     }

--- a/core/views.py
+++ b/core/views.py
@@ -266,6 +266,7 @@ def _compute_enrichment_progress(user, profile, dna_data):
         total=Count("id", distinct=True),
         genres_done=Count("id", filter=Q(genres__isnull=False), distinct=True),
         pages_done=Count("id", filter=Q(page_count__isnull=False), distinct=True),
+        year_done=Count("id", filter=Q(publish_year__isnull=False), distinct=True),
         attempted=Count("id", filter=Q(google_books_last_checked__isnull=False), distinct=True),
     )
     total = counts["total"]
@@ -308,6 +309,12 @@ def _compute_enrichment_progress(user, profile, dna_data):
         "genres_pending": (genres_done / total) < 0.5,
         "pages_done": pages_done,
         "pages_pending": (pages_done / total) < 0.5,
+        # Distinct from pages_pending (a 50% sparseness threshold for skeletons):
+        # these are True iff any book is still missing the field, used to gate
+        # per-stat "Still enriching" banners. Goodreads supplies both fields
+        # per row, so they're False on Goodreads uploads even mid-enrichment.
+        "length_pending": pages_done < total,
+        "year_pending": counts["year_done"] < total,
         "remaining_minutes": max(1, math.ceil((total - attempted) / 20)),
         "csv_source": dna_data.get("csv_source", "goodreads"),
     }


### PR DESCRIPTION
## Summary

The "Still enriching" banner showed up on stats that didn't actually need enrichment for users uploading Goodreads CSVs (which include `Number of Pages` and `Original Publication Year` per row).

Root cause: a single global `enrichment.pending` flag (`Count(google_books_last_checked NOT NULL) < total`) gated banners on three stats whose values were already final from the CSV — Total Pages Read, Average Book Length, and Average Book Age.

## Fix

Added two per-stat flags to `_compute_enrichment_progress`:

- `length_pending` — true iff any book has `page_count IS NULL`
- `year_pending` — true iff any book has `publish_year IS NULL`

The three affected banners now gate on these flags instead of the global one. Genre/fiction-split/mainstream banners still use the global flag because they genuinely depend on enrichment-derived data.

The Alpine `x-show="$store.enrichment?.pending"` binding stays on the inline banners so they vanish the moment global enrichment finishes (instead of waiting for the page reload).

## Behaviour

- **Goodreads upload**: page count + publish year are populated at sync time → both new flags are False → those three banners never render. Genre/mainstream banners still show until enrichment completes.
- **StoryGraph upload**: neither field is in the CSV → both flags stay True until enrichment fills them in → banners show as before.
- **Mid-enrichment**: each stat's banner clears as soon as the underlying data is complete, independent of the global flag.

## Test plan

- [x] Added 4 tests to `EnrichmentCompletionDetectionTests` covering both flags True/False
- [x] Existing 5 tests in same class still pass
- [x] `core.tests.test_views_e2e` + `core.tests.test_storygraph_integration` (27 tests) all pass
- [ ] Manual: upload `csv/test-csvs/goodreads_alien_batch3.csv`, confirm Total Pages Read / Avg Book Length / Avg Book Age don't show "Still enriching"
- [ ] Manual: upload a StoryGraph CSV and confirm those three banners DO show until enrichment completes