### PR TITLE
feat: button press animation — fixed shadow, button presses into it

### DIFF
--- a/.claude/rules/ui-and-styling.md
+++ b/.claude/rules/ui-and-styling.md
@@ -20,6 +20,7 @@ Hard 2px borders, heavy offset shadows, bright saturated colors, VT323 retro mon
 **Shadows:**
 - `shadow-neo`: `4px 4px 0px 0px var(--color-brand-text)` (standard)
 - `shadow-neo-sm`: `2px 2px 0px 0px var(--color-brand-text)` (small)
+- `shadow-neo-lg`: `6px 6px 0px 0px var(--color-brand-text)` (hover lift)
 
 **Font:** `--font-sans: "VT323", ui-sans-serif, system-ui, sans-serif`
 
@@ -33,11 +34,14 @@ Hard 2px borders, heavy offset shadows, bright saturated colors, VT323 retro mon
 **Button (all buttons follow this):**
 ```html
 <button class="bg-brand-green shadow-neo border-brand-text border-2 px-4 py-3 font-bold
-    transition-all duration-150 ease-in-out hover:shadow-none
-    active:translate-x-1 active:translate-y-1 cursor-pointer">
+    transition-all duration-150 ease-in-out
+    hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg
+    active:translate-x-1 active:translate-y-1 active:shadow-none cursor-pointer">
 ```
-- Hover removes shadow (pressed effect)
-- Active translates 0.5-1px (tactile feedback)
+- The shadow's outer edge is the button's fixed "contact point with the page" — it must never move
+- Hover lifts the button face (−2px translate, shadow grows `neo` → `neo-lg`)
+- Active presses it flat: translate by exactly the shadow offset while the shadow shrinks to none
+- Offsets must match the shadow size: `shadow-neo` (4px) pairs with `active:translate-*-1` and `hover:shadow-neo-lg`; `shadow-neo-sm` (2px) pairs with `active:translate-*-0.5` and `hover:shadow-neo`
 
 **Button partials** in `templates/core/partials/buttons/`: `primary_button`, `secondary_button` (multi-color/size), `nav_button`, `small_button`, `small_link_button`, `link_button`, `close_button`, `icon_button`. Include with context vars like `text`, `color`, `size`, `hover_color`.
 

--- a/core/templates/core/about.html
+++ b/core/templates/core/about.html
@@ -151,7 +151,7 @@
         <div class="text-center">
             <a
                 href="{% url 'core:home' %}"
-                class="border-brand-text shadow-neo bg-brand-green inline-block border-2 px-6 py-3 text-xl font-bold uppercase transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-1 active:translate-y-1"
+                class="border-brand-text shadow-neo bg-brand-green inline-block border-2 px-6 py-3 text-xl font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
             >
                 Generate Your Bibliotype Now
             </a>

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -69,7 +69,7 @@
                     </div>
                     <a
                         href="{% url 'core:home' %}"
-                        class="shadow-neo border-brand-text bg-brand-yellow mt-6 inline-block border-2 px-6 py-3 text-lg font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-1 active:translate-y-1"
+                        class="shadow-neo border-brand-text bg-brand-yellow mt-6 inline-block border-2 px-6 py-3 text-lg font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
                     >
                         Try Again
                     </a>

--- a/core/templates/core/partials/buttons/close_button.html
+++ b/core/templates/core/partials/buttons/close_button.html
@@ -1,6 +1,6 @@
 <button
     type="button"
-    class="border-brand-text text-brand-text shadow-neo-sm border-2 bg-white {% if size == 'sm' %}px-1 text-xl{% else %}px-2 text-2xl leading-none{% endif %} font-bold hover:shadow-none active:translate-x-0.5 active:translate-y-0.5 {{ extra_classes|default:'' }}"
+    class="border-brand-text text-brand-text shadow-neo-sm border-2 bg-white {% if size == 'sm' %}px-1 text-xl{% else %}px-2 text-2xl leading-none{% endif %} font-bold active:translate-x-0.5 active:translate-y-0.5 {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
     {{ extra_attrs|safe }}
     >
     &times;

--- a/core/templates/core/partials/buttons/icon_button.html
+++ b/core/templates/core/partials/buttons/icon_button.html
@@ -1,7 +1,7 @@
 {% if color == 'pink' %}
     <button
         type="button"
-        class="shadow-neo bg-brand-pink border-brand-text border-2 p-1 transition-all hover:shadow-none active:translate-x-px active:translate-y-px {{ extra_classes|default:'' }}"
+        class="shadow-neo bg-brand-pink border-brand-text border-2 p-1 transition-all {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:translate-x-1 active:translate-y-1 active:shadow-none"
         {{ extra_attrs|safe }}
         >
         {{ icon_svg|safe }}
