### PR TITLE
feat: show-password toggles + forgot-password link spacing

### DIFF
--- a/core/templates/core/login.html
+++ b/core/templates/core/login.html
@@ -22,34 +22,47 @@ and book recommendations.{% endblock %}
                             {% endfor %}
                         </div>
                     {% endif %}
-                    {% for field in form %}
-                        <div>
-                            <label for="{{ field.id_for_label }}" class="mb-1 block text-xl font-bold uppercase">
-                                {% if field.name == 'username' %}
-                                    Email
-                                {% else %}
-                                    {{ field.label }}
-                                {% endif %}
-                            </label>
+                    <div>
+                        <label for="{{ form.username.id_for_label }}" class="mb-1 block text-xl font-bold uppercase">
+                            Email
+                        </label>
+                        <input
+                            type="text"
+                            name="{{ form.username.name }}"
+                            id="{{ form.username.id_for_label }}"
+                            class="border-brand-text focus:ring-brand-purple w-full border-2 bg-white p-3 text-lg focus:ring-2 focus:outline-none"
+                            placeholder="Email..."
+                        />
+                        {% for error in form.username.errors %}
+                            <p class="mt-2 text-lg font-bold text-red-600 uppercase">{{ error }}</p>
+                        {% endfor %}
+                    </div>
+                    <div x-data="{ showPassword: false }">
+                        <label for="{{ form.password.id_for_label }}" class="mb-1 block text-xl font-bold uppercase">
+                            {{ form.password.label }}
+                        </label>
+                        <div class="relative">
                             <input
-                                type="{{ field.field.widget.input_type }}"
-                                name="{{ field.name }}"
-                                id="{{ field.id_for_label }}"
-                                class="border-brand-text focus:ring-brand-purple w-full border-2 bg-white p-3 text-lg focus:ring-2 focus:outline-none"
-                                placeholder="{{ field.label }}..."
+                                type="password"
+                                :type="showPassword ? 'text' : 'password'"
+                                name="{{ form.password.name }}"
+                                id="{{ form.password.id_for_label }}"
+                                class="border-brand-text focus:ring-brand-purple w-full border-2 bg-white p-3 pr-14 text-lg focus:ring-2 focus:outline-none"
+                                placeholder="{{ form.password.label }}..."
                             />
-                            {% for error in field.errors %}
-                                <p class="mt-2 text-lg font-bold text-red-600 uppercase">{{ error }}</p>
-                            {% endfor %}
+                            {% include 'core/partials/password_toggle.html' with toggle_var="showPassword" %}
                         </div>
-                    {% endfor %}
-                    <div class="mt-1 text-right">
-                        <a
-                            href="{% url 'password_reset' %}"
-                            class="hover:bg-brand-yellow text-base font-bold uppercase underline"
-                        >
-                            Forgot Password?
-                        </a>
+                        {% for error in form.password.errors %}
+                            <p class="mt-2 text-lg font-bold text-red-600 uppercase">{{ error }}</p>
+                        {% endfor %}
+                        <div class="mt-3 text-right">
+                            <a
+                                href="{% url 'password_reset' %}"
+                                class="hover:bg-brand-yellow text-base font-bold uppercase underline"
+                            >
+                                Forgot Password?
+                            </a>
+                        </div>
                     </div>
                     {% include 'core/partials/buttons/primary_button.html' with text="Log In" %}
                 </form>

