### PR TITLE
Extend upload-nonce to author + late enrich tasks (fix stuck-at-50% on re-upload)

### DIFF
--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -494,7 +494,9 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                     from ..tasks import check_author_mainstream_status_task
 
                     logger.info(f"New author found: '{author.name}'. Dispatching background check.")
-                    check_author_mainstream_status_task.delay(author.id)
+                    check_author_mainstream_status_task.delay(
+                        author.id, user_id=upload_user_id, upload_nonce=upload_nonce
+                    )
 
                 normalized_book_title = Book._normalize_title(title_from_csv)
 
@@ -649,7 +651,9 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                 if created:
                     from ..tasks import check_author_mainstream_status_task
 
-                    check_author_mainstream_status_task.delay(author.id)
+                    check_author_mainstream_status_task.delay(
+                        author.id, user_id=upload_user_id, upload_nonce=upload_nonce
+                    )
 
                 normalized_title = Book._normalize_title(cr_title)
                 isbn13_value = None

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -35,7 +35,19 @@ else:
 
 
 @shared_task
-def check_author_mainstream_status_task(author_id: int):
+def check_author_mainstream_status_task(author_id: int, user_id: int = None, upload_nonce: str = None):
+    # If the upload that spawned this task has been superseded by a newer one,
+    # exit immediately. Without this, hundreds of leftover author-check tasks
+    # from a prior CSV upload drain the worker and starve the new DNA task
+    # (the "stuck at 50%" symptom on re-upload).
+    if user_id and upload_nonce:
+        from .cache_utils import safe_cache_get
+
+        current_nonce = safe_cache_get(f"upload_nonce_{user_id}")
+        if current_nonce and current_nonce != upload_nonce:
+            logger.info(f"Author status task for author {author_id} skipped — superseded by newer upload")
+            return
+
     try:
         author = Author.objects.get(pk=author_id)
         logger.info(f"Running mainstream status check for new author: {author.name}")