@@ -9,7 +9,7 @@
 {% elif color == 'green' %}
     <button
         type="button"
-        class="shadow-neo bg-brand-green border-brand-text border-2 p-1 transition-all hover:shadow-none active:translate-x-px active:translate-y-px {{ extra_classes|default:'' }}"
+        class="shadow-neo bg-brand-green border-brand-text border-2 p-1 transition-all {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:translate-x-1 active:translate-y-1 active:shadow-none"
         {{ extra_attrs|safe }}
         >
         {{ icon_svg|safe }}
@@ -17,7 +17,7 @@
 {% else %}
     <button
         type="button"
-        class="shadow-neo bg-brand-pink border-brand-text border-2 p-1 transition-all hover:shadow-none active:translate-x-px active:translate-y-px {{ extra_classes|default:'' }}"
+        class="shadow-neo bg-brand-pink border-brand-text border-2 p-1 transition-all {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:translate-x-1 active:translate-y-1 active:shadow-none"
         {{ extra_attrs|safe }}
         >
         {{ icon_svg|safe }}

--- a/core/templates/core/partials/buttons/link_button.html
+++ b/core/templates/core/partials/buttons/link_button.html
@@ -1,21 +1,21 @@
 {% if color == 'green' %}
     <a
         href="{{ href }}"
-        class="shadow-neo border-brand-text bg-brand-green {{ extra_classes|default:'' }} inline-block cursor-pointer border-2 px-6 py-3 font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+        class="shadow-neo border-brand-text bg-brand-green {{ extra_classes|default:'' }} inline-block cursor-pointer border-2 px-6 py-3 font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
     >
         {{ text }}
     </a>
 {% elif color == 'cyan' %}
     <a
         href="{{ href }}"
-        class="shadow-neo border-brand-text bg-brand-cyan {{ extra_classes|default:'' }} inline-block cursor-pointer border-2 px-6 py-3 font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+        class="shadow-neo border-brand-text bg-brand-cyan {{ extra_classes|default:'' }} inline-block cursor-pointer border-2 px-6 py-3 font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
     >
         {{ text }}
     </a>
 {% else %}
     <a
         href="{{ href }}"
-        class="shadow-neo border-brand-text bg-brand-green {{ extra_classes|default:'' }} inline-block cursor-pointer border-2 px-6 py-3 font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+        class="shadow-neo border-brand-text bg-brand-green {{ extra_classes|default:'' }} inline-block cursor-pointer border-2 px-6 py-3 font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
     >
         {{ text }}
     </a>

--- a/core/templates/core/partials/buttons/nav_button.html
+++ b/core/templates/core/partials/buttons/nav_button.html
@@ -1,26 +1,26 @@
 {% if is_signup %}
     <a
         href="{{ href|default:'#' }}"
-        class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm border-2 px-2 py-1 whitespace-nowrap transition-all duration-150 ease-in-out hover:bg-brand-yellow hover:shadow-none active:translate-x-0.5 active:translate-y-0.5 cursor-pointer md:px-4"
+        class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm border-2 px-2 py-1 whitespace-nowrap transition-all duration-150 ease-in-out hover:bg-brand-yellow active:translate-x-0.5 active:translate-y-0.5 cursor-pointer md:px-4 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
         >{{ text }}</a
     >
 {% else %}
     {% if hover_color == 'pink' %}
         <a
             href="{{ href|default:'#' }}"
-            class="hover:bg-brand-pink border-brand-text shadow-neo-sm border-2 bg-white px-2 whitespace-nowrap transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5 cursor-pointer"
+            class="hover:bg-brand-pink border-brand-text shadow-neo-sm border-2 bg-white px-2 whitespace-nowrap transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
             >{{ text }}</a
         >
     {% elif hover_color == 'cyan' %}
         <a
             href="{{ href|default:'#' }}"
-            class="hover:bg-brand-cyan border-brand-text shadow-neo-sm border-2 bg-white px-2 whitespace-nowrap transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5 cursor-pointer"
+            class="hover:bg-brand-cyan border-brand-text shadow-neo-sm border-2 bg-white px-2 whitespace-nowrap transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
             >{{ text }}</a
         >
     {% else %}
         <a
             href="{{ href|default:'#' }}"
