### PR TITLE
fix: deploy migration race + US-024 sentinel gap + session-key log hygiene

### DIFF
--- a/core/services/anonymization_service.py
+++ b/core/services/anonymization_service.py
@@ -1,8 +1,14 @@
+import hashlib
 import logging
 from django.utils import timezone
 from ..models import AnonymizedReadingProfile, AnonymousUserSession
 
 logger = logging.getLogger(__name__)
+
+
+def _key_hash(session_key):
+    """Session keys are bearer credentials — log a truncated hash, never the raw key."""
+    return hashlib.sha256(session_key.encode()).hexdigest()[:12] if session_key else "none"
 
 
 def anonymize_session(anonymous_session):
@@ -14,7 +20,10 @@ def anonymize_session(anonymous_session):
     # Only anonymize if meets quality thresholds
     total_books = user_stats.get("total_books_read", 0)
     if total_books < 10:
-        logger.info(f"Skipping anonymization of session {anonymous_session.session_key}: too few books ({total_books})")
+        logger.info(
+            f"Skipping anonymization of session {_key_hash(anonymous_session.session_key)}: "
+            f"too few books ({total_books})"
+        )
         return None
 
     AnonymizedReadingProfile.objects.create(
@@ -36,7 +45,7 @@ def anonymize_session(anonymous_session):
     anonymous_session.anonymized = True
     anonymous_session.save()
 
-    logger.info(f"Anonymized session {anonymous_session.session_key}")
+    logger.info(f"Anonymized session {_key_hash(anonymous_session.session_key)}")
     return True
 
 
@@ -51,7 +60,7 @@ def batch_anonymize_expired_sessions():
             if anonymize_session(session):
                 anonymized_count += 1
         except Exception as e:
-            logger.error(f"Error anonymizing session {session.session_key}: {e}", exc_info=True)
+            logger.error(f"Error anonymizing session {_key_hash(session.session_key)}: {e}", exc_info=True)
 
     # Clean up old anonymized sessions (keep for 30 days after anonymization)
     cleanup_date = timezone.now() - timezone.timedelta(days=30)

--- a/core/services/dna_analyser.py
+++ b/core/services/dna_analyser.py
@@ -291,15 +291,23 @@ def _save_dna_to_profile(profile, dna_data):
         )
 
         # Invalidate stale caches for this user
-        from ..cache_utils import safe_cache_delete
+        from ..cache_utils import safe_cache_add, safe_cache_delete
 
         safe_cache_delete(f"similar_users_{profile.user.id}")
         safe_cache_delete(f"user_recommendations_{profile.user.id}")
 
-        from ..tasks import generate_recommendations_task
+        # Sentinel-guard the dispatch (same guard as display_dna_view) so a
+        # dashboard poll landing in the window before the task picks up can't
+        # double-dispatch. The task's finally block clears the sentinel.
+        if safe_cache_add(f"recs_dispatching_{profile.user.id}", 1, timeout=300):
+            from ..tasks import generate_recommendations_task
 
-        generate_recommendations_task.delay(profile.user.id)
-        logger.info(f"Dispatched recommendations task for user {profile.user.username}")
+            generate_recommendations_task.delay(profile.user.id)
+            logger.info(f"Dispatched recommendations task for user {profile.user.username}")
+        else:
+            logger.info(
+                f"Skipped duplicate recommendations dispatch for user {profile.user.username} (sentinel held)"
+            )
 
     except Exception as e:
         logger.error(f"Error saving profile for user {profile.user.username}: {e}", exc_info=True)

--- a/core/tests/test_profile_and_recommendations.py
+++ b/core/tests/test_profile_and_recommendations.py
@@ -273,6 +273,33 @@ class RecommendationsTestCase(TestCase):
 
         self.assertIsNone(cache.get(f"recs_dispatching_{self.user1.id}"))
 
+    def test_save_dna_to_profile_dispatch_is_sentinel_guarded(self):
+        """US-024 follow-up: _save_dna_to_profile respects the dispatch sentinel,
+        so a dashboard poll that just dispatched can't be double-dispatched."""
+        from django.core.cache import cache
+
+        from core.services.dna_analyser import _save_dna_to_profile
+
+        cache.clear()
+        dna = {
+            "reader_type": "Fantasy Fanatic",
+            "user_stats": {"total_books_read": 10},
+            "top_genres": [("fantasy", 10)],
+        }
+
+        # Sentinel already held (e.g. a concurrent dashboard poll dispatched) → skip.
+        cache.set(f"recs_dispatching_{self.user1.id}", 1, timeout=300)
+        with patch("core.tasks.generate_recommendations_task.delay") as mock_delay:
+            _save_dna_to_profile(self.user1.userprofile, dna)
+            mock_delay.assert_not_called()
+
+        # Sentinel free → dispatches exactly once and seeds the sentinel.
+        cache.delete(f"recs_dispatching_{self.user1.id}")
+        with patch("core.tasks.generate_recommendations_task.delay") as mock_delay:
+            _save_dna_to_profile(self.user1.userprofile, dna)
+            mock_delay.assert_called_once_with(self.user1.id)
+        self.assertEqual(cache.get(f"recs_dispatching_{self.user1.id}"), 1)
+
     def test_anonymous_user_gets_recommendations(self):
         """Test that anonymous users can have sessions created (skips recommendation generation)"""
         # This test verifies AnonymousUserSession can be created with all required fields

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,7 @@ services:
             interval: 5s
             timeout: 5s
             retries: 5
