### PR TITLE
feat: genre accuracy part 2 — inline enrichment, shelf signals, coverage transparency

### DIFF
--- a/core/services/book_enrichment_service.py
+++ b/core/services/book_enrichment_service.py
@@ -145,10 +145,10 @@ def _extract_edition_data(edition_data, book_details):
         book_details["isbn_13"] = isbns_10[0]
 
 
-def _fetch_work_genres(work_key, book_title, session, book_details, slow_down=False):
+def _fetch_work_genres(work_key, book_title, session, book_details, slow_down=False, timeout=5):
     """Fetch genres from an OL work endpoint. Returns number of API calls made."""
     work_url = f"https://openlibrary.org{work_key}.json"
-    work_response = session.get(work_url, timeout=5)
+    work_response = session.get(work_url, timeout=timeout)
     if slow_down:
         _throttle()
     if work_response.status_code == 200:
@@ -161,13 +161,19 @@ def _fetch_work_genres(work_key, book_title, session, book_details, slow_down=Fa
     return 1
 
 
-def _fetch_from_open_library(book, session, slow_down=False):
+def _fetch_from_open_library(book, session, slow_down=False, quick_mode=False):
     """
     Fetches metadata from Open Library. Uses direct ISBN endpoint when available
     (skips search), then work endpoint for genres, and edition endpoint only if
     the book is missing page count/publisher/year data.
+
+    quick_mode=True (inline enrichment during DNA calculation) uses reduced
+    HTTP timeouts: 2s for search, 1.5s for work/edition/isbn detail endpoints.
     """
     logger.debug(f"Querying Open Library for '{book.title}'")
+
+    search_timeout = 2 if quick_mode else 10
+    detail_timeout = 1.5 if quick_mode else 5
 
     book_details = {
         "genres": [],
@@ -183,7 +189,7 @@ def _fetch_from_open_library(book, session, slow_down=False):
         # Fast path: direct ISBN lookup (skips search entirely)
         if book.isbn13:
             isbn_url = f"https://openlibrary.org/isbn/{book.isbn13}.json"
-            res = session.get(isbn_url, timeout=5)
+            res = session.get(isbn_url, timeout=detail_timeout)
             api_calls += 1
             if slow_down:
                 _throttle()
@@ -200,7 +206,9 @@ def _fetch_from_open_library(book, session, slow_down=False):
                 if works := edition_data.get("works"):
                     work_key = works[0].get("key")
                     if work_key:
-                        api_calls += _fetch_work_genres(work_key, book.title, session, book_details, slow_down)
+                        api_calls += _fetch_work_genres(
+                            work_key, book.title, session, book_details, slow_down, timeout=detail_timeout
+                        )
 
                 track_external_api_call("open_library", book.pk, book.title, "success")
                 return book_details, api_calls
@@ -209,7 +217,7 @@ def _fetch_from_open_library(book, session, slow_down=False):
         # Fallback: search by title+author
         search_url = "https://openlibrary.org/search.json"
         search_params = {"title": _clean_title_for_api(book.title), "author": book.author.name}
-        res = session.get(search_url, params=search_params, timeout=10)
+        res = session.get(search_url, params=search_params, timeout=search_timeout)
         api_calls += 1
         if slow_down:
             _throttle()
@@ -229,14 +237,16 @@ def _fetch_from_open_library(book, session, slow_down=False):
 
         # Fetch genres from work endpoint
         if work_key:
-            api_calls += _fetch_work_genres(work_key, book.title, session, book_details, slow_down)
+            api_calls += _fetch_work_genres(
+                work_key, book.title, session, book_details, slow_down, timeout=detail_timeout
+            )
 
         # Skip edition endpoint if book already has all edition data
         if book.page_count and book.publisher and book.publish_year and book.isbn13:
             logger.debug(f"Skipping OL edition for '{book.title}' — already has page/publisher/year/isbn data")
         elif edition_key:
             edition_url = f"https://openlibrary.org/books/{edition_key}.json"
-            edition_response = session.get(edition_url, timeout=5)
+            edition_response = session.get(edition_url, timeout=detail_timeout)
             api_calls += 1
             if slow_down:
                 _throttle()
@@ -253,11 +263,13 @@ def _fetch_from_open_library(book, session, slow_down=False):
         return {}, api_calls or 1
 
 
-def _fetch_ratings_and_categories_from_google_books(book, session, slow_down=False):
+def _fetch_ratings_and_categories_from_google_books(book, session, slow_down=False, quick_mode=False):
     """
     Fetches ratings AND categories (genres) from Google Books.
     Google Books categories are often more accurate than Open Library subjects.
     Returns a dictionary of data and the number of API calls made (always 1 or 0).
+
+    quick_mode=True uses a reduced 2s HTTP timeout for inline enrichment.
     """
     if not GOOGLE_BOOKS_API_KEY:
         return {}, 0  # No API key, so no call is made
@@ -273,7 +285,7 @@ def _fetch_ratings_and_categories_from_google_books(book, session, slow_down=Fal
     url = f"https://www.googleapis.com/books/v1/volumes?q={query}&key={GOOGLE_BOOKS_API_KEY}"
 
     try:
-        res = session.get(url, timeout=10)
+        res = session.get(url, timeout=2 if quick_mode else 10)
 
         if slow_down:
             _throttle()
@@ -323,11 +335,15 @@ def _fetch_ratings_and_categories_from_google_books(book, session, slow_down=Fal
         return {}, 1
 
 
-def enrich_book_from_apis(book, session, slow_down=False):
+def enrich_book_from_apis(book, session, slow_down=False, quick_mode=False):
     """
     The main public function to enrich a single Book object.
     It orchestrates the calls to the different APIs, but only if data is missing.
     Returns the updated book object and the total number of API calls made.
+
+    quick_mode=True reduces internal HTTP timeouts (2s OL search, 1.5s OL
+    work/edition, 2s Google Books) for inline enrichment during DNA calculation,
+    where a single slow API response must not stall the whole upload.
     """
     ol_api_calls = 0
     gb_api_calls = 0
@@ -335,7 +351,7 @@ def enrich_book_from_apis(book, session, slow_down=False):
     is_updated = False
 
     # Always refresh genres from Open Library even if other data exists
-    ol_data, calls_made = _fetch_from_open_library(book, session, slow_down)
+    ol_data, calls_made = _fetch_from_open_library(book, session, slow_down, quick_mode=quick_mode)
     ol_api_calls += calls_made
 
     if ol_data:
@@ -366,7 +382,9 @@ def enrich_book_from_apis(book, session, slow_down=False):
     # subjects, so they lead the merge below.
     gb_genres = set()
     if book.google_books_last_checked is None:
-        gb_data, calls_made = _fetch_ratings_and_categories_from_google_books(book, session, slow_down)
+        gb_data, calls_made = _fetch_ratings_and_categories_from_google_books(
+            book, session, slow_down, quick_mode=quick_mode
+        )
         gb_api_calls += calls_made
 
         if gb_data:

--- a/core/services/dna/__init__.py
+++ b/core/services/dna/__init__.py
@@ -284,7 +284,8 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                             from ..book_enrichment_service import enrich_book_from_apis
 
                             logger.debug(
-                                f"Inline enrichment for '{book.title}' (created={created}, has_genres={has_genres}, needs_page_data={needs_page_data})"
+                                f"Inline enrichment for '{book.title}' (created={created}, "
+                                f"has_genres={has_genres}, needs_page_data={needs_page_data})"
                             )
                             enrich_book_from_apis(book, session, slow_down=False, quick_mode=True)
                             enriched_inline = True
@@ -293,7 +294,9 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                     if not enriched_inline:
                         from ...tasks import enrich_book_task
 
-                        logger.debug(f"Dispatching async enrichment for '{book.title}' (budget exhausted or inline failed)")
+                        logger.debug(
+                            f"Dispatching async enrichment for '{book.title}' (budget exhausted or inline failed)"
+                        )
                         enrich_book_task.delay(book.pk, user_id=upload_user_id, upload_nonce=upload_nonce)
                 else:
                     logger.debug(f"Book '{book.title}' already enriched. Skipping.")

--- a/core/services/dna/__init__.py
+++ b/core/services/dna/__init__.py
@@ -29,7 +29,7 @@ from ...dna_constants import (
     compute_contrariness,
 )
 from ...models import Author, Book, Genre
-from ..genre_classification import canonicalize_genre_names, count_fiction_nonfiction
+from ..genre_classification import canonicalize_genre_names, count_fiction_nonfiction, parse_shelf_signals
 from ...percentile_engine import (
     calculate_community_means,
     calculate_percentiles_from_aggregates,
@@ -338,16 +338,29 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                     if progress_cb:
                         progress_cb(processed, total_books, "Syncing books")
 
+        # Goodreads `Bookshelves` (exact column name — NOT "Bookshelves with
+        # positions", whose "(#N)" suffixes would break matching) carries
+        # user-curated shelf names used as weak fiction/nonfiction tiebreakers.
+        # StoryGraph exports have no such column, so this is Goodreads-only.
+        has_shelf_column = "Bookshelves" in read_df.columns
         book_genre_sets = []
+        shelf_signal_list = []
         for book, genres, original_row in results:
             if book:
                 user_book_objects.append(book)
                 all_raw_genres.extend(genres)
                 book_genre_sets.append(canonicalize_genre_names(genres))
+                raw_shelves = original_row.get("Bookshelves") if has_shelf_column else None
+                if raw_shelves is None or pd.isna(raw_shelves):
+                    raw_shelves = ""
+                shelf_signal_list.append(parse_shelf_signals(raw_shelves))
 
         # Context-dependent fiction/nonfiction classification. Books with no
         # classifiable genres are tracked in defaulted_count — never fiction.
-        fiction_count, nonfiction_count, defaulted_count = count_fiction_nonfiction(book_genre_sets)
+        # Shelf signals only decide when API genres give no clear signal.
+        fiction_count, nonfiction_count, defaulted_count = count_fiction_nonfiction(
+            book_genre_sets, shelf_signal_list
+        )
 
         # Sync currently-reading books to DB (Book/Author only, no UserBook, no global_read_count)
         if currently_reading_books:

--- a/core/services/dna/__init__.py
+++ b/core/services/dna/__init__.py
@@ -40,6 +40,10 @@ from .csv_parser import (  # noqa: F401 — re-exported for stable import paths
     STORYGRAPH_TO_GOODREADS,
     _detect_and_normalize_csv,
 )
+from .enrichment_budget import (  # noqa: F401 — re-exported for stable import paths
+    INLINE_ENRICHMENT_BUDGET_SECONDS,
+    _EnrichmentBudget,
+)
 from .persistence import (  # noqa: F401 — re-exported for stable import paths
     _save_dna_to_profile,
     save_anonymous_session_data,
@@ -150,7 +154,13 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
             from ...cache_utils import safe_cache_get
 
             upload_nonce = safe_cache_get(f"upload_nonce_{user.id}")
+        # Wall-clock budget for inline enrichment, shared across the 8 sync
+        # workers via the process_book_row closure. Lazily started (the timer
+        # only runs once a book actually needs inline enrichment) and
+        # lock-guarded so the start is exactly-once under concurrency.
+        enrichment_budget = _EnrichmentBudget()
         with requests.Session() as session:
+            session.headers.update({"User-Agent": "BibliotypeApp/1.0"})
 
             def process_book_row(original_row):
                 author_name_from_csv = original_row.get("Author", "").strip()
@@ -260,17 +270,31 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
                             has_genres = True
                             logger.debug(f"Applied {len(tag_genres)} tag-derived genres for '{book.title}': {tag_genres}")
 
-                # Dispatch enrichment as a background task to avoid blocking upload
-                # Skip if the full enrichment pipeline already ran (google_books_last_checked is set)
+                # Inline-first enrichment: while the 90s budget lasts, enrich
+                # synchronously with quick_mode timeouts so genres land in THIS
+                # DNA calculation (no async race). On failure or once the budget
+                # is exhausted, fall back to the async task exactly as before.
+                # Skip if the full pipeline already ran (google_books_last_checked set).
                 already_attempted = not created and book.google_books_last_checked is not None
                 needs_page_data = not book.page_count or not book.publish_year
                 if not already_attempted and (created or not has_genres or needs_page_data):
-                    from ...tasks import enrich_book_task
+                    enriched_inline = False
+                    if enrichment_budget.has_remaining():
+                        try:
+                            from ..book_enrichment_service import enrich_book_from_apis
 
-                    logger.debug(
-                        f"Dispatching enrichment for '{book.title}' (created={created}, has_genres={has_genres}, needs_page_data={needs_page_data})"
-                    )
-                    enrich_book_task.delay(book.pk, user_id=upload_user_id, upload_nonce=upload_nonce)
+                            logger.debug(
+                                f"Inline enrichment for '{book.title}' (created={created}, has_genres={has_genres}, needs_page_data={needs_page_data})"
+                            )
+                            enrich_book_from_apis(book, session, slow_down=False, quick_mode=True)
+                            enriched_inline = True
+                        except Exception as e:
+                            logger.warning(f"Inline enrichment failed for '{book.title}': {e}")
+                    if not enriched_inline:
+                        from ...tasks import enrich_book_task
+
+                        logger.debug(f"Dispatching async enrichment for '{book.title}' (budget exhausted or inline failed)")
+                        enrich_book_task.delay(book.pk, user_id=upload_user_id, upload_nonce=upload_nonce)
                 else:
                     logger.debug(f"Book '{book.title}' already enriched. Skipping.")
 
@@ -292,6 +316,15 @@ def calculate_full_dna(csv_file_content: str, user=None, session_key=None, progr
             # Publisher is resolved by the unique constraints rather than serialising at
             # the executor level. The legacy max_workers=1 was a vestige of SQLite's
             # database-wide write lock and is no longer needed in the prod stack.
+            #
+            # Shared inline-enrichment state across the workers:
+            # - `session`: one requests.Session for all workers. Session.get is
+            #   thread-safe for concurrent requests (urllib3's connection pool
+            #   handles per-connection checkout); we only mutate headers once,
+            #   before the executor starts.
+            # - `enrichment_budget`: lazy start is lock-guarded (exactly-once);
+            #   has_remaining() reads are race-tolerant by design — at the
+            #   boundary a few in-flight workers may each admit one extra book.
             with ThreadPoolExecutor(max_workers=8) as executor:
                 results = []
                 processed = 0

--- a/core/services/dna/enrichment_budget.py
+++ b/core/services/dna/enrichment_budget.py
@@ -1,0 +1,38 @@
+"""Wall-clock budget for inline book enrichment during DNA calculation.
+
+Inline enrichment (quick_mode API calls made directly from the book-sync
+workers) must not stall an upload indefinitely: after the budget is exhausted,
+remaining books fall back to async `enrich_book_task` dispatch.
+"""
+
+import threading
+import time
+
+# Global wall-clock limit for inline enrichment per upload. After this many
+# seconds of inline enrichment, remaining books are enriched async instead.
+INLINE_ENRICHMENT_BUDGET_SECONDS = 90
+
+
+class _EnrichmentBudget:
+    """Lazily-started wall-clock budget, safe under the max_workers=8 sync pool.
+
+    The timer starts on the FIRST `has_remaining()` call, not at construction,
+    so CSV parsing and DB writes for already-enriched books don't consume the
+    budget. A lock guarantees the timer starts exactly once even when several
+    workers race the first call. `has_remaining()` itself is only loosely
+    ordered after start — at the budget boundary a couple of in-flight workers
+    may each let one extra book through, which is acceptable.
+    """
+
+    def __init__(self, max_seconds=INLINE_ENRICHMENT_BUDGET_SECONDS):
+        self._max = max_seconds
+        self._started_at = None  # Lazily initialized on first enrichment attempt
+        self._lock = threading.Lock()
+
+    def has_remaining(self):
+        if self._started_at is None:
+            with self._lock:
+                if self._started_at is None:
+                    self._started_at = time.monotonic()  # Start timing on first actual enrichment
+                    return True
+        return (time.monotonic() - self._started_at) < self._max

--- a/core/services/genre_classification.py
+++ b/core/services/genre_classification.py
@@ -6,12 +6,22 @@ genres alongside nonfiction genres (e.g. "classic fiction" + "history" for
 "A Brief History of Time") is really nonfiction. This module resolves that at
 analysis time, where the full set of a book's genres is available.
 
+Goodreads `Bookshelves` shelf names supply an additional WEAK signal: shelf
+`"fiction"` / `"nonfiction"` booleans and canonical shelf genres act as
+tiebreakers only — they never override clear API genre signals, so a user who
+shelves "Sapiens" as "fiction" can't flip a book with real nonfiction genres.
+
 Used by core/services/dna/__init__.py (calculate_full_dna) and
 core/views/_helpers.py (_compute_enrichment_stats) so both counting paths share
-one vocabulary and one resolution policy.
+one vocabulary and one resolution policy. The views helper has no CSV context
+and passes no shelf data — the defaults keep its behaviour unchanged.
 """
 
+from itertools import repeat
+
 from ..dna_constants import AMBIGUOUS_FICTION_GENRES, CANONICAL_GENRE_MAP, FICTION_GENRES, NONFICTION_GENRES
+
+_NO_SHELF_SIGNALS = (False, False, frozenset())
 
 
 def canonicalize_genre_names(genre_names):
@@ -19,21 +29,52 @@ def canonicalize_genre_names(genre_names):
     return {CANONICAL_GENRE_MAP.get(g, g) for g in genre_names}
 
 
-def classify_genres(canonical):
+def parse_shelf_signals(raw_bookshelves):
+    """Parse a Goodreads `Bookshelves` cell into (shelf_fiction, shelf_nonfiction, shelf_genres).
+
+    The column is comma-separated (e.g. "read, fiction, favorites"). `"fiction"`
+    and `"nonfiction"`/`"non-fiction"` are special-cased as boolean signals —
+    "fiction" sits in EXCLUDED_GENRES (API false-positive guard) and the
+    nonfiction spellings must stay weak booleans rather than becoming canonical
+    genres in the combined set. Other shelf names resolve through
+    CANONICAL_GENRE_MAP; non-genre shelves ("read", "owned", ...) fall out.
+    """
+    shelf_fiction = False
+    shelf_nonfiction = False
+    shelf_genres = set()
+    if not raw_bookshelves:
+        return _NO_SHELF_SIGNALS
+    for shelf in str(raw_bookshelves).split(","):
+        shelf_clean = shelf.strip().lower()
+        if shelf_clean == "fiction":
+            shelf_fiction = True
+        elif shelf_clean in ("nonfiction", "non-fiction"):
+            shelf_nonfiction = True
+        elif shelf_clean in CANONICAL_GENRE_MAP:
+            shelf_genres.add(CANONICAL_GENRE_MAP[shelf_clean])
+    return shelf_fiction, shelf_nonfiction, frozenset(shelf_genres)
+
+
+def classify_genres(canonical, shelf_fiction=False, shelf_nonfiction=False, shelf_genres=frozenset()):
     """Classify a set of canonical genre names as "fiction", "nonfiction", or None.
 
-    Resolution order (context-dependent, per the genre-accuracy plan):
+    Resolution order (context-dependent, per the genre-accuracy plan; shelf
+    signals are weak tiebreakers consulted ONLY when the genre sets provide no
+    clear signal):
     1. ONLY ambiguous fiction genres + a nonfiction signal → nonfiction
        (e.g. {"classic fiction", "history"})
     2. Any unambiguous fiction genre → fiction
        (e.g. {"classic fiction", "history", "fantasy"} — historical fantasy)
     3. Any nonfiction genre → nonfiction
-    4. Only ambiguous fiction genres, no other signal → fiction (the default)
-    5. Empty or unmatched set → None (caller decides how to track it)
+    4. Shelf "nonfiction" → nonfiction (no API signal, trust the shelf;
+       also disambiguates ambiguous-only sets like {"classic fiction"})
+    5. Shelf "fiction", or only ambiguous fiction genres → fiction
+    6. Empty or unmatched set, no shelf signal → None (caller decides)
     """
-    ambiguous_fiction = canonical & AMBIGUOUS_FICTION_GENRES
-    unambiguous_fiction = canonical & (FICTION_GENRES - AMBIGUOUS_FICTION_GENRES)
-    has_nonfiction = bool(canonical & NONFICTION_GENRES)
+    combined = canonical | shelf_genres
+    ambiguous_fiction = combined & AMBIGUOUS_FICTION_GENRES
+    unambiguous_fiction = combined & (FICTION_GENRES - AMBIGUOUS_FICTION_GENRES)
+    has_nonfiction = bool(combined & NONFICTION_GENRES)
 
     if ambiguous_fiction and has_nonfiction and not unambiguous_fiction:
         return "nonfiction"
@@ -41,24 +82,35 @@ def classify_genres(canonical):
         return "fiction"
     if has_nonfiction:
         return "nonfiction"
-    if ambiguous_fiction:
+    if shelf_nonfiction:
+        return "nonfiction"
+    if shelf_fiction or ambiguous_fiction:
         return "fiction"
     return None
 
 
-def count_fiction_nonfiction(genre_sets):
+def count_fiction_nonfiction(genre_sets, shelf_signals=None):
     """Count fiction/nonfiction/defaulted books across an iterable of canonical genre sets.
+
+    `shelf_signals`, when given, is an iterable aligned with `genre_sets` of
+    (shelf_fiction, shelf_nonfiction, shelf_genres) triples as produced by
+    `parse_shelf_signals`. Callers without shelf data (e.g. the views helper)
+    omit it and get pure API-genre classification.
 
     Returns (fiction_count, nonfiction_count, defaulted_count). The three
     counters are independent — books with no classifiable genres land in
     defaulted_count and are NEVER added to fiction_count — and always sum to
     the number of sets processed.
     """
+    if shelf_signals is None:
+        shelf_signals = repeat(_NO_SHELF_SIGNALS)
     fiction_count = 0
     nonfiction_count = 0
     defaulted_count = 0
-    for canonical in genre_sets:
-        classification = classify_genres(canonical)
+    for canonical, (shelf_fiction, shelf_nonfiction, shelf_genres) in zip(genre_sets, shelf_signals):
+        classification = classify_genres(
+            canonical, shelf_fiction=shelf_fiction, shelf_nonfiction=shelf_nonfiction, shelf_genres=shelf_genres
+        )
         if classification == "fiction":
             fiction_count += 1
         elif classification == "nonfiction":

--- a/core/templates/core/partials/dna/fiction_nonfiction_card.html
+++ b/core/templates/core/partials/dna/fiction_nonfiction_card.html
@@ -2,31 +2,36 @@
     {% include 'core/partials/dna/enrichment_banner.html' with condition=enrichment.pending %}
     <h2 class="mb-1 text-center text-2xl font-bold uppercase">Fiction vs Nonfiction</h2>
     <p class="text-center text-base text-gray-500 italic">
-        How {{ pronoun_pos|default:"your" }} library splits between fiction and nonfiction{% if enrichment.pending %} (so far){% endif %}
+        How {{ pronoun_pos|default:"your" }} library splits between fiction and nonfiction
+        {% if enrichment.pending %}(so far){% endif %}
     </p>
-    <div class="flex flex-1 flex-col items-center justify-center py-4 {% if enrichment.pending %}opacity-60 transition-opacity duration-500{% endif %}">
+    <div
+        class="{% if enrichment.pending %}opacity-60 transition-opacity duration-500{% endif %} flex flex-1 flex-col items-center justify-center py-4"
+    >
         <div class="chart-await mx-auto" style="height: 220px; width: 220px">
             <canvas id="fictionNonfictionChart"></canvas>
         </div>
     </div>
     {% with split=dna.fiction_nonfiction_split %}
         {% widthratio split.fiction_count split.fiction_count|add:split.nonfiction_count 100 as fiction_pct %}
-        <div class="flex items-center justify-center gap-6 text-lg {% if enrichment.pending %}opacity-60 transition-opacity duration-500{% endif %}">
+        <div
+            class="{% if enrichment.pending %}opacity-60 transition-opacity duration-500{% endif %} flex items-center justify-center gap-6 text-lg"
+        >
             <div class="flex items-center gap-2">
-                <span
-                    class="inline-block h-4 w-4 border-2 border-gray-800"
-                    style="background-color: #ffb4dd"
-                ></span>
+                <span class="inline-block h-4 w-4 border-2 border-gray-800" style="background-color: #ffb4dd"></span>
                 Fiction {{ fiction_pct }}%
             </div>
             <div class="flex items-center gap-2">
-                <span
-                    class="inline-block h-4 w-4 border-2 border-gray-800"
-                    style="background-color: #8bbfff"
-                ></span>
-                Nonfiction
-                {% widthratio split.nonfiction_count split.fiction_count|add:split.nonfiction_count 100 %}%
+                <span class="inline-block h-4 w-4 border-2 border-gray-800" style="background-color: #8bbfff"></span>
+                Nonfiction {% widthratio split.nonfiction_count split.fiction_count|add:split.nonfiction_count 100 %}%
             </div>
         </div>
+        {% if split.defaulted_count and enrichment.pending %}
+            <p class="mt-3 text-center text-sm text-gray-500 italic">
+                Based on {{ split.fiction_count|add:split.nonfiction_count }} of
+                {{ split.fiction_count|add:split.nonfiction_count|add:split.defaulted_count }} books — refresh in a few
+                minutes for more complete data
+            </p>
+        {% endif %}
     {% endwith %}
 </div>

--- a/core/tests/test_currently_reading.py
+++ b/core/tests/test_currently_reading.py
@@ -64,6 +64,11 @@ class CurrentlyReadingExtractionTests(TransactionTestCase):
             cache.clear()
         except Exception:
             pass
+        # Inline enrichment must never hit real APIs from tests — a no-op mock
+        # keeps books genre-less here, matching the old async-only behaviour.
+        inline_patcher = patch("core.services.book_enrichment_service.enrich_book_from_apis")
+        self.mock_inline_enrich = inline_patcher.start()
+        self.addCleanup(inline_patcher.stop)
 
     @patch("core.tasks.generate_recommendations_task.delay")
     @patch("core.tasks.check_author_mainstream_status_task.delay")
@@ -338,6 +343,10 @@ class CurrentlyReadingCoverUpgradeTests(TransactionTestCase):
             cache.clear()
         except Exception:
             pass
+        # Inline enrichment must never hit real APIs from tests (see above).
+        inline_patcher = patch("core.services.book_enrichment_service.enrich_book_from_apis")
+        self.mock_inline_enrich = inline_patcher.start()
+        self.addCleanup(inline_patcher.stop)
 
     @patch("core.tasks.generate_recommendations_task.delay")
     @patch("core.tasks.check_author_mainstream_status_task.delay")

--- a/core/tests/test_enrichment_stats.py
+++ b/core/tests/test_enrichment_stats.py
@@ -167,6 +167,36 @@ class ComputeEnrichmentProgressTests(TestCase):
         self.assertEqual(result["total"], 2)
         self.assertEqual(result["percent"], 50)
 
+    def test_genre_coverage_gate_applies_to_goodreads_uploads(self):
+        """enrichment pending + genres_pending for a Goodreads upload with <50%
+        genre coverage — the coverage gate is source-agnostic, not StoryGraph-only."""
+        self._add_book("A", attempted=True, has_genre=True)
+        self._add_book("B", attempted=False)
+        self._add_book("C", attempted=False)
+        self._add_book("D", attempted=False)
+
+        dna_data = {"csv_source": "goodreads"}
+        result = _compute_enrichment_progress(self.user, self.profile, dna_data)
+
+        self.assertTrue(result["pending"])
+        self.assertEqual(result["csv_source"], "goodreads")
+        # 1 of 4 books has genres → 25% coverage, below the 50% gate
+        self.assertTrue(result["genres_pending"])
+        self.assertEqual(result["genre_coverage_pct"], 25)
+
+    def test_genre_coverage_pct_above_gate(self):
+        """Coverage >= 50% clears genres_pending while enrichment continues."""
+        self._add_book("A", attempted=True, has_genre=True)
+        self._add_book("B", attempted=False, has_genre=True)
+        self._add_book("C", attempted=False, has_genre=True)
+        self._add_book("D", attempted=False)
+
+        result = _compute_enrichment_progress(self.user, self.profile, {})
+
+        self.assertTrue(result["pending"])
+        self.assertFalse(result["genres_pending"])
+        self.assertEqual(result["genre_coverage_pct"], 75)
+
     def test_finalize_flips_exactly_once(self):
         """All books attempted → finalize block runs once; second call no-ops the save."""
         self._add_book("A", attempted=True, has_genre=True, page_count=300)
@@ -192,6 +222,51 @@ class ComputeEnrichmentProgressTests(TestCase):
 
         self.profile.refresh_from_db()
         self.assertTrue(self.profile.dna_data.get("enrichment_finalized"))
+
+
+class FictionNonfictionCoverageSubtitleTests(TestCase):
+    """The card's 'Based on X of Y books' subtitle: shown only while enrichment
+    is pending AND some books were defaulted (unclassifiable)."""
+
+    def _render(self, split, enrichment):
+        from django.template.loader import render_to_string
+
+        return render_to_string(
+            "core/partials/dna/fiction_nonfiction_card.html",
+            {"dna": {"fiction_nonfiction_split": split}, "enrichment": enrichment},
+        )
+
+    def test_subtitle_shown_when_pending_with_defaulted_books(self):
+        html = self._render(
+            {"fiction_count": 6, "nonfiction_count": 4, "defaulted_count": 5},
+            {"pending": True, "genre_coverage_pct": 40},
+        )
+        self.assertIn("Based on 10 of", html)
+        self.assertIn("15 books", html)
+        self.assertIn("refresh in a", html)
+
+    def test_subtitle_hidden_when_enrichment_finished(self):
+        html = self._render(
+            {"fiction_count": 6, "nonfiction_count": 4, "defaulted_count": 5},
+            None,
+        )
+        self.assertNotIn("Based on", html)
+
+    def test_subtitle_hidden_when_nothing_defaulted(self):
+        html = self._render(
+            {"fiction_count": 6, "nonfiction_count": 4, "defaulted_count": 0},
+            {"pending": True, "genre_coverage_pct": 100},
+        )
+        self.assertNotIn("Based on", html)
+
+    def test_subtitle_hidden_for_old_format_split(self):
+        """Old stored DNA has no defaulted_count key — the card must still render."""
+        html = self._render(
+            {"fiction_count": 6, "nonfiction_count": 4},
+            {"pending": True, "genre_coverage_pct": 40},
+        )
+        self.assertNotIn("Based on", html)
+        self.assertIn("Fiction", html)
 
 
 @override_settings(

--- a/core/tests/test_genre_canonicalization.py
+++ b/core/tests/test_genre_canonicalization.py
@@ -1,9 +1,14 @@
 """Tests for the expanded canonical genre set and shared fiction/nonfiction classification.
 
 Covers the genre-accuracy work: 8 new canonical genres, ambiguous sub-splits
-with backward-compat aliases, EXCLUDED_GENRES regression guards, and the
-context-dependent classifier in core/services/genre_classification.py.
+with backward-compat aliases, EXCLUDED_GENRES regression guards, the
+context-dependent classifier in core/services/genre_classification.py, and the
+inline-enrichment wall-clock budget.
 """
+
+import threading
+from itertools import count
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -192,3 +197,75 @@ class CountFictionNonfictionTests(TestCase):
 
     def test_empty_iterable(self):
         self.assertEqual(count_fiction_nonfiction([]), (0, 0, 0))
+
+
+class EnrichmentBudgetTests(TestCase):
+    """_EnrichmentBudget: lazy start, exhaustion, exactly-once start under threads."""
+
+    def test_creation_does_not_start_the_clock(self):
+        from core.services.dna.enrichment_budget import _EnrichmentBudget
+
+        with patch("core.services.dna.enrichment_budget.time.monotonic") as mock_monotonic:
+            budget = _EnrichmentBudget()
+
+        mock_monotonic.assert_not_called()
+        self.assertIsNone(budget._started_at)
+
+    def test_first_call_starts_clock_and_returns_true(self):
+        from core.services.dna.enrichment_budget import _EnrichmentBudget
+
+        budget = _EnrichmentBudget(max_seconds=90)
+        with patch("core.services.dna.enrichment_budget.time.monotonic", return_value=1000.0):
+            self.assertTrue(budget.has_remaining())
+        self.assertEqual(budget._started_at, 1000.0)
+
+    def test_exhaustion_after_max_seconds(self):
+        from core.services.dna.enrichment_budget import _EnrichmentBudget
+
+        budget = _EnrichmentBudget(max_seconds=90)
+        clock = iter([1000.0, 1000.0 + 89.0, 1000.0 + 91.0])
+        with patch("core.services.dna.enrichment_budget.time.monotonic", side_effect=lambda: next(clock)):
+            self.assertTrue(budget.has_remaining())  # starts the clock at t=1000
+            self.assertTrue(budget.has_remaining())  # 89s elapsed — still within budget
+            self.assertFalse(budget.has_remaining())  # 91s elapsed — exhausted
+
+    def test_default_budget_is_90_seconds(self):
+        from core.services.dna.enrichment_budget import INLINE_ENRICHMENT_BUDGET_SECONDS, _EnrichmentBudget
+
+        self.assertEqual(INLINE_ENRICHMENT_BUDGET_SECONDS, 90)
+        self.assertEqual(_EnrichmentBudget()._max, 90)
+
+    def test_thread_safety_clock_starts_exactly_once(self):
+        """8 racing workers: exactly one call may take the start path (returns True
+        directly); every other concurrent call must observe the already-started
+        clock. The fake clock returns 0.0 for the very first monotonic call (the
+        start, made under the lock) and a huge value afterwards — so if a second
+        thread also 'started' the clock, later calls would wrongly return True."""
+        from core.services.dna.enrichment_budget import _EnrichmentBudget
+
+        budget = _EnrichmentBudget(max_seconds=90)
+        calls = count()
+
+        def fake_monotonic():
+            return 0.0 if next(calls) == 0 else 10_000.0
+
+        results = []
+        results_lock = threading.Lock()
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait()
+            result = budget.has_remaining()
+            with results_lock:
+                results.append(result)
+
+        with patch("core.services.dna.enrichment_budget.time.monotonic", side_effect=fake_monotonic):
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            self.assertEqual(results.count(True), 1, "clock must start exactly once across racing threads")
+            self.assertEqual(budget._started_at, 0.0)
+            self.assertFalse(budget.has_remaining())

--- a/core/tests/test_genre_canonicalization.py
+++ b/core/tests/test_genre_canonicalization.py
@@ -26,6 +26,7 @@ from core.services.genre_classification import (
     canonicalize_genre_names,
     classify_genres,
     count_fiction_nonfiction,
+    parse_shelf_signals,
 )
 
 
@@ -173,6 +174,64 @@ class ClassifyGenresMatrixTests(TestCase):
         self.assertEqual(classify_genres(canonicalize_genre_names(["classics"])), "fiction")
 
 
+class ShelfSignalTiebreakerTests(TestCase):
+    """The plan's 6-case shelf matrix: shelf signals never override clear API genres."""
+
+    def test_clear_nonfiction_api_signal_beats_fiction_shelf(self):
+        self.assertEqual(classify_genres({"history", "biography"}, shelf_fiction=True), "nonfiction")
+
+    def test_clear_fiction_api_signal_beats_nonfiction_shelf(self):
+        self.assertEqual(classify_genres({"fantasy"}, shelf_nonfiction=True), "fiction")
+
+    def test_no_api_signal_nonfiction_shelf_wins(self):
+        self.assertEqual(classify_genres(set(), shelf_nonfiction=True), "nonfiction")
+
+    def test_no_api_signal_fiction_shelf_wins(self):
+        self.assertEqual(classify_genres(set(), shelf_fiction=True), "fiction")
+
+    def test_nonfiction_shelf_disambiguates_ambiguous_only_genres(self):
+        self.assertEqual(classify_genres({"classic fiction"}, shelf_nonfiction=True), "nonfiction")
+
+    def test_no_api_signal_no_shelf_is_defaulted(self):
+        self.assertIsNone(classify_genres(set()))
+
+    def test_shelf_genres_supplement_empty_api_genres(self):
+        self.assertEqual(classify_genres(set(), shelf_genres=frozenset({"history"})), "nonfiction")
+        self.assertEqual(classify_genres(set(), shelf_genres=frozenset({"fantasy"})), "fiction")
+
+
+class ParseShelfSignalsTests(TestCase):
+    """Goodreads Bookshelves parsing: comma-split, special-cased fiction/nonfiction."""
+
+    def test_fiction_shelf_sets_fiction_signal(self):
+        self.assertEqual(parse_shelf_signals("read, fiction, favorites"), (True, False, frozenset()))
+
+    def test_nonfiction_spellings_set_nonfiction_signal(self):
+        for spelling in ("nonfiction", "non-fiction"):
+            shelf_fiction, shelf_nonfiction, shelf_genres = parse_shelf_signals(f"read, {spelling}")
+            self.assertFalse(shelf_fiction)
+            self.assertTrue(shelf_nonfiction)
+            self.assertEqual(shelf_genres, frozenset())
+
+    def test_genre_shelves_canonicalize(self):
+        shelf_fiction, shelf_nonfiction, shelf_genres = parse_shelf_signals("read, fantasy, memoirs")
+        self.assertFalse(shelf_fiction)
+        self.assertFalse(shelf_nonfiction)
+        self.assertEqual(shelf_genres, frozenset({"fantasy", "memoir"}))
+
+    def test_non_genre_shelves_are_ignored(self):
+        self.assertEqual(parse_shelf_signals("read, to-read, owned, favorites"), (False, False, frozenset()))
+
+    def test_empty_and_missing_values(self):
+        self.assertEqual(parse_shelf_signals(""), (False, False, frozenset()))
+        self.assertEqual(parse_shelf_signals(None), (False, False, frozenset()))
+
+    def test_case_and_whitespace_insensitive(self):
+        shelf_fiction, shelf_nonfiction, _ = parse_shelf_signals("  Fiction ,  NONFICTION  ")
+        self.assertTrue(shelf_fiction)
+        self.assertTrue(shelf_nonfiction)
+
+
 class CountFictionNonfictionTests(TestCase):
     """Counter independence: defaulted books are never added to fiction."""
 
@@ -197,6 +256,26 @@ class CountFictionNonfictionTests(TestCase):
 
     def test_empty_iterable(self):
         self.assertEqual(count_fiction_nonfiction([]), (0, 0, 0))
+
+    def test_shelf_signals_break_ties_without_overriding_api(self):
+        genre_sets = [
+            {"history", "biography"},  # nonfiction — fiction shelf can't override
+            {"fantasy"},  # fiction — nonfiction shelf can't override
+            set(),  # nonfiction via shelf tiebreaker
+            set(),  # fiction via shelf tiebreaker
+            {"classic fiction"},  # nonfiction — shelf disambiguates ambiguous-only
+            set(),  # defaulted — no shelf signal
+        ]
+        shelf_signals = [
+            (True, False, frozenset()),
+            (False, True, frozenset()),
+            (False, True, frozenset()),
+            (True, False, frozenset()),
+            (False, True, frozenset()),
+            (False, False, frozenset()),
+        ]
+        fiction, nonfiction, defaulted = count_fiction_nonfiction(genre_sets, shelf_signals)
+        self.assertEqual((fiction, nonfiction, defaulted), (2, 3, 1))
 
 
 class EnrichmentBudgetTests(TestCase):

--- a/core/tests/test_integration.py
+++ b/core/tests/test_integration.py
@@ -5,7 +5,7 @@ import requests
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test import TestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
 
 from core.models import (
@@ -501,6 +501,109 @@ class BookEnrichmentIntegrationTests(TestCase):
 
         self.book.refresh_from_db()
         self.assertEqual(self.book.cover_url, "https://covers.openlibrary.org/b/id/999-M.jpg")
+
+
+# ──────────────────────────────────────────────
+# Class 1a: Inline Enrichment During DNA Calculation
+# ──────────────────────────────────────────────
+
+
+@override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+)
+class InlineEnrichmentDuringDnaTests(TransactionTestCase):
+    """calculate_full_dna enriches new books inline (budget permitting) and
+    falls back to the async enrich_book_task on failure or budget exhaustion.
+
+    TransactionTestCase because calculate_full_dna's ThreadPoolExecutor workers
+    open their own DB connections — they must see the test's data (and vice
+    versa), which a transaction-wrapped TestCase would prevent."""
+
+    CSV = (
+        "Title,Author,Exclusive Shelf,My Rating,Number of Pages,"
+        "Original Publication Year,Date Read,Average Rating,My Review,ISBN13\n"
+        "Inline Book A,Inline Author,read,5,300,2020,2023/01/10,4.0,,\n"
+        "Inline Book B,Inline Author,read,4,250,2019,2023/02/15,4.5,,\n"
+    )
+
+    def _run_dna(self, user):
+        from core.services.dna import calculate_full_dna
+
+        return calculate_full_dna(self.CSV, user=user)
+
+    @patch("core.tasks.generate_recommendations_task.delay")
+    @patch("core.tasks.check_author_mainstream_status_task.delay")
+    @patch("core.tasks.enrich_book_task.delay")
+    @patch("core.services.dna.generate_vibe_with_llm", return_value=["vibe"])
+    @patch("core.services.book_enrichment_service.enrich_book_from_apis")
+    def test_inline_enrichment_provides_genres(self, mock_inline, mock_vibe, mock_delay, mock_author, mock_recs):
+        """New books are enriched inline with quick_mode=True; the genres land in
+        the same DNA calculation (top_genres + fiction/nonfiction split)."""
+
+        def add_genre(book, session, slow_down=False, quick_mode=False):
+            # get_or_create inside the side effect: it runs on the worker
+            # thread's own DB connection, like the real enrichment does.
+            fantasy, _ = Genre.objects.get_or_create(name="fantasy")
+            book.genres.add(fantasy)
+            return book, 1, 1
+
+        mock_inline.side_effect = add_genre
+        user = User.objects.create_user(username="inline_user", password="pw")
+
+        dna = self._run_dna(user)
+
+        self.assertEqual(mock_inline.call_count, 2)
+        for call in mock_inline.call_args_list:
+            self.assertFalse(call.kwargs["slow_down"])
+            self.assertTrue(call.kwargs["quick_mode"])
+        # Inline succeeded — no async fallback
+        mock_delay.assert_not_called()
+        # Inline genres flow into the per-book genre collection used downstream
+        self.assertIn("fantasy", [g for g, _ in dna["top_genres"]])
+        self.assertEqual(
+            dna["fiction_nonfiction_split"],
+            {"fiction_count": 2, "nonfiction_count": 0, "defaulted_count": 0},
+        )
+
+    @patch("core.tasks.generate_recommendations_task.delay")
+    @patch("core.tasks.check_author_mainstream_status_task.delay")
+    @patch("core.tasks.enrich_book_task.delay")
+    @patch("core.services.dna.generate_vibe_with_llm", return_value=["vibe"])
+    @patch("core.services.book_enrichment_service.enrich_book_from_apis")
+    def test_async_fallback_on_inline_exception(self, mock_inline, mock_vibe, mock_delay, mock_author, mock_recs):
+        """Inline failure falls back to enrich_book_task.delay with the upload-nonce args."""
+        mock_inline.side_effect = requests.RequestException("API timeout")
+        user = User.objects.create_user(username="fallback_user", password="pw")
+
+        dna = self._run_dna(user)
+
+        self.assertEqual(mock_inline.call_count, 2)
+        self.assertEqual(mock_delay.call_count, 2)
+        for call in mock_delay.call_args_list:
+            self.assertEqual(call.kwargs["user_id"], user.id)
+            self.assertIn("upload_nonce", call.kwargs)
+        # No genres → both books tracked as defaulted, split is None
+        self.assertIsNone(dna["fiction_nonfiction_split"])
+
+    @patch("core.tasks.generate_recommendations_task.delay")
+    @patch("core.tasks.check_author_mainstream_status_task.delay")
+    @patch("core.tasks.enrich_book_task.delay")
+    @patch("core.services.dna.generate_vibe_with_llm", return_value=["vibe"])
+    @patch("core.services.book_enrichment_service.enrich_book_from_apis")
+    @patch("core.services.dna.enrichment_budget._EnrichmentBudget.has_remaining", return_value=False)
+    def test_async_fallback_when_budget_exhausted(
+        self, mock_budget, mock_inline, mock_vibe, mock_delay, mock_author, mock_recs
+    ):
+        """Once the 90s budget is exhausted, remaining books skip inline enrichment
+        and dispatch the async task exactly as before."""
+        user = User.objects.create_user(username="budget_user", password="pw")
+
+        self._run_dna(user)
+
+        mock_inline.assert_not_called()
+        self.assertEqual(mock_delay.call_count, 2)
+        for call in mock_delay.call_args_list:
+            self.assertEqual(call.kwargs["user_id"], user.id)
 
 
 # ──────────────────────────────────────────────

--- a/core/tests/test_integration.py
+++ b/core/tests/test_integration.py
@@ -590,6 +590,35 @@ class InlineEnrichmentDuringDnaTests(TransactionTestCase):
     @patch("core.tasks.enrich_book_task.delay")
     @patch("core.services.dna.generate_vibe_with_llm", return_value=["vibe"])
     @patch("core.services.book_enrichment_service.enrich_book_from_apis")
+    def test_goodreads_bookshelves_break_ties_in_split(
+        self, mock_inline, mock_vibe, mock_delay, mock_author, mock_recs
+    ):
+        """With no API genres, the Goodreads Bookshelves column decides the split;
+        non-genre shelves are ignored."""
+        from core.services.dna import calculate_full_dna
+
+        mock_inline.side_effect = lambda book, session, **kwargs: (book, 0, 0)  # no genres found
+        csv = (
+            "Title,Author,Exclusive Shelf,Bookshelves,My Rating,Number of Pages,"
+            "Original Publication Year,Date Read,Average Rating,My Review,ISBN13\n"
+            'Shelf Book A,Shelf Author,read,"read, nonfiction, owned",5,300,2020,2023/01/10,4.0,,\n'
+            'Shelf Book B,Shelf Author,read,"read, fiction, favorites",4,250,2019,2023/02/15,4.5,,\n'
+            'Shelf Book C,Shelf Author,read,"read, to-read",3,200,2018,2023/03/20,4.2,,\n'
+        )
+        user = User.objects.create_user(username="shelf_user", password="pw")
+
+        dna = calculate_full_dna(csv, user=user)
+
+        self.assertEqual(
+            dna["fiction_nonfiction_split"],
+            {"fiction_count": 1, "nonfiction_count": 1, "defaulted_count": 1},
+        )
+
+    @patch("core.tasks.generate_recommendations_task.delay")
+    @patch("core.tasks.check_author_mainstream_status_task.delay")
+    @patch("core.tasks.enrich_book_task.delay")
+    @patch("core.services.dna.generate_vibe_with_llm", return_value=["vibe"])
+    @patch("core.services.book_enrichment_service.enrich_book_from_apis")
     @patch("core.services.dna.enrichment_budget._EnrichmentBudget.has_remaining", return_value=False)
     def test_async_fallback_when_budget_exhausted(
         self, mock_budget, mock_inline, mock_vibe, mock_delay, mock_author, mock_recs

--- a/core/tests/test_math_accuracy.py
+++ b/core/tests/test_math_accuracy.py
@@ -513,7 +513,8 @@ class IsbnNormalizationTests(TestCase):
         from unittest.mock import patch
 
         with patch("core.services.dna.generate_vibe_with_llm", return_value=["a", "b"]), \
-             patch("core.tasks.enrich_book_task.delay"):
+             patch("core.tasks.enrich_book_task.delay"), \
+             patch("core.services.book_enrichment_service.enrich_book_from_apis"):
             calculate_full_dna(goodreads_csv, user=user)
             calculate_full_dna(storygraph_csv, user=user)
 

--- a/core/tests/test_subtitle_data.py
+++ b/core/tests/test_subtitle_data.py
@@ -57,6 +57,11 @@ class SubtitleFieldsIntegrationTests(TransactionTestCase):
             cache.clear()
         except Exception:
             pass
+        # Inline enrichment must never hit real APIs from tests — a no-op mock
+        # keeps books genre-less here, matching the old async-only behaviour.
+        inline_patcher = patch("core.services.book_enrichment_service.enrich_book_from_apis")
+        self.mock_inline_enrich = inline_patcher.start()
+        self.addCleanup(inline_patcher.stop)
 
     # --- authenticated user with multiple books ---
 
@@ -286,6 +291,10 @@ class SubtitleEdgeCaseTests(TransactionTestCase):
             cache.clear()
         except Exception:
             pass
+        # Inline enrichment must never hit real APIs from tests (see above).
+        inline_patcher = patch("core.services.book_enrichment_service.enrich_book_from_apis")
+        self.mock_inline_enrich = inline_patcher.start()
+        self.addCleanup(inline_patcher.stop)
 
     @patch("core.tasks.generate_recommendations_task.delay")
     @patch("core.tasks.check_author_mainstream_status_task.delay")

--- a/core/tests/test_tasks_integration.py
+++ b/core/tests/test_tasks_integration.py
@@ -28,6 +28,11 @@ class TaskIntegrationTests(TransactionTestCase):
             cache.clear()
         except Exception:
             pass
+        # Inline enrichment must never hit real APIs from tests — a no-op mock
+        # keeps books genre-less here, matching the old async-only behaviour.
+        inline_patcher = patch("core.services.book_enrichment_service.enrich_book_from_apis")
+        self.mock_inline_enrich = inline_patcher.start()
+        self.addCleanup(inline_patcher.stop)
 
     # Mock the slow, external network calls
     @patch("core.tasks.generate_recommendations_task.delay")

--- a/core/views/_helpers.py
+++ b/core/views/_helpers.py
@@ -156,7 +156,12 @@ def _compute_enrichment_progress(user, profile, dna_data):
         "total": total,
         "percent": round(attempted / total * 100),
         "genres_done": genres_done,
+        # Genre-coverage gate — applies to ALL CSV sources (Goodreads included,
+        # not just StoryGraph): while fewer than 50% of the user's books have
+        # genres, genre-derived stats are flagged pending. genre_coverage_pct
+        # feeds the fiction/nonfiction card's coverage subtitle.
         "genres_pending": (genres_done / total) < 0.5,
+        "genre_coverage_pct": round(genres_done / total * 100),
         "pages_done": pages_done,
         "pages_pending": (pages_done / total) < 0.5,
         # Per-stat banner gates: True iff any book is still missing this field.


### PR DESCRIPTION
## Summary

Completes the genre overhaul (plan Phase 4; part 1 was #120):

- **Inline-first enrichment**: new/genre-less books are enriched synchronously during DNA calculation (`quick_mode` HTTP timeouts: 2s OL search / 1.5s OL work / 2s GB) under a lazily-started, thread-safe **90s budget** — so the fiction/nonfiction split and top genres are computed from real data on first render instead of waiting for async enrichment. On exception or budget exhaustion, books fall back to `enrich_book_task.delay` with the existing upload-nonce semantics, exactly as today.
  - Safe under the current `max_workers=8` executor: lock-guarded exactly-once budget start (thread smoke-test included); one shared `requests.Session` across workers (urllib3 pooled checkout), documented at the executor site.
  - Latency: uploads with many brand-new books pay up to ~90s extra (~100–130 books enrichable in-budget); re-uploads of known libraries pay ~0 (lazy clock).
- **Goodreads `Bookshelves` shelf signals** as weak tiebreakers: `fiction`/`nonfiction` shelf tags and shelf-genre matches decide ONLY when API genres give no signal or only-ambiguous ones — user mis-shelving can never override real genre data. 6-case test matrix per the plan.
- **Coverage transparency**: `genre_coverage_pct` in the enrichment context + status payload; the fiction/nonfiction card shows "Based on X of Y books — refresh in a few minutes" while enrichment is pending and defaulted books exist.
- Follow-up test hardening: the inline path exposed 4 legacy pipeline test modules silently hitting real OL/GB APIs — now patched no-op, suite fully offline.

## Post-deploy (owner action, once, covers #120 too)

`manage.py enrich_books --process-all` on the VPS (tmux) to re-fetch + merge GB genres for existing books.

## Testing

Full suite: **462/462 OK** (+29 over part 1's baseline). Budget thread-safety, inline/fallback paths, shelf matrix, non-genre-shelf ignoring, and the Goodreads coverage gate all covered.