### PR TITLE
test: fix flaky rate-limit tests (minute-window boundary)

### DIFF
--- a/core/tests/ratelimit_test_helpers.py
+++ b/core/tests/ratelimit_test_helpers.py
@@ -1,0 +1,22 @@
+"""Helpers for django-ratelimit tests.
+
+django-ratelimit counts requests inside fixed clock windows (e.g. `5/m` uses
+the current minute bucket, computed from `time.time()` in
+`django_ratelimit.core`). On a slow CI runner a burst of test requests can
+straddle a minute boundary, silently resetting the counter and flaking the
+"Nth request returns 429" assertion (seen on main CI run 28718182397).
+
+`frozen_ratelimit_window()` pins the module's clock so every request in the
+`with` block deterministically lands in the same window. It swaps only the
+`time` name inside django_ratelimit.core's namespace — the real `time` module
+is untouched for everything else.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+_FROZEN_CLOCK = SimpleNamespace(time=lambda: 1_700_000_000.0)
+
+
+def frozen_ratelimit_window():
+    return patch("django_ratelimit.core.time", _FROZEN_CLOCK)

--- a/core/tests/test_login_ratelimit.py
+++ b/core/tests/test_login_ratelimit.py
@@ -3,6 +3,8 @@ from django.core.cache import cache
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
+from .ratelimit_test_helpers import frozen_ratelimit_window
+
 
 @override_settings(
     CACHES={
@@ -33,11 +35,12 @@ class LoginRateLimitTests(TestCase):
         login_url = reverse("core:login")
         bad_payload = {"username": "ratelimit@example.com", "password": "wrongpassword"}
 
-        for _ in range(5):
-            response = self.client.post(login_url, bad_payload)
-            self.assertEqual(response.status_code, 200)
+        with frozen_ratelimit_window():
+            for _ in range(5):
+                response = self.client.post(login_url, bad_payload)
+                self.assertEqual(response.status_code, 200)
 
-        response = self.client.post(login_url, bad_payload)
+            response = self.client.post(login_url, bad_payload)
         self.assertEqual(response.status_code, 429)
         self.assertContains(response, "Too many attempts", status_code=429)
 
@@ -45,11 +48,12 @@ class LoginRateLimitTests(TestCase):
         login_url = reverse("core:login")
         bad_payload = {"username": "ratelimit@example.com", "password": "wrongpassword"}
 
-        for _ in range(4):
-            response = self.client.post(login_url, bad_payload)
-            self.assertEqual(response.status_code, 200)
+        with frozen_ratelimit_window():
+            for _ in range(4):
+                response = self.client.post(login_url, bad_payload)
+                self.assertEqual(response.status_code, 200)
 
-        good_payload = {"username": "ratelimit@example.com", "password": self.password}
-        response = self.client.post(login_url, good_payload)
+            good_payload = {"username": "ratelimit@example.com", "password": self.password}
+            response = self.client.post(login_url, good_payload)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(int(self.client.session["_auth_user_id"]), self.user.id)

--- a/core/tests/test_update_username_ratelimit.py
+++ b/core/tests/test_update_username_ratelimit.py
@@ -5,6 +5,8 @@ from django.core.cache import cache
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
+from .ratelimit_test_helpers import frozen_ratelimit_window
+
 
 @override_settings(
     CACHES={
@@ -41,20 +43,22 @@ class UpdateUsernameApiRateLimitTests(TestCase):
         )
 
     def test_eleventh_post_in_a_minute_returns_429(self):
-        for i in range(10):
-            response = self._post_username(f"name_{i}")
-            self.assertNotEqual(response.status_code, 429, f"Request {i + 1} unexpectedly 429'd")
+        with frozen_ratelimit_window():
+            for i in range(10):
+                response = self._post_username(f"name_{i}")
+                self.assertNotEqual(response.status_code, 429, f"Request {i + 1} unexpectedly 429'd")
 
-        response = self._post_username("over_the_limit")
+            response = self._post_username("over_the_limit")
         self.assertEqual(response.status_code, 429)
         payload = response.json()
         self.assertEqual(payload, {"error": "Too many attempts, try again later."})
 
     def test_tenth_post_returns_normal_response(self):
-        for i in range(9):
-            response = self._post_username(f"name_{i}")
-            self.assertNotEqual(response.status_code, 429, f"Request {i + 1} unexpectedly 429'd")
+        with frozen_ratelimit_window():
+            for i in range(9):
+                response = self._post_username(f"name_{i}")
+                self.assertNotEqual(response.status_code, 429, f"Request {i + 1} unexpectedly 429'd")
 
-        response = self._post_username("tenth_name")
+            response = self._post_username("tenth_name")
         self.assertNotEqual(response.status_code, 429)
         self.assertIn(response.status_code, (200, 400))


### PR DESCRIPTION
## Summary

`test_sixth_login_post_returns_429_with_template_error` flaked on main (run 28718182397: `200 != 429`, the email you got). Root cause: `django-ratelimit` buckets requests into fixed minute windows derived from `time.time()`; on a slow runner the test's request burst straddled a window boundary and the counter reset.

Fix: `frozen_ratelimit_window()` helper pins the clock **only inside `django_ratelimit.core`'s namespace** (no global `time` patching), so all requests in a test deterministically share one window. Applied to both login and update-username rate-limit suites.

## Testing

`test_login_ratelimit` + `test_update_username_ratelimit` + `test_ratelimit_utils`: 10/10 pass.