-            class="hover:bg-brand-yellow border-brand-text shadow-neo-sm border-2 bg-white px-2 whitespace-nowrap transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5 cursor-pointer"
+            class="hover:bg-brand-yellow border-brand-text shadow-neo-sm border-2 bg-white px-2 whitespace-nowrap transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
             >{{ text }}</a
         >
     {% endif %}

--- a/core/templates/core/partials/buttons/primary_button.html
+++ b/core/templates/core/partials/buttons/primary_button.html
@@ -1,6 +1,6 @@
 <button
     type="{{ type|default:'submit' }}"
-    class="bg-brand-green text-brand-text shadow-neo border-brand-text mt-6 w-full cursor-pointer border-2 px-4 py-3 text-2xl font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-1 active:translate-y-1"
+    class="bg-brand-green text-brand-text shadow-neo border-brand-text mt-6 w-full cursor-pointer border-2 px-4 py-3 text-2xl font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
     {{ disabled_attr|safe }}
 >
     {{ text|safe }}

--- a/core/templates/core/partials/buttons/secondary_button.html
+++ b/core/templates/core/partials/buttons/secondary_button.html
@@ -2,7 +2,7 @@
     {% if color == 'pink' %}
         <button
             type="button"
-            class="bg-brand-pink text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+            class="bg-brand-pink text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -10,7 +10,7 @@
     {% elif color == 'green' %}
         <button
             type="button"
-            class="bg-brand-green text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+            class="bg-brand-green text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -18,7 +18,7 @@
     {% elif color == 'cyan' %}
         <button
             type="button"
-            class="bg-brand-cyan text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+            class="bg-brand-cyan text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -26,7 +26,7 @@
     {% elif color == 'yellow' %}
         <button
             type="button"
-            class="bg-brand-yellow text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+            class="bg-brand-yellow text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -34,7 +34,7 @@
     {% elif color == 'purple' %}
         <button
             type="button"
-            class="bg-brand-purple text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+            class="bg-brand-purple text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -42,7 +42,7 @@
     {% else %}
         <button
             type="button"
-            class="bg-brand-pink text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+            class="bg-brand-pink text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-4 py-2 text-xl font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -52,7 +52,7 @@
     {% if color == 'pink' %}
         <button
             type="button"
-            class="bg-brand-pink text-brand-text border-brand-text shadow-neo-sm cursor-pointer border-2 px-2 py-1 text-base font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+            class="bg-brand-pink text-brand-text border-brand-text shadow-neo-sm cursor-pointer border-2 px-2 py-1 text-base font-bold transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -60,7 +60,7 @@
     {% elif color == 'green' %}
         <button
             type="button"
-            class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm cursor-pointer border-2 px-2 py-1 text-base font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+            class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm cursor-pointer border-2 px-2 py-1 text-base font-bold transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -68,7 +68,7 @@
     {% else %}
         <button
             type="button"
-            class="bg-brand-pink text-brand-text border-brand-text shadow-neo-sm cursor-pointer border-2 px-2 py-1 text-base font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+            class="bg-brand-pink text-brand-text border-brand-text shadow-neo-sm cursor-pointer border-2 px-2 py-1 text-base font-bold transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -78,7 +78,7 @@
     {% if color == 'pink' %}
         <button
             type="button"
-            class="bg-brand-pink text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-1 text-lg font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-1 active:translate-y-1"
+            class="bg-brand-pink text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-1 text-lg font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -86,7 +86,7 @@
     {% elif color == 'green' %}
         <button
             type="button"
-            class="bg-brand-green text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-1 text-lg font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-1 active:translate-y-1"
+            class="bg-brand-green text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-1 text-lg font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -94,7 +94,7 @@
     {% else %}
         <button
             type="button"
-            class="bg-brand-pink text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-1 text-lg font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-1 active:translate-y-1"
+            class="bg-brand-pink text-brand-text border-brand-text shadow-neo cursor-pointer border-2 px-1 text-lg font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}

--- a/core/templates/core/partials/buttons/small_button.html
+++ b/core/templates/core/partials/buttons/small_button.html
@@ -2,7 +2,7 @@
     {% if hover_color == 'yellow' %}
         <button
             type="{{ type|default:'submit' }}"
-            class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm border-2 px-4 py-2 font-bold transition-all duration-150 ease-in-out hover:bg-brand-yellow hover:shadow-none active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }}"
+            class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm border-2 px-4 py-2 font-bold transition-all duration-150 ease-in-out hover:bg-brand-yellow active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -10,7 +10,7 @@
     {% else %}
         <button
             type="{{ type|default:'submit' }}"