+        restart: unless-stopped
     redis:
         image: redis:7-alpine
         # No ports are exposed to the outside world in production.
@@ -59,6 +60,7 @@ services:
                 condition: service_healthy
             redis:
                 condition: service_healthy
+        restart: unless-stopped
 
     worker:
         build: .
@@ -84,6 +86,7 @@ services:
                 condition: service_healthy
             redis:
                 condition: service_healthy
+        restart: unless-stopped
 
 volumes:
     postgres_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,28 +5,44 @@ set -e
 # Wait for the database to be ready.
 ./wait-for-postgres.sh db
 
-echo "Applying database migrations..."
-poetry run python manage.py migrate
+# Celery workers skip web bootstrap (migrations + staticfiles). When web and
+# worker boot together (docker compose up -d --force-recreate on deploy), both
+# used to race `manage.py migrate`; the loser crashed on a duplicate-index
+# error and, with no restart policy, stayed dead until manually restarted.
+case "$*" in
+    *celery*)
+        echo "Worker container detected — skipping migrations (web applies them)."
+        # Don't start consuming tasks against a half-migrated schema: wait
+        # until the web container has applied everything.
+        until poetry run python manage.py migrate --check >/dev/null 2>&1; do
+            echo "Waiting for web to finish applying migrations..."
+            sleep 3
+        done
+        echo "Migrations are up to date — starting worker."
+        ;;
+    *)
+        echo "Applying database migrations..."
+        poetry run python manage.py migrate
 
-# This is the key difference: check the environment variable.
-# In production, we need to collect static files.
-if [ "$DJANGO_ENV" = "production" ]; then
-    echo "Running in PRODUCTION mode"
-    
-    echo "Collecting static files..."
-    poetry run python manage.py collectstatic --noinput
+        # In production, the web container also collects static files for Nginx.
+        if [ "$DJANGO_ENV" = "production" ]; then
+            echo "Running in PRODUCTION mode"
 
-    echo "Applying ownership and permissions to staticfiles for Nginx..."
-    # The 'www-data' user on the host has a standard UID and GID of 33.
-    # We change the ownership of the files inside the container to match.
-    chown -R 33:33 /app/staticfiles
-    # Set permissions so the owner/group can read/write and others can read.
-    chmod -R 775 /app/staticfiles
+            echo "Collecting static files..."
+            poetry run python manage.py collectstatic --noinput
 
-else
-    echo "Running in DEVELOPMENT mode"
-    # No extra steps needed for development before the main command.
-fi
+            echo "Applying ownership and permissions to staticfiles for Nginx..."
+            # The 'www-data' user on the host has a standard UID and GID of 33.
+            # We change the ownership of the files inside the container to match.
+            chown -R 33:33 /app/staticfiles
+            # Set permissions so the owner/group can read/write and others can read.
+            chmod -R 775 /app/staticfiles
+        else
+            echo "Running in DEVELOPMENT mode"
+            # No extra steps needed for development before the main command.
+        fi
+        ;;
+esac
 
 # This special command executes the 'command' from the docker-compose file.
 exec "$@"


### PR DESCRIPTION
## Summary

The three open follow-ups from the triage handoff:

1. **Deploy migration race** — `web` and `worker` both ran `manage.py migrate` from the shared entrypoint; on every deploy the loser crashed on a duplicate-index error and stayed dead (this bit the Phase 4+5 deploy). Workers now skip migrations and poll `migrate --check` until web has applied them — they can't boot against a half-migrated schema, and no manual `up -d worker` after deploys. Adds `restart: unless-stopped` to `db`/`web`/`worker` in prod compose (only redis had it), so crashed containers and host reboots recover.
2. **US-024 sentinel gap** — `_save_dna_to_profile` dispatched `generate_recommendations_task` without setting the `recs_dispatching_` sentinel, leaving a ms-scale double-dispatch window against dashboard polls (documented in PR #108). Same `safe_cache_add` guard as `display_dna_view` now.
3. **Session-key log hygiene** — `anonymization_service` logged raw session keys at three sites; now sha256-truncated per the established pattern in `tasks.py`.

## Testing

- New `test_save_dna_to_profile_dispatch_is_sentinel_guarded` (skips when held, dispatches + seeds when free)
- `test_profile_and_recommendations` + `test_tasks_integration`: 22/22 pass
- `docker compose -f docker-compose.prod.yml config` validates