### PR TITLE
feat: genre accuracy overhaul part 1 — canonical set, OL+GB merge, context-dependent fiction/nonfiction

### DIFF
--- a/core/dna_constants.py
+++ b/core/dna_constants.py
@@ -150,7 +150,6 @@ GENRE_ALIASES = {
         "fantastique",
         "quests (expeditions)",
         "discworld (imaginary place",  # Typo fix
-        "adventure fiction",
         "epic literature",
     },
     "science fiction": {
@@ -171,28 +170,26 @@ GENRE_ALIASES = {
     "dystopian": {
         "dystopian fiction",
         "dystopias",
+        "dystopia",
+        "post-apocalyptic",
         "fiction, dystopian",
         "totalitarianism",
         "totalitarianism -- fiction",
     },
     "thriller": {
         "thriller",
-        "mystery fiction",
         "crime fiction",
         "suspense fiction",
         "assassins",
-        "detective and mystery stories",
         "thrillers (fiction)",
         "spy stories",
         "crime",
-        "mystery",
         "murder",
         "murderers",
         "fiction, crime",
         "theft",
         "assassination",
         "fiction, thrillers",
-        "detectives",
         "criminal investigation",
         "revenge",
         "crime, fiction",
@@ -201,11 +198,31 @@ GENRE_ALIASES = {
         "fiction, thrillers, general",
         "investigation",
         "malicious accusation",
-        "mystery and detective stories",
-        "adventure stories",
         "suspense",
         "espionage",
+    },
+    "mystery": {
+        "mystery fiction",
+        "detective and mystery stories",
+        "mystery and detective stories",
+        "detectives",
+        "whodunit",
+        "cozy mystery",
+    },
+    "adventure": {
+        "adventure fiction",
+        "adventure stories",
         "adventure and adventurers",
+        "action and adventure",
+    },
+    "literary fiction": {
+        "contemporary literary fiction",
+        "literary novels",
+    },
+    "poetry": {
+        "poems",
+        "verse",
+        "collected poems",
     },
     "horror": {
         "horror fiction",
@@ -284,8 +301,13 @@ GENRE_ALIASES = {
         "humor.",
         "fiction, humorous",
     },
-    "young adult": {
-        "young adult fiction",
+    # Ambiguous genres are split into fiction/nonfiction sub-categories. The old
+    # canonical names ("young adult", "children's literature", "classics") are kept
+    # as aliases of the *fiction* defaults so existing Genre DB rows still classify.
+    # Context-dependent resolution (co-occurring nonfiction genres) happens at DNA
+    # analysis time via core/services/genre_classification.py.
+    "young adult fiction": {
+        "young adult",
         "juvenile literature",
         "ya",
         "juvenile",
@@ -297,20 +319,28 @@ GENRE_ALIASES = {
         "teenage boys",
         "youth, fiction",
     },
-    "children's literature": {
+    "young adult nonfiction": {
+        "juvenile nonfiction",
+    },
+    "children's fiction": {
+        "children's literature",
         "children's stories",
         "picture books",
         "boys",
         "children's plays",
         "children's plays, english",
     },
-    "classics": {
+    # Classification label only — resolved from "children's fiction" at analysis time.
+    "children's nonfiction": set(),
+    "classic fiction": {
+        "classics",
         "classic",
         "classical literature",
         "fiction classics",
-        "classic fiction",
         "classic literature",
     },
+    # Classification label only — resolved from "classic fiction" at analysis time.
+    "classic nonfiction": set(),
     "mythology & folklore": {
         "mythology",
         "retellings",
@@ -341,13 +371,25 @@ GENRE_ALIASES = {
     "holiday fiction": {"christmas stories"},
     "fairy tales & fables": {"fairy tales", "fables", "fairy tale fiction"},
     # --- NON-FICTION ---
-    "non-fiction": {"nonfiction", "essays", "journalism", "creative nonfiction", "doctrines"},
+    "non-fiction": {"nonfiction", "journalism", "creative nonfiction", "doctrines"},
+    "essays": {
+        "collected essays",
+        "literary essays",
+        "personal essays",
+    },
+    "memoir": {
+        "memoirs",
+        "personal narratives",
+        "autobiographies",
+    },
+    "true crime": {
+        "crime nonfiction",
+        "murder nonfiction",
+    },
     "biography": {
         "biography",
         "autobiography",
-        "memoir",
         "biographies",
-        "memoirs",
         "diaries",
         "fiction, biographical",
         "biography & autobiography",
@@ -603,7 +645,6 @@ EXCLUDED_GENRES = {
     "romans, nouvelles",
     "english literature",
     "juvenile fiction",
-    "children's fiction",
     "general",
     "fiction / general",
     "fictional works",
@@ -714,7 +755,6 @@ EXCLUDED_GENRES = {
     "labyrinths",
     "life change events",
     "livres et lecture",
-    "love",
     "male friendship",
     "man",
     "man-woman relationships",
@@ -740,7 +780,6 @@ EXCLUDED_GENRES = {
     "motion picture industry",
     "moški in ženske",
     "mujeres",
-    "musicians",
     "musicians, fiction",
     "médicos",
     "neighbors",
@@ -780,7 +819,6 @@ EXCLUDED_GENRES = {
     "rebellion",
     "refugees",
     "reincarnation",
-    "revenge",
     "rich people",
     "riot grrrl movement",
     "rock musicians",
@@ -834,7 +872,6 @@ EXCLUDED_GENRES = {
     "women hermits",
     "women journalists",
     "women poets",
-    "women rock musicians",
     "writers",
     "young adults",
     "young men",
@@ -856,7 +893,6 @@ EXCLUDED_GENRES = {
     "indiana, fiction",
     "jalisco (méxico)",
     "england in fiction",
-    "france in fiction",
     "mexico, fiction",
     "vermont, fiction",
     "united states, fiction",
@@ -888,13 +924,8 @@ EXCLUDED_GENRES = {
     "roman",
     "romans",
     "romans, nouvelles",
-    "drama",
-    "drama (dramatic works by one author)",
-    "adventure stories",
     "coming-of-age",
     "erotic fiction",
-    "literary fiction",
-    "short stories",
     "children's books",
     "audiobooks",
     "electronic books",
@@ -913,7 +944,6 @@ EXCLUDED_GENRES = {
     "spanish",
     "ficción juvenil",
     "ficción",
-    "novela fantástica",
     # Character/topic subjects not genres
     "vampires",
     "vampiros",
@@ -924,7 +954,6 @@ EXCLUDED_GENRES = {
     "the blitz",
     "fauns",
     "turkish delight",
-    "good and evil",
     "bien y mal",
     "end of the world",
     "apocalypse",
@@ -937,7 +966,6 @@ EXCLUDED_GENRES = {
     "brothers and sisters, fiction",
     "brothers and sisters--fiction",
     "jealousy",
-    "revenge",
     "affront",
     "truth",
     "loyalty",
@@ -971,7 +999,6 @@ EXCLUDED_GENRES = {
     "burial--fiction",
     "soul",
     "hedonism",
-    "fate and fatalism",
     "fate",
     "painting, fiction",
     "painting",
@@ -987,7 +1014,6 @@ EXCLUDED_GENRES = {
     "oklahoma",
     "mississippi",
     "dust bowl era, 1931-1939",
-    "great depression, 1929-1939",
     "depressions",
     "depressions--fiction",
     "agricultural laborers",
@@ -1000,9 +1026,6 @@ EXCLUDED_GENRES = {
     # More specific exclusions from enrichment logs
     "open library staff picks",
     "international relations",
-    "adventure",
-    "music",
-    "revenge",
     "school",
     "best sellers",
     "novelists",
@@ -1067,16 +1090,11 @@ EXCLUDED_GENRES = {
     "narnia (imaginary place)",
     "middle earth (imaginary place)",
     "yoknapatawpha county (imaginary place)",
-    "dune (imaginary place)",
     "seven kingdoms (imaginary place)",
     "battle school (imaginary place)",
     "matrix (imaginary place)",
     "rama (imaginary space vehicle)",
     # Literary style/subgenre terms (not genres)
-    "southern gothic",
-    "urban fantasy",
-    "high fantasy",
-    "epic fantasy",
     # Collection tags
     "collection:eanes challenge",
     "collection:bannedbooks",
@@ -1105,15 +1123,12 @@ EXCLUDED_GENRES = {
     "earthquake zones",
     "geographical myths",
     "complex (psychology)",
-    "drama",
     "slavery",
     "communism",
     "german",
     "literary collections",
     "coloring books",
-    "detective and mystery stories",
     # Google Books categories that aren't meaningful genres
-    "brigands and robbers",
     "future life",
     "imaginary wars and battles",
     "reference",
@@ -1123,7 +1138,6 @@ EXCLUDED_GENRES = {
     "comics & graphic novels, general",
     "comics & graphic novels, literary",
     "comics & graphic novels, adaptations",
-    "comic books, strips",
     "migrant agricultural laborers--california--fiction",
     "labor camps--california--fiction",
     "migrant agricultural laborers--fiction",
@@ -1151,7 +1165,6 @@ EXCLUDED_GENRES = {
     "orphans, fiction",
     "orphans in fiction",
     "homeless children",
-    "runaway teenagers",
     "immigrant children",
     "illegal alien children",
     "adoptees, fiction",
@@ -1186,8 +1199,6 @@ EXCLUDED_GENRES = {
     "photographers",
     "photographers, fiction",
     "rock musicians",
-    "women rock musicians",
-    "musicians",
     "musicians, fiction",
     "lawyers",
     "lawyers, fiction",
@@ -1217,8 +1228,6 @@ EXCLUDED_GENRES = {
     "photographers",
     "photographers, fiction",
     "rock musicians",
-    "women rock musicians",
-    "musicians",
     "musicians, fiction",
     "lawyers",
     "lawyers, fiction",
@@ -1282,7 +1291,6 @@ EXCLUDED_GENRES = {
     "narnia (imaginary place)",
     "narnia (imaginary place), fiction",
     "series",
-    "demons",
     "homeless children",
     "antiheroes",
     "storytelling",
@@ -1359,9 +1367,7 @@ EXCLUDED_GENRES = {
     "children--fiction",
     "teenagers",
     "teenage girls",
-    "teenage boys",
     "teenage boy/girl relations",
-    "runaway teenagers",
     "alienation in teenagers",
     "high school seniors",
     "preparatory school students",
@@ -1402,7 +1408,6 @@ EXCLUDED_GENRES = {
     "orphans, fiction",
     "orphans in fiction",
     "homeless children",
-    "runaway teenagers",
     "immigrant children",
     "illegal alien children",
     "adoptees, fiction",
@@ -1436,8 +1441,6 @@ EXCLUDED_GENRES = {
     "photographers",
     "photographers, fiction",
     "rock musicians",
-    "women rock musicians",
-    "musicians",
     "musicians, fiction",
     "lawyers",
     "lawyers, fiction",
@@ -1490,8 +1493,6 @@ EXCLUDED_GENRES = {
     "photographers",
     "photographers, fiction",
     "rock musicians",
-    "women rock musicians",
-    "musicians",
     "musicians, fiction",
     "lawyers",
     "lawyers, fiction",
@@ -1531,7 +1532,8 @@ GLOBAL_AVERAGES = {
 }
 
 # Priority ordering for genre selection in book enrichment: most specific first,
-# generic/classics last. Genres absent from this list sort to the end.
+# generic/classics last. Must contain EVERY canonical genre (asserted below) so
+# nothing silently sorts to the end.
 # Used by core/services/book_enrichment_service.py to pick the top-N genres for a book
 # after merging Open Library and Google Books canonical genre sets.
 GENRE_PRIORITY = [
@@ -1540,12 +1542,18 @@ GENRE_PRIORITY = [
     "science fiction",
     "dystopian",
     "thriller",
+    "mystery",
     "horror",
     "historical fiction",
     "romance",
+    "literary fiction",
     "humorous fiction",
-    "young adult",
+    "adventure",
+    "young adult fiction",
+    "young adult nonfiction",
     "short stories",
+    "memoir",
+    "true crime",
     # Non-fiction genres
     "biography",
     "philosophy",
@@ -1553,14 +1561,25 @@ GENRE_PRIORITY = [
     "history",
     "social science",
     "non-fiction",
+    "essays",
+    "self-help",
     "science",
     "nature",
     "art & music",
     "travel",
+    "poetry",
     # Generic/classics
-    "classics",
+    "classic fiction",
+    "classic nonfiction",
     "plays & drama",
-    "children's literature",
+    "children's fiction",
+    "children's nonfiction",
+    "food & cooking",
+    "religion & spirituality",
+    "holiday fiction",
+    "fairy tales & fables",
+    "mythology & folklore",
+    "comics & graphic novels",
 ]
 
 NICHE_THRESHOLD = 5
@@ -1594,13 +1613,18 @@ FICTION_GENRES = {
     "science fiction",
     "dystopian",
     "thriller",
+    "mystery",
+    "adventure",
     "horror",
     "historical fiction",
     "romance",
+    "literary fiction",
     "humorous fiction",
-    "young adult",
-    "children's literature",
-    "classics",
+    # Poetry is classified as fiction by default — a known simplification.
+    "poetry",
+    "young adult fiction",
+    "children's fiction",
+    "classic fiction",
     "mythology & folklore",
     "short stories",
     "comics & graphic novels",
@@ -1611,6 +1635,9 @@ FICTION_GENRES = {
 
 NONFICTION_GENRES = {
     "non-fiction",
+    "essays",
+    "memoir",
+    "true crime",
     "biography",
     "history",
     "psychology",
@@ -1623,11 +1650,30 @@ NONFICTION_GENRES = {
     "art & music",
     "food & cooking",
     "religion & spirituality",
+    "young adult nonfiction",
+    "children's nonfiction",
+    "classic nonfiction",
+}
+
+# Genres that default to fiction but could be nonfiction based on context
+# (co-occurring genres on the same book). Resolved at DNA analysis time by
+# core/services/genre_classification.py.
+AMBIGUOUS_FICTION_GENRES = {"classic fiction", "young adult fiction", "children's fiction"}
+
+# Mapping to nonfiction variants when context indicates nonfiction.
+AMBIGUOUS_TO_NONFICTION = {
+    "classic fiction": "classic nonfiction",
+    "young adult fiction": "young adult nonfiction",
+    "children's fiction": "children's nonfiction",
 }
 
 _all_canonical = set(GENRE_ALIASES.keys())
 _classified = FICTION_GENRES | NONFICTION_GENRES
 assert _classified == _all_canonical, f"Unclassified genres: {_all_canonical - _classified}"
+assert set(GENRE_PRIORITY) == _all_canonical, (
+    f"GENRE_PRIORITY out of sync with canonical genres. "
+    f"Missing: {_all_canonical - set(GENRE_PRIORITY)}; extra: {set(GENRE_PRIORITY) - _all_canonical}"
+)
 
 # Maps common StoryGraph user tags to canonical genres.
 # Applied before enrichment dispatch so tagged books can skip API genre lookups.
@@ -1638,22 +1684,27 @@ STORYGRAPH_TAG_TO_GENRE = {
     "fantasy": "fantasy",
     "dystopian": "dystopian",
     "dystopia": "dystopian",
-    "classic": "classics",
-    "classics": "classics",
+    "classic": "classic fiction",
+    "classics": "classic fiction",
     "non-fiction": "non-fiction",
     "nonfiction": "non-fiction",
     "horror": "horror",
     "romance": "romance",
     "thriller": "thriller",
-    "mystery": "thriller",
+    "mystery": "mystery",
+    "adventure": "adventure",
     "biography": "biography",
-    "memoir": "biography",
+    "memoir": "memoir",
+    "true crime": "true crime",
+    "essays": "essays",
+    "poetry": "poetry",
+    "literary fiction": "literary fiction",
     "history": "history",
     "philosophy": "philosophy",
     "psychology": "psychology",
     "historical fiction": "historical fiction",
-    "young adult": "young adult",
-    "ya": "young adult",
+    "young adult": "young adult fiction",
+    "ya": "young adult fiction",
     "short stories": "short stories",
     "travel": "travel",
     "science": "science",

--- a/core/management/commands/enrich_books.py
+++ b/core/management/commands/enrich_books.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
 
     def _get_queryset(self, process_all):
         if process_all:
-            self._warn("--process-all flag set. Re-checking all books.")
+            self._warn("--process-all flag set. Re-checking all books (Google Books will be re-fetched).")
             return Book.objects.all()
         return Book.objects.filter(
             Q(publish_year__isnull=True) | Q(genres__isnull=True) | Q(google_books_last_checked__isnull=True)
@@ -70,19 +70,27 @@ class Command(BaseCommand):
             self._log("Dry run — no tasks dispatched.")
             return
 
-        if options["sync"]:
-            self._sync_enrich(queryset, options["google_books_limit"])
-        else:
-            self._async_enrich(queryset)
+        # Re-enrichment must re-fetch Google Books data so OL + GB genres get
+        # merged; enrich_book_from_apis skips the GB call for books whose
+        # google_books_last_checked is already set.
+        reset_gb = options["process_all"]
 
-    def _async_enrich(self, queryset):
+        if options["sync"]:
+            self._sync_enrich(queryset, options["google_books_limit"], reset_gb)
+        else:
+            self._async_enrich(queryset, reset_gb)
+
+    def _async_enrich(self, queryset, reset_gb=False):
         dispatched = 0
         for book in queryset.iterator():
+            if reset_gb and book.google_books_last_checked is not None:
+                # The Celery task reloads the book from the DB, so the reset must be persisted.
+                Book.objects.filter(pk=book.pk).update(google_books_last_checked=None)
             enrich_book_task.delay(book.pk)
             dispatched += 1
         self._log(f"Dispatched {dispatched} enrichment tasks to Celery.")
 
-    def _sync_enrich(self, queryset, gb_limit):
+    def _sync_enrich(self, queryset, gb_limit, reset_gb=False):
         session = requests.Session()
         session.headers.update({"User-Agent": "BibliotypeApp/1.0"})
         gb_calls = 0
@@ -97,6 +105,9 @@ class Command(BaseCommand):
             processed += 1
             self._log(f'  -> Processing: "{book.title}" ({processed}) | OL: {ol_calls} | GB: {gb_calls}')
 
+            if reset_gb:
+                # enrich_book_from_apis checks the in-memory instance and persists on save.
+                book.google_books_last_checked = None
             _, ol, gb = enrich_book_from_apis(book, session, slow_down=True)
             ol_calls += ol
             gb_calls += gb

--- a/core/services/book_enrichment_service.py
+++ b/core/services/book_enrichment_service.py
@@ -357,54 +357,14 @@ def enrich_book_from_apis(book, session, slow_down=False):
                 book.publisher = publisher_obj
                 is_updated = True
 
-        if new_genres := ol_data.get("genres"):
-            # Always clear and replace existing genres with fresh API data
-            book.genres.clear()
-            # No need to save here - ManyToMany changes are persisted immediately
+    # Open Library genres are held back and merged with Google Books below —
+    # neither source replaces the other any more.
+    ol_genres = set(ol_data.get("genres") or []) if ol_data else set()
 
-            logger.debug(f"Adding genres for '{book.title}': {new_genres}")
-
-            # Limit to top 5-6 genres max - prioritize specific over generic
-            # Sort genres by priority (most specific first)
-            prioritized_genres = sorted(
-                new_genres, key=lambda g: GENRE_PRIORITY.index(g) if g in GENRE_PRIORITY else 999
-            )
-
-            # Take top 5-6 genres (aim for 5, allow up to 6 if they're all highly specific)
-            if len(prioritized_genres) <= 6:
-                genres_to_add_limited = prioritized_genres
-            elif len(prioritized_genres) >= 6 and prioritized_genres[5] in [
-                "fantasy",
-                "science fiction",
-                "thriller",
-                "horror",
-                "historical fiction",
-                "romance",
-            ]:
-                # If we have 6+ specific fiction genres, take all 6
-                genres_to_add_limited = prioritized_genres[:6]
-            else:
-                # Otherwise, take top 5
-                genres_to_add_limited = prioritized_genres[:5]
-
-            # Add the limited genres
-            if genres_to_add_limited:
-                genre_objs = [Genre.objects.get_or_create(name=g_name)[0] for g_name in genres_to_add_limited]
-                book.genres.add(*genre_objs)
-                is_updated = True
-                logger.debug(
-                    f"Added {len(genres_to_add_limited)} genres (limited from {len(new_genres)}): {genres_to_add_limited}"
-                )
-            else:
-                logger.debug(f"No genres to add after limiting")
-
-    # Skip Google Books when OL already found good genres — GB is mainly a genre fallback
-    if ol_data.get("genres") and book.google_books_last_checked is None:
-        book.google_books_last_checked = timezone.now()
-        is_updated = True
-        logger.debug(f"OL found genres for '{book.title}', skipping Google Books")
-
-    # Google Books: only called if OL didn't find genres (fallback for ratings + categories)
+    # Google Books: fetched once per book (guarded by google_books_last_checked)
+    # for ratings + categories. Its categories carry higher confidence than OL
+    # subjects, so they lead the merge below.
+    gb_genres = set()
     if book.google_books_last_checked is None:
         gb_data, calls_made = _fetch_ratings_and_categories_from_google_books(book, session, slow_down)
         gb_api_calls += calls_made
@@ -417,34 +377,50 @@ def enrich_book_from_apis(book, session, slow_down=False):
                 book.google_books_average_rating = gb_data["average_rating"]
                 is_updated = True
 
-            # Use Google Books categories as primary source for genres if available
             if google_genres := gb_data.get("categories"):
-                canonical_google_genres = list(_canonicalize_google_books_categories(google_genres))
-
-                # Only use Google Books genres if we got good results
-                if canonical_google_genres:
-                    logger.debug(f"Using Google Books categories for '{book.title}': {canonical_google_genres}")
-
-                    # Clear ALL existing genres and replace with Google Books (more accurate)
-                    book.genres.clear()
-
-                    prioritized_genres = sorted(
-                        canonical_google_genres,
-                        key=lambda g: GENRE_PRIORITY.index(g) if g in GENRE_PRIORITY else 999,
-                    )
-
-                    # Take top 5 (Google Books categories are usually more accurate)
-                    genres_to_add_limited = prioritized_genres[:5]
-
-                    if genres_to_add_limited:
-                        genre_objs = [Genre.objects.get_or_create(name=g_name)[0] for g_name in genres_to_add_limited]
-                        book.genres.add(*genre_objs)
-                        is_updated = True
-                        logger.debug(f"Added Google Books genres for '{book.title}': {genres_to_add_limited}")
+                gb_genres = set(_canonicalize_google_books_categories(google_genres))
 
         # Mark as checked *after* the API call is attempted.
         book.google_books_last_checked = timezone.now()
         is_updated = True  # Always true if we ran the check
+
+    # Merge both sources: Google Books canonical genres first (higher
+    # confidence), Open Library supplements. The combined set is priority-sorted
+    # so the most specific genres survive the cap regardless of source.
+    if combined_genres := gb_genres | ol_genres:
+        logger.debug(f"Merged genres for '{book.title}': GB={sorted(gb_genres)}, OL={sorted(ol_genres)}")
+
+        # Sort genres by priority (most specific first)
+        prioritized_genres = sorted(
+            combined_genres, key=lambda g: GENRE_PRIORITY.index(g) if g in GENRE_PRIORITY else 999
+        )
+
+        # Take top 5-6 genres (aim for 5, allow up to 6 if they're all highly specific)
+        if len(prioritized_genres) <= 6:
+            genres_to_add_limited = prioritized_genres
+        elif prioritized_genres[5] in [
+            "fantasy",
+            "science fiction",
+            "thriller",
+            "horror",
+            "historical fiction",
+            "romance",
+        ]:
+            # If we have 6+ specific fiction genres, take all 6
+            genres_to_add_limited = prioritized_genres[:6]
+        else:
+            # Otherwise, take top 5
+            genres_to_add_limited = prioritized_genres[:5]
+
+        # Always clear and replace existing genres with fresh API data.
+        # No need to save here - ManyToMany changes are persisted immediately.
+        book.genres.clear()
+        genre_objs = [Genre.objects.get_or_create(name=g_name)[0] for g_name in genres_to_add_limited]
+        book.genres.add(*genre_objs)
+        is_updated = True
+        logger.debug(
+            f"Added {len(genres_to_add_limited)} genres (limited from {len(combined_genres)}): {genres_to_add_limited}"
+        )
 
     # --- Set cover_url from best available source (only if not already set) ---
     if not book.cover_url:

--- a/core/services/dna/__init__.py
+++ b/core/services/dna/__init__.py
@@ -22,15 +22,14 @@ from core.services.llm_service import generate_vibe_with_llm
 
 from ...dna_constants import (
     CANONICAL_GENRE_MAP,
-    FICTION_GENRES,
     GLOBAL_AVERAGES,
     NICHE_THRESHOLD,
-    NONFICTION_GENRES,
     READER_TYPE_DESCRIPTIONS,
     STORYGRAPH_TAG_TO_GENRE,
     compute_contrariness,
 )
 from ...models import Author, Book, Genre
+from ..genre_classification import canonicalize_genre_names, count_fiction_nonfiction
 from ...percentile_engine import (
     calculate_community_means,
     calculate_percentiles_from_aggregates,
@@ -306,20 +305,16 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                     if progress_cb:
                         progress_cb(processed, total_books, "Syncing books")
 
-        fiction_count = 0
-        nonfiction_count = 0
-
+        book_genre_sets = []
         for book, genres, original_row in results:
             if book:
                 user_book_objects.append(book)
                 all_raw_genres.extend(genres)
-                # Fiction-first: books with any fiction genre are counted as fiction,
-                # even if they also carry nonfiction genres (e.g. historical fiction).
-                canonical = {CANONICAL_GENRE_MAP.get(g, g) for g in genres}
-                if canonical & FICTION_GENRES:
-                    fiction_count += 1
-                elif canonical & NONFICTION_GENRES:
-                    nonfiction_count += 1
+                book_genre_sets.append(canonicalize_genre_names(genres))
+
+        # Context-dependent fiction/nonfiction classification. Books with no
+        # classifiable genres are tracked in defaulted_count — never fiction.
+        fiction_count, nonfiction_count, defaulted_count = count_fiction_nonfiction(book_genre_sets)
 
         # Sync currently-reading books to DB (Book/Author only, no UserBook, no global_read_count)
         if currently_reading_books:
@@ -722,7 +717,11 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
             "currently_reading_count": currently_reading_count,
             "custom_shelf_count": custom_shelf_count,
             "fiction_nonfiction_split": (
-                {"fiction_count": fiction_count, "nonfiction_count": nonfiction_count}
+                {
+                    "fiction_count": fiction_count,
+                    "nonfiction_count": nonfiction_count,
+                    "defaulted_count": defaulted_count,
+                }
                 if (fiction_count + nonfiction_count) > 0
                 else None
             ),

--- a/core/services/dna/reader_type.py
+++ b/core/services/dna/reader_type.py
@@ -39,9 +39,22 @@ def assign_reader_type(read_df, enriched_data, all_genres):
     genre_counts = Counter(mapped_genres)
     logger.debug(f"Genre counts: {genre_counts}")
 
-    # These scores are now based on CLEAN, CANONICAL genre counts
-    scores["Fantasy Fanatic"] += genre_counts.get("fantasy", 0) + genre_counts.get("science fiction", 0) + genre_counts.get("dystopian", 0)
-    scores["Non-Fiction Ninja"] += genre_counts.get("non-fiction", 0)
+    # These scores are now based on CLEAN, CANONICAL genre counts.
+    # Mystery, literary fiction, and poetry get no dedicated type — they
+    # contribute to genre diversity (Versatile Valedictorian) only.
+    scores["Fantasy Fanatic"] += (
+        genre_counts.get("fantasy", 0)
+        + genre_counts.get("science fiction", 0)
+        + genre_counts.get("dystopian", 0)
+        + genre_counts.get("adventure", 0)
+    )
+    scores["Non-Fiction Ninja"] += (
+        genre_counts.get("non-fiction", 0)
+        + genre_counts.get("memoir", 0)
+        + genre_counts.get("true crime", 0)
+        + genre_counts.get("essays", 0)
+        + genre_counts.get("classic nonfiction", 0)
+    )
     scores["Philosophical Philomath"] += genre_counts.get("philosophy", 0)
     scores["Nature Nut Case"] += genre_counts.get("nature", 0)
     scores["Social Savant"] += genre_counts.get("social science", 0)

--- a/core/services/genre_classification.py
+++ b/core/services/genre_classification.py
@@ -1,0 +1,68 @@
+"""Shared context-dependent fiction/nonfiction classification.
+
+Ambiguous genres ("classic fiction", "young adult fiction", "children's fiction")
+default to fiction in the Genre DB, but a book carrying ONLY ambiguous fiction
+genres alongside nonfiction genres (e.g. "classic fiction" + "history" for
+"A Brief History of Time") is really nonfiction. This module resolves that at
+analysis time, where the full set of a book's genres is available.
+
+Used by core/services/dna/__init__.py (calculate_full_dna) and
+core/views/_helpers.py (_compute_enrichment_stats) so both counting paths share
+one vocabulary and one resolution policy.
+"""
+
+from ..dna_constants import AMBIGUOUS_FICTION_GENRES, CANONICAL_GENRE_MAP, FICTION_GENRES, NONFICTION_GENRES
+
+
+def canonicalize_genre_names(genre_names):
+    """Map an iterable of raw genre names to a set of canonical genre names."""
+    return {CANONICAL_GENRE_MAP.get(g, g) for g in genre_names}
+
+
+def classify_genres(canonical):
+    """Classify a set of canonical genre names as "fiction", "nonfiction", or None.
+
+    Resolution order (context-dependent, per the genre-accuracy plan):
+    1. ONLY ambiguous fiction genres + a nonfiction signal → nonfiction
+       (e.g. {"classic fiction", "history"})
+    2. Any unambiguous fiction genre → fiction
+       (e.g. {"classic fiction", "history", "fantasy"} — historical fantasy)
+    3. Any nonfiction genre → nonfiction
+    4. Only ambiguous fiction genres, no other signal → fiction (the default)
+    5. Empty or unmatched set → None (caller decides how to track it)
+    """
+    ambiguous_fiction = canonical & AMBIGUOUS_FICTION_GENRES
+    unambiguous_fiction = canonical & (FICTION_GENRES - AMBIGUOUS_FICTION_GENRES)
+    has_nonfiction = bool(canonical & NONFICTION_GENRES)
+
+    if ambiguous_fiction and has_nonfiction and not unambiguous_fiction:
+        return "nonfiction"
+    if unambiguous_fiction:
+        return "fiction"
+    if has_nonfiction:
+        return "nonfiction"
+    if ambiguous_fiction:
+        return "fiction"
+    return None
+
+
+def count_fiction_nonfiction(genre_sets):
+    """Count fiction/nonfiction/defaulted books across an iterable of canonical genre sets.
+
+    Returns (fiction_count, nonfiction_count, defaulted_count). The three
+    counters are independent — books with no classifiable genres land in
+    defaulted_count and are NEVER added to fiction_count — and always sum to
+    the number of sets processed.
+    """
+    fiction_count = 0
+    nonfiction_count = 0
+    defaulted_count = 0
+    for canonical in genre_sets:
+        classification = classify_genres(canonical)
+        if classification == "fiction":
+            fiction_count += 1
+        elif classification == "nonfiction":
+            nonfiction_count += 1
+        else:
+            defaulted_count += 1
+    return fiction_count, nonfiction_count, defaulted_count

--- a/core/services/user_similarity_service.py
+++ b/core/services/user_similarity_service.py
@@ -1,9 +1,23 @@
 import numpy as np
 from collections import Counter, defaultdict
+from ..dna_constants import CANONICAL_GENRE_MAP
 from ..models import UserBook, User, Book, Author, AnonymousUserSession, AnonymizedReadingProfile
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _canonicalize_genre_counter(counts):
+    """Fold a {genre_name: weight} mapping onto canonical genre names.
+
+    Stored genre distributions and Genre DB rows may predate genre renames
+    (e.g. "classics" → "classic fiction"). Canonicalizing both sides before
+    cosine similarity keeps old and new vocabularies comparable.
+    """
+    canonical = Counter()
+    for name, weight in counts.items():
+        canonical[CANONICAL_GENRE_MAP.get(name, name)] += weight
+    return canonical
 
 
 def _calculate_cosine_similarity(counter1, counter2):
@@ -62,9 +76,9 @@ def _build_user_context_for_similarity(user):
 
         weight = rating if rating else 3
 
-        # Genres (prefetched, no query)
+        # Genres (prefetched, no query) — canonicalized so old genre rows compare
         for genre in ub.book.genres.all():
-            genre_weights[genre.name] += weight
+            genre_weights[CANONICAL_GENRE_MAP.get(genre.name, genre.name)] += weight
 
         # Authors (select_related, no query)
         author_weights[ub.book.author.normalized_name] += weight
@@ -297,7 +311,7 @@ def _bulk_build_user_contexts(user_ids):
             weight = rating if rating else 3
 
             for genre in ub.book.genres.all():
-                genre_weights[genre.name] += weight
+                genre_weights[CANONICAL_GENRE_MAP.get(genre.name, genre.name)] += weight
 
             author_weights[ub.book.author.normalized_name] += weight
 
@@ -401,7 +415,7 @@ def calculate_anonymous_similarity_with_context(anonymous_session, user_ctx):
     """
     anon_books = set(anonymous_session.books_data or [])
     anon_top_books = set(anonymous_session.top_books_data or [])
-    anon_genres = Counter(anonymous_session.genre_distribution or {})
+    anon_genres = _canonicalize_genre_counter(anonymous_session.genre_distribution or {})
     anon_authors = Counter(anonymous_session.author_distribution or {})
     anon_ratings = getattr(anonymous_session, "book_ratings", None) or {}
 
@@ -515,9 +529,9 @@ def calculate_similarity_with_anonymized(profile_data, anon_profile, user_ctx=No
             user_authors = Counter()
             user_top_books = set(UserBook.objects.filter(user=user, is_top_book=True).values_list("book_id", flat=True))
 
-            # Extract from DNA data
+            # Extract from DNA data (canonicalized; += folds renamed duplicates together)
             for genre, count in dna.get("top_genres", []):
-                user_genres[genre] = count
+                user_genres[CANONICAL_GENRE_MAP.get(genre, genre)] += count
 
             for author, count in dna.get("top_authors", []):
                 normalized = Author._normalize(author)
@@ -530,19 +544,19 @@ def calculate_similarity_with_anonymized(profile_data, anon_profile, user_ctx=No
 
     elif isinstance(profile_data, AnonymousUserSession):
         # AnonymousUserSession object
-        user_genres = Counter(profile_data.genre_distribution or {})
+        user_genres = _canonicalize_genre_counter(profile_data.genre_distribution or {})
         user_authors = Counter(profile_data.author_distribution or {})
         user_top_books = set(profile_data.top_books_data or [])
         user_rating_dist = Counter()  # Anonymous sessions may not have this
     else:
         # Dict with anonymous session data
-        user_genres = Counter(profile_data.get("genre_distribution", {}))
+        user_genres = _canonicalize_genre_counter(profile_data.get("genre_distribution", {}))
         user_authors = Counter(profile_data.get("author_distribution", {}))
         user_top_books = set(profile_data.get("top_books_data", []))
         user_rating_dist = Counter(profile_data.get("rating_distribution", {}))
 
     # Extract anonymized profile data
-    anon_genres = Counter(anon_profile.genre_distribution or {})
+    anon_genres = _canonicalize_genre_counter(anon_profile.genre_distribution or {})
     anon_authors = Counter(anon_profile.author_distribution or {})
     anon_top_books = set(anon_profile.top_book_ids or [])
     anon_rating_dist = Counter(getattr(anon_profile, "rating_distribution", None) or {})

--- a/core/tests/test_enrichment_stats.py
+++ b/core/tests/test_enrichment_stats.py
@@ -61,11 +61,14 @@ class ComputeEnrichmentStatsTests(TestCase):
         self._add_book("Novel B", genres=["thriller"])  # fiction
         self._add_book("Memoir", genres=["biography"])  # non-fiction
         self._add_book("History Book", genres=["history"])  # non-fiction
-        self._add_book("Untagged")  # neither
+        self._add_book("Untagged")  # neither — tracked as defaulted, never fiction
 
         result = _compute_enrichment_stats(self.user)
 
-        self.assertEqual(result["fiction_nonfiction_split"], {"fiction_count": 2, "nonfiction_count": 2})
+        self.assertEqual(
+            result["fiction_nonfiction_split"],
+            {"fiction_count": 2, "nonfiction_count": 2, "defaulted_count": 1},
+        )
 
     def test_mainstream_count_via_author(self):
         """Mainstream score counts books whose author is_mainstream."""

--- a/core/tests/test_fiction_book_extremes.py
+++ b/core/tests/test_fiction_book_extremes.py
@@ -3,11 +3,11 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 
 from core.dna_constants import (
-    CANONICAL_GENRE_MAP,
     FICTION_GENRES,
     GENRE_ALIASES,
     NONFICTION_GENRES,
 )
+from core.services.genre_classification import canonicalize_genre_names, classify_genres
 from core.services.top_books_service import compute_book_score
 
 
@@ -25,16 +25,10 @@ class FictionNonfictionConstantsTests(TestCase):
 
 
 class FictionNonfictionClassificationTests(TestCase):
-    """Test the fiction-first classification logic used in core.services.dna."""
+    """Test the shared context-dependent classifier used by core.services.dna and views."""
 
     def _classify(self, genre_names):
-        """Reproduce the classification logic from core.services.dna."""
-        canonical = {CANONICAL_GENRE_MAP.get(g, g) for g in genre_names}
-        if canonical & FICTION_GENRES:
-            return "fiction"
-        elif canonical & NONFICTION_GENRES:
-            return "nonfiction"
-        return "unclassified"
+        return classify_genres(canonicalize_genre_names(genre_names))
 
     def test_pure_fiction(self):
         self.assertEqual(self._classify(["fantasy fiction", "epic fantasy"]), "fiction")
@@ -43,20 +37,36 @@ class FictionNonfictionClassificationTests(TestCase):
         self.assertEqual(self._classify(["history", "military history"]), "nonfiction")
 
     def test_mixed_genres_fiction_wins(self):
-        """A book with both fiction and nonfiction genres should classify as fiction."""
+        """A book with an unambiguous fiction genre classifies as fiction even with nonfiction genres."""
         self.assertEqual(self._classify(["fantasy", "history"]), "fiction")
 
     def test_no_matching_genres(self):
-        self.assertEqual(self._classify(["unknown genre xyz"]), "unclassified")
+        self.assertIsNone(self._classify(["unknown genre xyz"]))
 
     def test_empty_genres(self):
-        self.assertEqual(self._classify([]), "unclassified")
+        self.assertIsNone(self._classify([]))
 
     def test_alias_maps_to_fiction(self):
         self.assertEqual(self._classify(["ghost stories"]), "fiction")
 
     def test_alias_maps_to_nonfiction(self):
         self.assertEqual(self._classify(["autobiography"]), "nonfiction")
+
+    def test_ambiguous_genre_with_fiction_signal(self):
+        """classics + fantasy → fiction (unambiguous fiction signal wins)."""
+        self.assertEqual(self._classify(["classics", "fantasy"]), "fiction")
+
+    def test_ambiguous_genre_with_nonfiction_signal(self):
+        """classics + history → nonfiction (e.g. 'A Brief History of Time')."""
+        self.assertEqual(self._classify(["classics", "history"]), "nonfiction")
+
+    def test_ambiguous_genre_no_signal_defaults_fiction(self):
+        """classics alone → fiction (the conservative default)."""
+        self.assertEqual(self._classify(["classics"]), "fiction")
+
+    def test_ambiguous_plus_nonfiction_plus_fiction_stays_fiction(self):
+        """classics + history + fantasy → fiction (historical fantasy, not nonfiction)."""
+        self.assertEqual(self._classify(["classics", "history", "fantasy"]), "fiction")
 
 
 class BookExtremesTests(TestCase):

--- a/core/tests/test_genre_canonicalization.py
+++ b/core/tests/test_genre_canonicalization.py
@@ -1,0 +1,194 @@
+"""Tests for the expanded canonical genre set and shared fiction/nonfiction classification.
+
+Covers the genre-accuracy work: 8 new canonical genres, ambiguous sub-splits
+with backward-compat aliases, EXCLUDED_GENRES regression guards, and the
+context-dependent classifier in core/services/genre_classification.py.
+"""
+
+from django.test import TestCase
+
+from core.dna_constants import (
+    AMBIGUOUS_FICTION_GENRES,
+    AMBIGUOUS_TO_NONFICTION,
+    CANONICAL_GENRE_MAP,
+    EXCLUDED_GENRES,
+    FICTION_GENRES,
+    GENRE_ALIASES,
+    GENRE_PRIORITY,
+    NONFICTION_GENRES,
+)
+from core.services.genre_classification import (
+    canonicalize_genre_names,
+    classify_genres,
+    count_fiction_nonfiction,
+)
+
+
+class NewCanonicalGenreMappingTests(TestCase):
+    """Each new canonical genre must map from its representative aliases."""
+
+    def _assert_maps(self, expected_canonical, aliases):
+        for alias in aliases:
+            self.assertEqual(
+                CANONICAL_GENRE_MAP.get(alias),
+                expected_canonical,
+                f"Alias '{alias}' should map to '{expected_canonical}', got '{CANONICAL_GENRE_MAP.get(alias)}'",
+            )
+
+    def test_memoir(self):
+        self._assert_maps("memoir", ["memoir", "memoirs", "personal narratives", "autobiographies"])
+
+    def test_true_crime(self):
+        self._assert_maps("true crime", ["true crime", "crime nonfiction", "murder nonfiction"])
+
+    def test_poetry(self):
+        self._assert_maps("poetry", ["poetry", "poems", "verse", "collected poems"])
+
+    def test_essays(self):
+        self._assert_maps("essays", ["essays", "collected essays", "literary essays", "personal essays"])
+
+    def test_literary_fiction(self):
+        self._assert_maps("literary fiction", ["literary fiction", "contemporary literary fiction", "literary novels"])
+
+    def test_dystopian(self):
+        self._assert_maps("dystopian", ["dystopian", "dystopian fiction", "dystopia", "post-apocalyptic"])
+
+    def test_mystery(self):
+        self._assert_maps(
+            "mystery",
+            ["mystery", "mystery fiction", "detective and mystery stories", "whodunit", "cozy mystery", "detectives"],
+        )
+
+    def test_adventure(self):
+        self._assert_maps(
+            "adventure",
+            ["adventure", "adventure fiction", "adventure stories", "adventure and adventurers"],
+        )
+        self._assert_maps("adventure", ["action and adventure"])
+
+    def test_moved_aliases_left_their_old_genres(self):
+        """Aliases moved to new genres must no longer sit under their old canonical genre."""
+        self.assertNotIn("memoir", GENRE_ALIASES["biography"])
+        self.assertNotIn("memoirs", GENRE_ALIASES["biography"])
+        self.assertNotIn("mystery", GENRE_ALIASES["thriller"])
+        self.assertNotIn("detective and mystery stories", GENRE_ALIASES["thriller"])
+        self.assertNotIn("adventure fiction", GENRE_ALIASES["fantasy"])
+        self.assertNotIn("adventure stories", GENRE_ALIASES["thriller"])
+        self.assertNotIn("essays", GENRE_ALIASES["non-fiction"])
+
+    def test_autobiographical_fiction_is_not_memoir(self):
+        """'autobiographical fiction' is fiction and must NOT map to memoir."""
+        self.assertNotEqual(CANONICAL_GENRE_MAP.get("autobiographical fiction"), "memoir")
+
+
+class BackwardCompatAliasTests(TestCase):
+    """Old canonical names must resolve to their fiction sub-categories — no data migration."""
+
+    def test_classics_maps_to_classic_fiction(self):
+        self.assertEqual(CANONICAL_GENRE_MAP["classics"], "classic fiction")
+
+    def test_young_adult_maps_to_young_adult_fiction(self):
+        self.assertEqual(CANONICAL_GENRE_MAP["young adult"], "young adult fiction")
+
+    def test_childrens_literature_maps_to_childrens_fiction(self):
+        self.assertEqual(CANONICAL_GENRE_MAP["children's literature"], "children's fiction")
+
+    def test_old_names_are_no_longer_canonical(self):
+        for old_name in ("classics", "young adult", "children's literature"):
+            self.assertNotIn(old_name, GENRE_ALIASES)
+
+    def test_ambiguous_sets_are_consistent(self):
+        self.assertEqual(
+            AMBIGUOUS_FICTION_GENRES, {"classic fiction", "young adult fiction", "children's fiction"}
+        )
+        self.assertEqual(set(AMBIGUOUS_TO_NONFICTION.keys()), AMBIGUOUS_FICTION_GENRES)
+        for nonfiction_variant in AMBIGUOUS_TO_NONFICTION.values():
+            self.assertIn(nonfiction_variant, NONFICTION_GENRES)
+
+
+class ExcludedGenresRegressionTests(TestCase):
+    """The exclusion check runs BEFORE alias matching — collisions silently kill genres."""
+
+    def test_no_canonical_genre_is_excluded(self):
+        collisions = {name for name in GENRE_ALIASES if name in EXCLUDED_GENRES}
+        self.assertEqual(collisions, set(), f"Canonical genres blocked by EXCLUDED_GENRES: {collisions}")
+
+    def test_no_alias_is_excluded(self):
+        collisions = {alias for aliases in GENRE_ALIASES.values() for alias in aliases if alias in EXCLUDED_GENRES}
+        self.assertEqual(collisions, set(), f"Aliases blocked by EXCLUDED_GENRES: {collisions}")
+
+    def test_generic_terms_remain_excluded(self):
+        """'literary' and 'fiction' must stay excluded to prevent API false positives."""
+        self.assertIn("literary", EXCLUDED_GENRES)
+        self.assertIn("fiction", EXCLUDED_GENRES)
+
+    def test_genre_priority_covers_all_canonical_genres(self):
+        """Nothing may sort to the 999 fallback in enrichment priority sorting."""
+        self.assertEqual(set(GENRE_PRIORITY), set(GENRE_ALIASES.keys()))
+
+    def test_fiction_nonfiction_sets_partition_canonical_genres(self):
+        self.assertEqual(FICTION_GENRES | NONFICTION_GENRES, set(GENRE_ALIASES.keys()))
+        self.assertEqual(FICTION_GENRES & NONFICTION_GENRES, set())
+
+
+class ClassifyGenresMatrixTests(TestCase):
+    """The plan's classification matrix for context-dependent resolution."""
+
+    def test_ambiguous_plus_fiction_is_fiction(self):
+        self.assertEqual(classify_genres({"classic fiction", "fantasy"}), "fiction")
+
+    def test_ambiguous_plus_nonfiction_is_nonfiction(self):
+        self.assertEqual(classify_genres({"classic fiction", "history"}), "nonfiction")
+
+    def test_ambiguous_alone_defaults_to_fiction(self):
+        self.assertEqual(classify_genres({"classic fiction"}), "fiction")
+
+    def test_ambiguous_plus_both_signals_is_fiction(self):
+        self.assertEqual(classify_genres({"classic fiction", "history", "fantasy"}), "fiction")
+
+    def test_empty_set_is_none(self):
+        self.assertIsNone(classify_genres(set()))
+
+    def test_unmatched_genres_are_none(self):
+        self.assertIsNone(classify_genres({"totally unknown genre"}))
+
+    def test_pure_nonfiction(self):
+        self.assertEqual(classify_genres({"history", "biography"}), "nonfiction")
+
+    def test_all_ambiguous_variants_resolve_against_nonfiction(self):
+        for ambiguous in AMBIGUOUS_FICTION_GENRES:
+            self.assertEqual(classify_genres({ambiguous, "history"}), "nonfiction")
+            self.assertEqual(classify_genres({ambiguous}), "fiction")
+
+    def test_canonicalize_genre_names_resolves_aliases(self):
+        self.assertEqual(canonicalize_genre_names(["classics", "poems"]), {"classic fiction", "poetry"})
+
+    def test_db_row_with_old_classics_name_classifies_as_fiction(self):
+        """A Genre DB row named 'classics' must still classify via the backward-compat alias."""
+        self.assertEqual(classify_genres(canonicalize_genre_names(["classics"])), "fiction")
+
+
+class CountFictionNonfictionTests(TestCase):
+    """Counter independence: defaulted books are never added to fiction."""
+
+    def test_counters_sum_to_total(self):
+        genre_sets = [
+            {"fantasy"},  # fiction
+            {"history"},  # nonfiction
+            {"classic fiction", "history"},  # nonfiction (context)
+            {"classic fiction"},  # fiction (default)
+            set(),  # defaulted
+            {"unmatched genre"},  # defaulted
+        ]
+        fiction, nonfiction, defaulted = count_fiction_nonfiction(genre_sets)
+        self.assertEqual((fiction, nonfiction, defaulted), (2, 2, 2))
+        self.assertEqual(fiction + nonfiction + defaulted, len(genre_sets))
+
+    def test_defaulted_not_counted_as_fiction(self):
+        fiction, nonfiction, defaulted = count_fiction_nonfiction([set(), set(), set()])
+        self.assertEqual(fiction, 0)
+        self.assertEqual(nonfiction, 0)
+        self.assertEqual(defaulted, 3)
+
+    def test_empty_iterable(self):
+        self.assertEqual(count_fiction_nonfiction([]), (0, 0, 0))

--- a/core/tests/test_integration.py
+++ b/core/tests/test_integration.py
@@ -45,8 +45,8 @@ class BookEnrichmentIntegrationTests(TestCase):
     @patch("core.services.book_enrichment_service._fetch_from_open_library")
     def test_enrich_book_task_updates_book_with_api_data(self, mock_ol, mock_gb):
         """Full enrichment pipeline: task → service → DB updates.
-        When OL returns genres, GB is skipped (optimization) so google_books_last_checked
-        is set but ratings come from the GB-skip path (no actual GB call)."""
+        GB is fetched alongside OL (genres merge, ratings apply) and
+        google_books_last_checked is set."""
         from core.tasks import enrich_book_task
 
         mock_ol.return_value = (
@@ -67,8 +67,10 @@ class BookEnrichmentIntegrationTests(TestCase):
         self.assertEqual(self.book.publish_year, 2020)
         self.assertEqual(self.book.page_count, 350)
         self.assertIsNotNone(self.book.google_books_last_checked)
-        # GB is skipped when OL found genres, so no ratings from GB
-        mock_gb.assert_not_called()
+        # GB is always fetched on first enrichment — ratings now apply even when OL found genres
+        mock_gb.assert_called_once()
+        self.assertEqual(self.book.google_books_ratings_count, 500)
+        self.assertEqual(self.book.google_books_average_rating, 4.1)
 
         # Check publisher was created and linked
         self.assertIsNotNone(self.book.publisher)
@@ -256,8 +258,8 @@ class BookEnrichmentIntegrationTests(TestCase):
 
     @patch("core.services.book_enrichment_service._fetch_ratings_and_categories_from_google_books")
     @patch("core.services.book_enrichment_service._fetch_from_open_library")
-    def test_gb_skipped_when_ol_found_genres(self, mock_ol, mock_gb):
-        """When OL returns genres, GB is skipped entirely (optimization)."""
+    def test_google_books_genres_merged_with_open_library_genres(self, mock_ol, mock_gb):
+        """GB categories no longer replace OL genres — both sources merge."""
         from core.services.book_enrichment_service import enrich_book_from_apis
 
         mock_ol.return_value = (
@@ -270,15 +272,46 @@ class BookEnrichmentIntegrationTests(TestCase):
             },
             2,
         )
+        mock_gb.return_value = (
+            {"categories": ["Fiction/Romance"], "ratings_count": 100, "average_rating": 4.0},
+            1,
+        )
 
         session = MagicMock()
         enrich_book_from_apis(self.book, session)
 
-        mock_gb.assert_not_called()
+        mock_gb.assert_called_once()
         self.book.refresh_from_db()
         self.assertIsNotNone(self.book.google_books_last_checked)
         genre_names = set(self.book.genres.values_list("name", flat=True))
-        self.assertIn("fantasy", genre_names)
+        self.assertEqual(genre_names, {"fantasy", "romance"})
+
+    @patch("core.services.book_enrichment_service._fetch_ratings_and_categories_from_google_books")
+    @patch("core.services.book_enrichment_service._fetch_from_open_library")
+    def test_merged_genres_capped_by_priority(self, mock_ol, mock_gb):
+        """The merged OL+GB set is priority-sorted and capped at 5 when the 6th genre is generic."""
+        from core.services.book_enrichment_service import enrich_book_from_apis
+
+        mock_ol.return_value = (
+            {
+                "genres": ["fantasy", "science fiction", "poetry", "classic fiction", "non-fiction"],
+                "publish_year": None,
+                "page_count": None,
+                "publisher": None,
+                "isbn_13": None,
+            },
+            2,
+        )
+        mock_gb.return_value = ({"categories": ["Fiction/Mystery", "Fiction/Romance"]}, 1)
+
+        session = MagicMock()
+        enrich_book_from_apis(self.book, session)
+
+        self.book.refresh_from_db()
+        genre_names = set(self.book.genres.values_list("name", flat=True))
+        # 7 merged genres → top 5 by GENRE_PRIORITY (the 6th, "poetry", is not a
+        # specific fiction genre, so the 6-genre allowance doesn't kick in)
+        self.assertEqual(genre_names, {"fantasy", "science fiction", "mystery", "romance", "non-fiction"})
 
     def test_ol_isbn_direct_lookup_skips_search(self):
         """When book has isbn13, _fetch_from_open_library uses /isbn/ endpoint, not search."""

--- a/core/tests/test_math_accuracy.py
+++ b/core/tests/test_math_accuracy.py
@@ -278,11 +278,12 @@ class StoryGraphTagMappingTests(TestCase):
         sci_targets = {STORYGRAPH_TAG_TO_GENRE[t] for t in ["sci-fi", "scifi", "science fiction"]}
         self.assertEqual(sci_targets, {"science fiction"})
 
-        biography_targets = {STORYGRAPH_TAG_TO_GENRE[t] for t in ["biography", "memoir"]}
-        self.assertEqual(biography_targets, {"biography"})
+        # memoir is its own canonical genre now — no longer lumped into biography
+        self.assertEqual(STORYGRAPH_TAG_TO_GENRE["biography"], "biography")
+        self.assertEqual(STORYGRAPH_TAG_TO_GENRE["memoir"], "memoir")
 
         ya_targets = {STORYGRAPH_TAG_TO_GENRE[t] for t in ["young adult", "ya"]}
-        self.assertEqual(ya_targets, {"young adult"})
+        self.assertEqual(ya_targets, {"young adult fiction"})
 
 
 # ────────────────────────────────────────────

--- a/core/tests/test_tasks_unit.py
+++ b/core/tests/test_tasks_unit.py
@@ -251,10 +251,11 @@ class StoryGraphTagMappingTests(TestCase):
         self.assertEqual(STORYGRAPH_TAG_TO_GENRE["sci-fi"], "science fiction")
         self.assertEqual(STORYGRAPH_TAG_TO_GENRE["fantasy"], "fantasy")
         self.assertEqual(STORYGRAPH_TAG_TO_GENRE["dystopian"], "dystopian")
-        self.assertEqual(STORYGRAPH_TAG_TO_GENRE["classic"], "classics")
+        self.assertEqual(STORYGRAPH_TAG_TO_GENRE["classic"], "classic fiction")
         self.assertEqual(STORYGRAPH_TAG_TO_GENRE["non-fiction"], "non-fiction")
-        self.assertEqual(STORYGRAPH_TAG_TO_GENRE["ya"], "young adult")
-        self.assertEqual(STORYGRAPH_TAG_TO_GENRE["memoir"], "biography")
+        self.assertEqual(STORYGRAPH_TAG_TO_GENRE["ya"], "young adult fiction")
+        self.assertEqual(STORYGRAPH_TAG_TO_GENRE["memoir"], "memoir")
+        self.assertEqual(STORYGRAPH_TAG_TO_GENRE["mystery"], "mystery")
 
     def test_unknown_tags_are_not_in_mapping(self):
         """Tags not in the mapping are silently ignored during processing."""

--- a/core/views/_helpers.py
+++ b/core/views/_helpers.py
@@ -9,7 +9,8 @@ from django.db import transaction
 from django.db.models import Count, Q
 
 from ..cache_utils import safe_cache_get, safe_cache_set
-from ..dna_constants import CANONICAL_GENRE_MAP, FICTION_GENRES, GLOBAL_AVERAGES, NONFICTION_GENRES
+from ..dna_constants import CANONICAL_GENRE_MAP, GLOBAL_AVERAGES
+from ..services.genre_classification import canonicalize_genre_names, count_fiction_nonfiction
 
 logger = logging.getLogger(__name__)
 
@@ -42,19 +43,18 @@ def _compute_enrichment_stats(user):
     page_counts = [b.page_count for b in books if b.page_count]
 
     all_genres = []
-    fiction_count = 0
-    nonfiction_count = 0
+    genre_sets = []
     mainstream_count = 0
     for book in books:
         book_genres = [g.name for g in book.genres.all()]
         all_genres.extend(book_genres)
-        canonical = {CANONICAL_GENRE_MAP.get(g, g) for g in book_genres}
-        if canonical & FICTION_GENRES:
-            fiction_count += 1
-        elif canonical & NONFICTION_GENRES:
-            nonfiction_count += 1
+        genre_sets.append(canonicalize_genre_names(book_genres))
         if book.author.is_mainstream or (book.publisher and book.publisher.is_mainstream):
             mainstream_count += 1
+
+    # Context-dependent fiction/nonfiction classification (shared helper).
+    # Books with no classifiable genres land in defaulted_count, never fiction.
+    fiction_count, nonfiction_count, defaulted_count = count_fiction_nonfiction(genre_sets)
 
     mapped = [CANONICAL_GENRE_MAP.get(g, g) for g in all_genres]
 
@@ -64,7 +64,11 @@ def _compute_enrichment_stats(user):
         "top_genres": Counter(mapped).most_common(10),
         "unique_genres_count": len(set(mapped)),
         "fiction_nonfiction_split": (
-            {"fiction_count": fiction_count, "nonfiction_count": nonfiction_count}
+            {
+                "fiction_count": fiction_count,
+                "nonfiction_count": nonfiction_count,
+                "defaulted_count": defaulted_count,
+            }
             if (fiction_count + nonfiction_count) > 0
             else None
         ),


### PR DESCRIPTION
## Summary

Part 1 of the genre overhaul (`docs/plans/2026-03-02` plan, rebased onto the split packages). Part 2 (inline enrichment, shelf signals, coverage UI) follows separately.

- **8 new canonical genres** — memoir, true crime, poetry, essays, literary fiction, dystopian, mystery, adventure — with aliases moved from the genres that used to swallow them (mystery out of thriller, memoir out of biography, essays out of non-fiction…)
- **Ambiguous genres split**: classic/YA/children's each get fiction + nonfiction variants; old names remain as backward-compat aliases → fiction defaults (no data migration)
- **EXCLUDED_GENRES cleanup**: 28 colliding strings removed (incl. the pre-existing bug silently blocking `short stories`), with a both-directions regression test so no canonical genre or alias can ever be excluded again
- **Open Library + Google Books genres now merge** (GB priority) instead of GB replacing OL as a fallback; `enrich_books --process-all` resets `google_books_last_checked` so re-enrichment propagates the merge
- **One shared classifier** (`core/services/genre_classification.py`) replaces the two duplicated fiction-first counting loops (dna package + views helpers): ambiguous-only + nonfiction signal → nonfiction; unclassifiable books tracked in a new `defaulted_count` instead of being silently skipped. Templates verified to handle both old- and new-format split dicts — no template changes needed
- StoryGraph tags un-lossied; genre canonicalization at all 7 similarity comparison sites; new genres wired into current reader-type scoring per the plan's table

## Expected user-visible shifts (intended)

- Fiction share drops / nonfiction rises for most libraries ("A Brief History of Time" stops counting as fiction; unclassifiable books leave the pie)
- Top genres get more precise: `mystery`, `memoir`, `essays`, `adventure`, `true crime`, `literary fiction` appear; `classics`/`young adult` labels become `classic fiction`/`young adult fiction`
- Every first-time enrichment now calls Google Books (watch the 1,000/day quota on heavy days)

## Post-deploy (owner action)

Run `manage.py enrich_books --process-all` on the VPS (tmux) to re-fetch + merge GB genres for existing books.

## Testing

New `test_genre_canonicalization.py` (alias mapping, exclusion guards, classification matrix, counter independence, backward compat) + merge tests; old-vocabulary assertions updated. Full suite: **433/433 OK** (was 398).