-            class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm border-2 px-4 py-2 font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }}"
+            class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm border-2 px-4 py-2 font-bold transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -20,7 +20,7 @@
     {% if hover_color == 'yellow' %}
         <button
             type="{{ type|default:'submit' }}"
-            class="bg-brand-pink cursor-pointer text-brand-text border-brand-text shadow-neo-sm hover:bg-brand-yellow hover:shadow-none border-2 px-4 py-2 font-bold transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 {{ extra_classes|default:'' }}"
+            class="bg-brand-pink cursor-pointer text-brand-text border-brand-text shadow-neo-sm hover:bg-brand-yellow border-2 px-4 py-2 font-bold transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -28,7 +28,7 @@
     {% else %}
         <button
             type="{{ type|default:'submit' }}"
-            class="bg-brand-pink cursor-pointer text-brand-text border-brand-text shadow-neo-sm border-2 px-4 py-2 font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5 {{ extra_classes|default:'' }}"
+            class="bg-brand-pink cursor-pointer text-brand-text border-brand-text shadow-neo-sm border-2 px-4 py-2 font-bold transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
             {{ extra_attrs|safe }}
             >
             {{ text }}
@@ -45,7 +45,7 @@
 {% else %}
     <button
         type="{{ type|default:'submit' }}"
-        class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm border-2 px-4 py-2 font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }}"
+        class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm border-2 px-4 py-2 font-bold transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
         {{ extra_attrs|safe }}
         >
         {{ text }}

--- a/core/templates/core/partials/buttons/small_link_button.html
+++ b/core/templates/core/partials/buttons/small_link_button.html
@@ -1,21 +1,21 @@
 {% if color == 'green' %}
     <a
         href="{{ href }}"
-        class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm hover:bg-opacity-90 hover:shadow-none border-2 px-3 py-3 text-center font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }}"
+        class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm hover:bg-opacity-90 border-2 px-3 py-3 text-center font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
         >
         {{ text }}
     </a>
 {% elif color == 'purple' %}
     <a
         href="{{ href }}"
-        class="bg-brand-purple border-brand-text shadow-neo-sm hover:bg-opacity-90 hover:shadow-none block w-full border-2 px-4 py-2 text-center font-bold transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }}"
+        class="bg-brand-purple border-brand-text shadow-neo-sm hover:bg-opacity-90 block w-full border-2 px-4 py-2 text-center font-bold transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
         >
         {{ text }}
     </a>
 {% else %}
     <a
         href="{{ href }}"
-        class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm hover:bg-opacity-90 hover:shadow-none border-2 px-3 py-3 text-center font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }}"
+        class="bg-brand-green text-brand-text border-brand-text shadow-neo-sm hover:bg-opacity-90 border-2 px-3 py-3 text-center font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 cursor-pointer {{ extra_classes|default:'' }} hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
         >
         {{ text }}
     </a>

--- a/core/templates/core/partials/share/share_button.html
+++ b/core/templates/core/partials/share/share_button.html
@@ -1,7 +1,7 @@
 <button
     type="button"
     @click="shareModalOpen = true"
-    class="bg-brand-pink border-brand-text shadow-neo flex w-full cursor-pointer items-center justify-center gap-3 border-2 px-6 py-4 text-xl font-bold uppercase tracking-wider transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-1 active:translate-y-1"
+    class="bg-brand-pink border-brand-text shadow-neo flex w-full cursor-pointer items-center justify-center gap-3 border-2 px-6 py-4 text-xl font-bold uppercase tracking-wider transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
 >
     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />

--- a/core/templates/core/partials/share/share_modal.html
+++ b/core/templates/core/partials/share/share_modal.html
@@ -28,7 +28,7 @@
                     <button
                         @click="shareImage($refs.cardIdentity, 'bibliotype-reader-type.png')"
                         type="button"
-                        class="bg-brand-purple border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+                        class="bg-brand-purple border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
                     >
                         <span x-text="shareButtonLabel">Share</span>
                     </button>
@@ -41,7 +41,7 @@
                     <button
                         @click="shareImage($refs.cardStats, 'bibliotype-stats.png')"
                         type="button"
-                        class="bg-brand-yellow border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+                        class="bg-brand-yellow border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
                     >
                         <span x-text="shareButtonLabel">Share</span>
                     </button>
@@ -54,7 +54,7 @@
                     <button
                         @click="shareImage($refs.cardTaste, 'bibliotype-taste.png')"
                         type="button"
-                        class="bg-brand-green border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+                        class="bg-brand-green border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
                     >
                         <span x-text="shareButtonLabel">Share</span>
                     </button>