@@ -74,19 +86,30 @@ def enrich_book_task(self, book_id: int, user_id: int = None, upload_nonce: str 
     for this user. If a newer upload has started, this task exits early to avoid
     wasting API calls on stale enrichment work.
     """
-    # Check if this enrichment task is still relevant (not superseded by a re-upload)
-    if user_id and upload_nonce:
-        from .cache_utils import safe_cache_get
+    from .cache_utils import safe_cache_get
 
+    def _is_superseded():
+        if not (user_id and upload_nonce):
+            return False
         current_nonce = safe_cache_get(f"upload_nonce_{user_id}")
-        if current_nonce and current_nonce != upload_nonce:
-            logger.info(f"Enrich task for book {book_id} skipped — superseded by newer upload")
-            return
+        return bool(current_nonce) and current_nonce != upload_nonce
+
+    # Check if this enrichment task is still relevant (not superseded by a re-upload)
+    if _is_superseded():
+        logger.info(f"Enrich task for book {book_id} skipped at start — superseded by newer upload")
+        return
 
     try:
         book = Book.objects.get(pk=book_id)
     except Book.DoesNotExist:
         logger.error(f"Enrich task: Book with ID {book_id} not found")
+        return
+
+    # Re-check after the DB fetch. Tasks can sit in the queue for a while; the
+    # nonce may have changed between dispatch and execution, and we don't want
+    # to spend ~5s of API calls (plus the subsequent book.save) on stale work.
+    if _is_superseded():
+        logger.info(f"Enrich task for book {book_id} skipped before API call — superseded by newer upload")
         return
 
     logger.info(f"Enriching book '{book.title}' (id={book_id}) via background task")

--- a/core/tests/test_integration.py
+++ b/core/tests/test_integration.py
@@ -114,6 +114,36 @@ class BookEnrichmentIntegrationTests(TestCase):
 
         mock_enrich.assert_called_once()
 
+    @override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+    @patch("core.book_enrichment_service.enrich_book_from_apis")
+    def test_enrich_book_task_skipped_at_second_check_if_nonce_changed_during_db_fetch(self, mock_enrich):
+        """Re-check defends against the window between task start and API call.
+
+        Without this, a task that started under a valid nonce, then sat waiting
+        on its DB fetch while a new upload superseded it, would still spend
+        ~5s of API calls and write stale data.
+        """
+        from core.cache_utils import safe_cache_set
+        from core.tasks import enrich_book_task
+
+        # Start with matching nonce. After the first check passes, the cached
+        # value is overwritten — the second check (after Book.objects.get)
+        # should catch this and bail before enrich_book_from_apis runs.
+        safe_cache_set("upload_nonce_42", "old-upload-id", timeout=3600)
+        book_id = self.book.id
+
+        original_get = Book.objects.get
+
+        def get_with_nonce_change(*args, **kwargs):
+            result = original_get(*args, **kwargs)
+            safe_cache_set("upload_nonce_42", "new-upload-id", timeout=3600)
+            return result
+
+        with patch("core.tasks.Book.objects.get", side_effect=get_with_nonce_change):
+            enrich_book_task.delay(book_id, user_id=42, upload_nonce="old-upload-id")
+
+        mock_enrich.assert_not_called()
+
     @patch("core.book_enrichment_service.enrich_book_from_apis")
     def test_enrich_book_task_retries_on_api_failure(self, mock_enrich):
         """Task should retry on API failures."""
@@ -425,6 +455,62 @@ class BookEnrichmentIntegrationTests(TestCase):
 
         self.book.refresh_from_db()
         self.assertEqual(self.book.cover_url, "https://covers.openlibrary.org/b/id/999-M.jpg")
+
+
+# ──────────────────────────────────────────────
+# Class 1b: Author Mainstream Status Task Tests
+# ──────────────────────────────────────────────
+
+
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=True,
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+)
+class CheckAuthorMainstreamStatusTaskTests(TestCase):
+
+    def setUp(self):
+        self.author = Author.objects.create(name="Test Author")
+
+    @patch("core.tasks.check_author_mainstream_status")
+    def test_skipped_when_superseded_by_newer_upload(self, mock_check):
+        """Author check exits early if a newer upload nonce is in the cache."""
+        from core.cache_utils import safe_cache_set
+        from core.tasks import check_author_mainstream_status_task
+
+        safe_cache_set("upload_nonce_42", "new-upload-id", timeout=3600)
+
+        check_author_mainstream_status_task.delay(
+            self.author.id, user_id=42, upload_nonce="old-upload-id"
+        )
+
+        mock_check.assert_not_called()
+
+    @patch("core.tasks.check_author_mainstream_status")
+    def test_runs_when_nonce_matches(self, mock_check):
+        """Author check runs normally when upload nonce is current."""
+        from core.cache_utils import safe_cache_set
+        from core.tasks import check_author_mainstream_status_task
+
+        safe_cache_set("upload_nonce_42", "current-upload-id", timeout=3600)
+        mock_check.return_value = {"error": None, "is_mainstream": True, "reason": "test"}
+
+        check_author_mainstream_status_task.delay(
+            self.author.id, user_id=42, upload_nonce="current-upload-id"
+        )
+
+        mock_check.assert_called_once()
+
+    @patch("core.tasks.check_author_mainstream_status")
+    def test_runs_when_no_nonce_provided(self, mock_check):
+        """Backwards-compat: tasks dispatched without nonce kwargs still run."""
+        from core.tasks import check_author_mainstream_status_task
+
+        mock_check.return_value = {"error": None, "is_mainstream": False, "reason": "test"}
+
+        check_author_mainstream_status_task.delay(self.author.id)
+
+        mock_check.assert_called_once()
 
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR #101 revoked the parent `generate_reading_dna_task` on re-upload, but the StoryGraph→Goodreads repro still hits the stuck-at-50% loading state. Diagnosed two uncovered paths:

1. **`check_author_mainstream_status_task` had no nonce protection at all.** StoryGraph uploads spawn one per new author at the two dispatch sites (`core/services/dna_analyser.py:497`, `:652`). Even after the parent DNA task is revoked, these keep running, flood the worker queue, and starve the new DNA task — visible as the loading bar freezing at the "Syncing books" stage (≈50%).
2. **`enrich_book_task` only checked the nonce at task start.** A task that passed the start check could still sit briefly on `Book.objects.get` before its ~5s of API calls. If a new upload landed in that window, the in-flight task would still spend the API time and write stale data.

## Changes

- `check_author_mainstream_status_task` now accepts optional `user_id` + `upload_nonce`; exits early on nonce mismatch using the same `safe_cache_get("upload_nonce_{user_id}")` pattern as `enrich_book_task`.
- `enrich_book_task` keeps its start-of-task check and adds a second re-check after `Book.objects.get`, before invoking `enrich_book_from_apis`.
- Both dispatch sites in `core/services/dna_analyser.py` now pass `user_id=upload_user_id, upload_nonce=upload_nonce`.
- Three new tests for the author-task path (skip / run / backwards-compat with no nonce kwargs) and one for the mid-task re-check on `enrich_book_task`.

## Out of scope (follow-up)

- The deeper "in-flight enrich task finishes its `book.save()` even when superseded mid-API-call" window. Closing this requires splitting `enrich_book_from_apis` into fetch + persist phases so the task can re-check between them. Worth doing if we see stale writes in prod, but the API window is short (~5s per book, single-worker) compared to the queue-depth issue this PR addresses.
- A higher-priority queue for `generate_reading_dna_task` so it can't be starved by subtask backlog. Deployment-affecting change; left for a separate decision.

## Test plan

- [x] `core.tests.test_integration.CheckAuthorMainstreamStatusTaskTests` — skip / run / no-nonce.
- [x] `core.tests.test_integration.BookEnrichmentIntegrationTests.test_enrich_book_task_skipped_at_second_check_if_nonce_changed_during_db_fetch` — validates the new mid-task re-check by mutating the nonce inside a `Book.objects.get` side-effect.
- [x] Full suite (351 tests) passes.
- [ ] Manual: on prod, repro the StoryGraph→Goodreads flow and verify the loading bar progresses past 50%.