--- a/core/templates/core/partials/password_toggle.html
+++ b/core/templates/core/partials/password_toggle.html
@@ -1,0 +1,47 @@
+{% comment %}
+Show/hide toggle for a password input. Include INSIDE a `relative` wrapper div
+around the input (give the input `pr-14` so text doesn't run under the button).
+Requires an Alpine scope with a boolean named by `toggle_var`.
+
+Usage:
+    {% include 'core/partials/password_toggle.html' with toggle_var="showPassword" %}
+{% endcomment %}
+<button
+    type="button"
+    @click="{{ toggle_var }} = !{{ toggle_var }}"
+    :aria-label="{{ toggle_var }} ? 'Hide password' : 'Show password'"
+    class="text-brand-text hover:bg-brand-yellow absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer p-1"
+>
+    <svg
+        x-show="!{{ toggle_var }}"
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+    >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+        />
+    </svg>
+    <svg
+        x-show="{{ toggle_var }}"
+        x-cloak
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+    >
+        <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+        />
+    </svg>
+</button>

--- a/core/templates/core/password_reset_confirm.html
+++ b/core/templates/core/password_reset_confirm.html
@@ -26,21 +26,25 @@
                             </div>
                         {% endif %}
                         {% for field in form %}
-                            <div>
+                            <div x-data="{ showPassword: false }">
                                 <label
                                     for="{{ field.id_for_label }}"
                                     class="mb-1 block text-xl font-bold uppercase"
                                 >
                                     {{ field.label }}
                                 </label>
-                                <input
-                                    type="password"
-                                    name="{{ field.name }}"
-                                    id="{{ field.id_for_label }}"
-                                    class="border-brand-text focus:ring-brand-purple w-full border-2 bg-white p-3 text-lg focus:ring-2 focus:outline-none"
-                                    placeholder="{{ field.label }}..."
-                                    required
-                                />
+                                <div class="relative">
+                                    <input
+                                        type="password"
+                                        :type="showPassword ? 'text' : 'password'"
+                                        name="{{ field.name }}"
+                                        id="{{ field.id_for_label }}"
+                                        class="border-brand-text focus:ring-brand-purple w-full border-2 bg-white p-3 pr-14 text-lg focus:ring-2 focus:outline-none"
+                                        placeholder="{{ field.label }}..."
+                                        required
+                                    />
+                                    {% include 'core/partials/password_toggle.html' with toggle_var="showPassword" %}
+                                </div>
                                 {% if field.help_text %}
                                     <p class="mt-2 text-lg text-gray-600">{{ field.help_text|safe }}</p>
                                 {% endif %}

--- a/core/templates/core/signup.html
+++ b/core/templates/core/signup.html
@@ -28,6 +28,8 @@
                         email: '{{ form.email.value|default:''|escapejs }}',
                         password1: '',
                         password2: '',
+                        showPassword1: false,
+                        showPassword2: false,
                         emailError: '',
                         password1Error: '',
                         password2Error: '',
@@ -146,17 +148,21 @@
                         <label for="{{ form.password1.id_for_label }}" class="mb-1 block text-xl font-bold uppercase">
                             {{ form.password1.label }}
                         </label>
-                        <input
-                            type="password"
-                            name="{{ form.password1.name }}"
-                            id="{{ form.password1.id_for_label }}"
-                            class="border-brand-text focus:ring-brand-purple w-full border-2 bg-white p-3 text-lg focus:ring-2 focus:outline-none"
-                            placeholder="{{ form.password1.label }}..."
-                            x-model="password1"
-                            @blur="blurPassword1()"
-                            @focus="password1Error = ''; clearTimeout(_password1Timer)"
-                            required
-                        />
+                        <div class="relative">
+                            <input
+                                type="password"
+                                :type="showPassword1 ? 'text' : 'password'"
+                                name="{{ form.password1.name }}"
+                                id="{{ form.password1.id_for_label }}"
+                                class="border-brand-text focus:ring-brand-purple w-full border-2 bg-white p-3 pr-14 text-lg focus:ring-2 focus:outline-none"
+                                placeholder="{{ form.password1.label }}..."
+                                x-model="password1"
+                                @blur="blurPassword1()"
+                                @focus="password1Error = ''; clearTimeout(_password1Timer)"
+                                required
+                            />
+                            {% include 'core/partials/password_toggle.html' with toggle_var="showPassword1" %}
+                        </div>
                         {% if form.password1.help_text %}
                             <p class="mt-2 text-lg text-gray-600">{{ form.password1.help_text|safe }}</p>
                         {% endif %}
@@ -175,17 +181,21 @@
                         <label for="{{ form.password2.id_for_label }}" class="mb-1 block text-xl font-bold uppercase">
                             {{ form.password2.label }}
                         </label>
-                        <input
-                            type="password"
-                            name="{{ form.password2.name }}"
-                            id="{{ form.password2.id_for_label }}"
-                            class="border-brand-text focus:ring-brand-purple w-full border-2 bg-white p-3 text-lg focus:ring-2 focus:outline-none"
-                            placeholder="{{ form.password2.label }}..."
-                            x-model="password2"
-                            @blur="blurPassword2()"
-                            @focus="password2Error = ''; clearTimeout(_password2Timer)"
-                            required
-                        />
+                        <div class="relative">
+                            <input
+                                type="password"
+                                :type="showPassword2 ? 'text' : 'password'"
+                                name="{{ form.password2.name }}"
+                                id="{{ form.password2.id_for_label }}"
+                                class="border-brand-text focus:ring-brand-purple w-full border-2 bg-white p-3 pr-14 text-lg focus:ring-2 focus:outline-none"
+                                placeholder="{{ form.password2.label }}..."
+                                x-model="password2"
+                                @blur="blurPassword2()"
+                                @focus="password2Error = ''; clearTimeout(_password2Timer)"
+                                required
+                            />
+                            {% include 'core/partials/password_toggle.html' with toggle_var="showPassword2" %}
+                        </div>
                         {% if form.password2.help_text %}
                             <p class="mt-2 text-lg text-gray-600">{{ form.password2.help_text|safe }}</p>
                         {% endif %}


### PR DESCRIPTION
## Summary

Auth UI todos: adds a show/hide password toggle (new reusable `password_toggle.html` Alpine partial) to login, both signup password fields (independent toggles), and password-reset-confirm. The login password field is extracted from the generic `{% for field %}` loop to carry the toggle, and the forgot-password link gets breathing room (`mt-3`, grouped inside the password block).

## Testing

- Browser-verified: toggles flip `type` password↔text independently; signup's live validation (short-password error on blur) still fires; screenshot-checked spacing on the login card.
- `test_views_e2e` + `test_password_reset` + `test_login_ratelimit`: 44/44 pass.