@@ -67,7 +67,7 @@
                     <button
                         @click="shareImage($refs.cardMainstream, 'bibliotype-mainstream.png')"
                         type="button"
-                        class="bg-brand-orange border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+                        class="bg-brand-orange border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
                     >
                         <span x-text="shareButtonLabel">Share</span>
                     </button>
@@ -80,7 +80,7 @@
                     <button
                         @click="shareImage($refs.cardFullSherbet, 'bibliotype-full.png')"
                         type="button"
-                        class="bg-brand-pink border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+                        class="bg-brand-pink border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
                     >
                         <span x-text="shareButtonLabel">Share</span> — Sherbet
                     </button>
@@ -93,7 +93,7 @@
                     <button
                         @click="shareImage($refs.cardFullNeonPicnic, 'bibliotype-full.png')"
                         type="button"
-                        class="bg-brand-green border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+                        class="bg-brand-green border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
                     >
                         <span x-text="shareButtonLabel">Share</span> — Neon Picnic
                     </button>
@@ -106,7 +106,7 @@
                     <button
                         @click="shareImage($refs.cardFullMiami, 'bibliotype-full.png')"
                         type="button"
-                        class="bg-brand-orange border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-0.5 active:translate-y-0.5"
+                        class="bg-brand-orange border-brand-text shadow-neo-sm mt-2 w-full cursor-pointer border-2 px-4 py-2 font-bold uppercase transition-all duration-150 ease-in-out active:translate-x-0.5 active:translate-y-0.5 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo active:shadow-none"
                     >
                         <span x-text="shareButtonLabel">Share</span> — Miami Vice
                     </button>

--- a/core/templates/core/password_reset_complete.html
+++ b/core/templates/core/password_reset_complete.html
@@ -15,7 +15,7 @@
                 <div class="mt-6">
                     <a
                         href="{% url 'core:login' %}"
-                        class="bg-brand-green text-brand-text shadow-neo border-brand-text inline-block border-2 px-6 py-3 text-2xl font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-1 active:translate-y-1"
+                        class="bg-brand-green text-brand-text shadow-neo border-brand-text inline-block border-2 px-6 py-3 text-2xl font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
                     >
                         Log In
                     </a>

--- a/core/templates/core/password_reset_confirm.html
+++ b/core/templates/core/password_reset_confirm.html
@@ -56,7 +56,7 @@
                     <div class="mt-6">
                         <a
                             href="{% url 'password_reset' %}"
-                            class="bg-brand-green text-brand-text shadow-neo border-brand-text inline-block border-2 px-6 py-3 text-2xl font-bold transition-all duration-150 ease-in-out hover:shadow-none active:translate-x-1 active:translate-y-1"
+                            class="bg-brand-green text-brand-text shadow-neo border-brand-text inline-block border-2 px-6 py-3 text-2xl font-bold transition-all duration-150 ease-in-out active:translate-x-1 active:translate-y-1 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-neo-lg active:shadow-none"
                         >
                             Request New Link
                         </a>

--- a/static/src/input.css
+++ b/static/src/input.css
@@ -21,6 +21,7 @@
 
     --shadow-neo: 4px 4px 0px 0px var(--color-brand-text);
     --shadow-neo-sm: 2px 2px 0px 0px var(--color-brand-text);
+    --shadow-neo-lg: 6px 6px 0px 0px var(--color-brand-text);
 
     --font-sans: "VT323", ui-sans-serif, system-ui, sans-serif;
 


### PR DESCRIPTION
## Summary

Fixes the button press feel (todo item). Previously `hover:shadow-none` removed the shadow before you clicked, so on `:active` the whole button slid 4px with no anchor — the shadow appeared to move.

New model: **the shadow's outer edge is the button's fixed contact point with the page.**

- **Hover**: face lifts — `-2px` translate, shadow grows (`shadow-neo` → new `shadow-neo-lg` 6px token; `neo-sm` → `neo`)
- **Press**: face presses flat — translate by exactly the shadow offset while the shadow shrinks to none

Also normalizes two latent mismatches: secondary buttons pressed 2px against their 4px shadow, and `icon_button` carried a stale 1px active translate.

44 sites across 14 templates (all button partials + inline buttons in about/dashboard/share/password-reset pages); pattern documented in `.claude/rules/ui-and-styling.md`.

## Testing

- `pnpm run build` compiles the new token
- Verified visually in the running app: side-by-side normal/hover/pressed renders confirm the shadow's outer boundary is constant across all three states at both shadow scales